### PR TITLE
Add clean-dark and tokyo-night themes

### DIFF
--- a/themes/clean-dark.json
+++ b/themes/clean-dark.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "../theme.schema.json",
+  "foreground": "#e0e0e0",
+  "background": "#1a1a1a",
+  "cursor": "#ffffff",
+  "black": "#1a1a1a",
+  "red": "#ff6b6b",
+  "green": "#69db7c",
+  "yellow": "#ffd43b",
+  "blue": "#74c0fc",
+  "magenta": "#da77f2",
+  "cyan": "#66d9e8",
+  "white": "#e0e0e0",
+  "bright_black": "#4a4a4a",
+  "bright_red": "#ff8787",
+  "bright_green": "#8ce99a",
+  "bright_yellow": "#ffe066",
+  "bright_blue": "#a5d8ff",
+  "bright_magenta": "#e599f7",
+  "bright_cyan": "#99e9f2",
+  "bright_white": "#ffffff"
+}

--- a/themes/tokyo-night-dark.json
+++ b/themes/tokyo-night-dark.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "../theme.schema.json",
+  "foreground": "#a9b1d6",
+  "background": "#1a1b26",
+  "cursor": "#c0caf5",
+  "black": "#15161e",
+  "red": "#f7768e",
+  "green": "#9ece6a",
+  "yellow": "#e0af68",
+  "blue": "#7aa2f7",
+  "magenta": "#bb9af7",
+  "cyan": "#7dcfff",
+  "white": "#a9b1d6",
+  "bright_black": "#414868",
+  "bright_red": "#f7768e",
+  "bright_green": "#9ece6a",
+  "bright_yellow": "#e0af68",
+  "bright_blue": "#7aa2f7",
+  "bright_magenta": "#bb9af7",
+  "bright_cyan": "#7dcfff",
+  "bright_white": "#c0caf5"
+}

--- a/themes/tokyo-night-light.json
+++ b/themes/tokyo-night-light.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "../theme.schema.json",
+  "foreground": "#343b58",
+  "background": "#d5d6db",
+  "cursor": "#343b58",
+  "black": "#0f0f14",
+  "red": "#8c4351",
+  "green": "#485e30",
+  "yellow": "#8f5e15",
+  "blue": "#34548a",
+  "magenta": "#5a4a78",
+  "cyan": "#0f4b6e",
+  "white": "#343b58",
+  "bright_black": "#9699a3",
+  "bright_red": "#8c4351",
+  "bright_green": "#485e30",
+  "bright_yellow": "#8f5e15",
+  "bright_blue": "#34548a",
+  "bright_magenta": "#5a4a78",
+  "bright_cyan": "#0f4b6e",
+  "bright_white": "#d5d6db"
+}


### PR DESCRIPTION
Add three new theme files in themes/: clean-dark.json, tokyo-night-dark.json, and tokyo-night-light.json. Each file references ../theme.schema.json and defines foreground, background, cursor, and 16 color slots (normal and bright variants) to provide dark and light color schemes, including a minimalist clean dark theme and Tokyo Night dark/light variants.