### PR TITLE
Bump to 0.1.14; add opacity and Windows titlebar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5177,7 +5177,7 @@ dependencies = [
 
 [[package]]
 name = "termy"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "termy"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2024"
 
 [package.metadata.bundle]
@@ -31,7 +31,7 @@ anyhow = "1.0"
 log = "0.4"
 env_logger = "0.11"
 
-# Auto-update
+# Termy Workspace Crates
 termy_auto_update = { path = "crates/auto_update" }
 termy_themes = { path = "crates/themes" }
 termy_terminal_ui = { path = "crates/terminal_ui" }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -113,11 +113,11 @@ Explicit payload examples:
 - Values: template string
 
 `window_width`
-- Default: `1100`
+- Default: `1280`
 - Values: positive number
 
 `window_height`
-- Default: `720`
+- Default: `820`
 - Values: positive number
 
 `font_family`
@@ -127,6 +127,12 @@ Explicit payload examples:
 `font_size`
 - Default: `14`
 - Values: positive number
+
+`transparent_background_opacity`
+- Default: `1.0`
+- Values: number between `0.0` and `1.0`
+- What it does: controls terminal background transparency (`0.0` fully transparent, `1.0` opaque)
+- Note: `transparent_background_opccaity` (misspelled) is also accepted for backward compatibility.
 
 `padding_x`
 - Default: `12`

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,12 +29,14 @@ tab_title_shell_integration = true\n\
 # tab_title_prompt_format = {cwd}\n\
 # tab_title_command_format = {command}\n\
 # Startup window size in pixels\n\
-window_width = 1100\n\
-window_height = 720\n\
+window_width = 1280\n\
+window_height = 820\n\
 # Terminal font family\n\
 font_family = JetBrains Mono\n\
 # Terminal font size in pixels\n\
 font_size = 14\n\
+# Terminal background opacity (0.0 = fully transparent, 1.0 = opaque)\n\
+# transparent_background_opacity = 1.0\n\
 # Inner terminal padding in pixels\n\
 padding_x = 12\n\
 padding_y = 8\n";
@@ -158,6 +160,7 @@ pub struct AppConfig {
     pub window_height: f32,
     pub font_family: String,
     pub font_size: f32,
+    pub transparent_background_opacity: f32,
     pub padding_x: f32,
     pub padding_y: f32,
 }
@@ -169,10 +172,11 @@ impl Default for AppConfig {
             working_dir: None,
             use_tabs: false,
             tab_title: TabTitleConfig::default(),
-            window_width: 1100.0,
-            window_height: 720.0,
+            window_width: 1280.0,
+            window_height: 820.0,
             font_family: "JetBrains Mono".to_string(),
             font_size: 14.0,
+            transparent_background_opacity: 1.0,
             padding_x: 12.0,
             padding_y: 8.0,
         }
@@ -292,6 +296,14 @@ impl AppConfig {
                     if font_size > 0.0 {
                         config.font_size = font_size;
                     }
+                }
+            }
+
+            if key.eq_ignore_ascii_case("transparent_background_opacity")
+                || key.eq_ignore_ascii_case("transparent_background_opccaity")
+            {
+                if let Ok(opacity) = value.parse::<f32>() {
+                    config.transparent_background_opacity = opacity.clamp(0.0, 1.0);
                 }
             }
 

