### PR TITLE
Update GitHub Sponsors username in FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: lassejlv


### PR DESCRIPTION
This pull request adds a funding configuration file to the repository, specifying a GitHub sponsor username.

- Repository funding:
  * Added a `.github/FUNDING.yml` file to enable GitHub Sponsors, specifying `lassejlv` as the sponsor username.