### PR TITLE
Add scrolling and improve terminal rendering

### DIFF
--- a/crates/terminal_ui/src/grid.rs
+++ b/crates/terminal_ui/src/grid.rs
@@ -23,6 +23,7 @@ pub struct TerminalGrid {
     pub cell_size: Size<Pixels>,
     pub cols: usize,
     pub rows: usize,
+    pub default_bg: Hsla,
     pub cursor_color: Hsla,
     pub selection_bg: Hsla,
     pub selection_fg: Hsla,
@@ -102,6 +103,21 @@ impl Element for TerminalGrid {
         cx: &mut App,
     ) {
         let origin = bounds.origin;
+        let grid_bounds = Bounds {
+            origin,
+            size: bounds.size,
+        };
+
+        // Always clear the full terminal surface first to avoid ghosting artifacts
+        // when scrolled content reveals previously untouched cells.
+        window.paint_quad(quad(
+            grid_bounds,
+            px(0.0),
+            self.default_bg,
+            gpui::Edges::default(),
+            Hsla::transparent_black(),
+            gpui::BorderStyle::default(),
+        ));
 
         // Paint background colors and cursor first.
         for cell in &self.cells {

--- a/src/terminal_view/mod.rs
+++ b/src/terminal_view/mod.rs
@@ -5,7 +5,8 @@ use flume::{Sender, bounded};
 use gpui::{
     AnyElement, App, AsyncApp, ClipboardItem, Context, Element, FocusHandle, Focusable, Font,
     FontWeight, InteractiveElement, IntoElement, KeyDownEvent, MouseButton, MouseDownEvent,
-    MouseMoveEvent, MouseUpEvent, ParentElement, Pixels, Render, SharedString, Size,
+    MouseMoveEvent, MouseUpEvent, ParentElement, Pixels, Render, ScrollDelta, ScrollWheelEvent,
+    SharedString, Size,
     StatefulInteractiveElement, Styled, WeakEntity, Window, WindowControlArea, div, px,
 };
 use std::{
@@ -165,6 +166,7 @@ pub struct TerminalView {
     command_palette_open: bool,
     command_palette_query: String,
     command_palette_selected: usize,
+    command_palette_scroll_offset: usize,
     command_palette_query_select_all: bool,
     command_palette_opened_at: Option<Instant>,
     /// Cached cell dimensions
@@ -276,6 +278,7 @@ impl TerminalView {
             command_palette_open: false,
             command_palette_query: String::new(),
             command_palette_selected: 0,
+            command_palette_scroll_offset: 0,
             command_palette_query_select_all: false,
             command_palette_opened_at: None,
             cell_size: None,


### PR DESCRIPTION
Add Terminal::scroll_display and scroll_state; add TerminalGrid.default_bg
and paint a full background quad to avoid ghosting. Implement command palette scroll offset with wheel handling and selection syncing. Use an effective background opacity on Windows (force opaque for transparent backgrounds) and restyle toast visuals. Add a native Windows info dialog helper.