--- a/src/terminal_view/command_palette.rs
+++ b/src/terminal_view/command_palette.rs
@@ -62,6 +62,11 @@ impl TerminalView {
     fn command_palette_items(&self) -> Vec<CommandPaletteItem> {
         let mut items = vec![
             CommandPaletteItem {
+                title: "App Info",
+                keywords: "information version about build",
+                action: CommandPaletteAction::AppInfo,
+            },
+            CommandPaletteItem {
                 title: "Restart App",
                 keywords: "relaunch reopen restart",
                 action: CommandPaletteAction::RestartApp,
@@ -263,6 +268,21 @@ impl TerminalView {
         self.command_palette_query_select_all = false;
 
         match action {
+            CommandPaletteAction::AppInfo => {
+                let config_path = self
+                    .config_path
+                    .as_ref()
+                    .map(|path| path.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| "unknown".to_string());
+                termy_toast::info(format!(
+                    "Termy v{} | {}-{} | config: {}",
+                    crate::APP_VERSION,
+                    std::env::consts::OS,
+                    std::env::consts::ARCH,
+                    config_path
+                ));
+                cx.notify();
+            }
             CommandPaletteAction::RestartApp => match self.restart_application() {
                 Ok(()) => cx.quit(),
                 Err(error) => {

--- a/src/terminal_view/mod.rs
+++ b/src/terminal_view/mod.rs
@@ -3,10 +3,10 @@ use crate::config::{self, AppConfig, TabTitleConfig, TabTitleSource};
 use alacritty_terminal::term::cell::Flags;
 use flume::{Sender, bounded};
 use gpui::{
-    AnyElement, App, AppContext, AsyncApp, ClipboardItem, Context, Element, Entity, FocusHandle,
-    Focusable, Font, FontWeight, InteractiveElement, IntoElement, KeyDownEvent, MouseButton,
-    MouseDownEvent, MouseMoveEvent, MouseUpEvent, ParentElement, Pixels, Render, SharedString,
-    Size, StatefulInteractiveElement, Styled, WeakEntity, Window, WindowControlArea, div, px,
+    AnyElement, App, AsyncApp, ClipboardItem, Context, Element, FocusHandle, Focusable, Font,
+    FontWeight, InteractiveElement, IntoElement, KeyDownEvent, MouseButton, MouseDownEvent,
+    MouseMoveEvent, MouseUpEvent, ParentElement, Pixels, Render, SharedString, Size,
+    StatefulInteractiveElement, Styled, WeakEntity, Window, WindowControlArea, div, px,
 };
 use std::{
     fs,
@@ -22,6 +22,8 @@ use termy_toast::ToastManager;
 
 #[cfg(target_os = "macos")]
 use termy_auto_update::{AutoUpdater, UpdateState};
+#[cfg(target_os = "macos")]
+use gpui::Entity;
 
 mod command_palette;
 mod interaction;
@@ -54,6 +56,7 @@ const COMMAND_TITLE_DELAY_MS: u64 = 250;
 const CONFIG_WATCH_INTERVAL_MS: u64 = 750;
 const SELECTION_BG_ALPHA: f32 = 0.35;
 const DIM_TEXT_FACTOR: f32 = 0.66;
+#[cfg(target_os = "macos")]
 const UPDATE_BANNER_HEIGHT: f32 = 32.0;
 const COMMAND_PALETTE_WIDTH: f32 = 640.0;
 const COMMAND_PALETTE_MAX_ITEMS: usize = 8;
@@ -111,6 +114,7 @@ struct HoveredLink {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum CommandPaletteAction {
+    AppInfo,
     RestartApp,
     NewTab,
     CloseTab,
@@ -148,6 +152,7 @@ pub struct TerminalView {
     font_family: SharedString,
     base_font_size: f32,
     font_size: Pixels,
+    transparent_background_opacity: f32,
     padding_x: f32,
     padding_y: f32,
     line_height: f32,
@@ -258,6 +263,7 @@ impl TerminalView {
             font_family: config.font_family.into(),
             base_font_size,
             font_size: px(base_font_size),
+            transparent_background_opacity: config.transparent_background_opacity,
             padding_x,
             padding_y,
             line_height: 1.4,
@@ -310,6 +316,7 @@ impl TerminalView {
         self.font_family = config.font_family.into();
         self.base_font_size = config.font_size.clamp(MIN_FONT_SIZE, MAX_FONT_SIZE);
         self.font_size = px(self.base_font_size);
+        self.transparent_background_opacity = config.transparent_background_opacity;
         self.padding_x = config.padding_x.max(0.0);
         self.padding_y = config.padding_y.max(0.0);
 


### PR DESCRIPTION
Update default window size to 1280x820 and auto-upgrade legacy Windows 1100x720 settings.

Add transparent_background_opacity (default 1.0) and accept the misspelled transparent_background_opccaity for backward compatibility; apply it when rendering the terminal background.

Add an "App Info" command palette item and render a Windows-style titlebar with window controls.