### PR TITLE
fix: improve terminal input handling and shell UI rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+AGENTS.md


### PR DESCRIPTION
Cool project, feels very performant. Here's a few bugfixes I needed to make the prototype usable regarding zsh suggestions, backspace, etc. 

Use GPUI key_char for PTY text input so typed commands are not mangled by layout/IME behavior (seen with zsh suggestions). Keep control/special key handling explicit while avoiding command-modified text fallthrough.

Also render INVERSE/DIM/HIDDEN terminal flags correctly and ignore local AGENTS.md.