### PR TITLE
Update lib.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5318,6 +5318,7 @@ dependencies = [
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
+ "windows 0.61.3",
 ]
 
 [[package]]

--- a/crates/native_sdk/Cargo.toml
+++ b/crates/native_sdk/Cargo.toml
@@ -8,3 +8,6 @@ dispatch2 = "0.3.0"
 objc2 = "0.6.3"
 objc2-foundation = { version = "0.3.2", default-features = false, features = ["NSString"] }
 objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSAlert", "NSApplication", "NSButton", "NSControl", "NSResponder", "NSView"] }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { version = "0.61", features = ["Win32_UI_WindowsAndMessaging"] }


### PR DESCRIPTION
This pull request adds native Linux support for the `show_alert` and `confirm` functions in the `crates/native_sdk` crate, making them use graphical dialog boxes when possible. On Linux, the code now tries to use `zenity` or `kdialog` for displaying alerts and confirmation dialogs, falling back to printing to stderr if neither is available. This improves the user experience on Linux by providing GUI dialogs similar to those on macOS.

**Linux dialog support:**

* Added a helper function `has_command` to check for the presence of external commands like `zenity` and `kdialog`.
* Updated `show_alert` to use `zenity` or `kdialog` for graphical dialogs on Linux, falling back to stderr if neither is available.
* Updated `confirm` to use `zenity` or `kdialog` for confirmation dialogs on Linux, returning `false` if neither is available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Native alert and confirmation dialogs now use platform-specific native UIs on Linux and Windows for a more consistent experience; systems without native dialog tools fall back to console output.
* **Chores**
  * Platform-specific dependency configuration added to enable native dialog support on Windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->