### PR TITLE
Automate Homebrew cask version and checksum updates on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,11 +245,11 @@ jobs:
           ARM_SHA: ${{ steps.checksums.outputs.arm_sha }}
           INTEL_SHA: ${{ steps.checksums.outputs.intel_sha }}
         run: |
-          perl -i -pe 's/^  version ".*"$/  version "'"$VERSION"'"/' Casks/termy.rb
-          perl -0777 -i -pe 's/  sha256 arm:\s*"[^"]+",\n\s*intel:\s*"[^"]+"/  sha256 arm:   "'"$ARM_SHA"'",\n         intel: "'"$INTEL_SHA"'"/' Casks/termy.rb
+          perl -i -pe 's|^  version ".*"$|  version "$ENV{VERSION}"|' Casks/termy.rb
+          perl -0777 -i -pe 's|  sha256 arm:\s*"[^"]+",\n\s*intel:\s*"[^"]+"|  sha256 arm:   "$ENV{ARM_SHA}",\n         intel: "$ENV{INTEL_SHA}"|' Casks/termy.rb
 
       - name: Open cask update PR
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           branch: automation/homebrew-cask-${{ steps.release.outputs.version }}
           delete-branch: true


### PR DESCRIPTION
Adds a release workflow that reads the published macOS DMGs, computes arm64/x86_64 SHA-256 hashes, updates [termy.rb](app://-/index.html#), and opens an automated PR with the cask bump.Adds a release workflow job that reads the published macOS DMGs, computes arm64/x86_64 SHA-256 hashes, updates [termy.rb](app://-/index.html#), and opens an automated PR with the cask bump.


note: Requires repository Actions permissions to allow GITHUB_TOKEN with contents: write and pull-requests: write, plus “Allow GitHub Actions to create and approve pull requests”; once enabled, each published release will auto-open a cask update PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated Homebrew cask updates now run automatically when new releases are published, ensuring package manager installations stay up-to-date with the latest version and security checksums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->