### PR TITLE
Clear frame with terminal surface background

### DIFF
--- a/src/terminal_view/render.rs
+++ b/src/terminal_view/render.rs
@@ -1005,7 +1005,9 @@ impl Render for TerminalView {
             cell_size,
             cols: terminal_size.cols as usize,
             rows: terminal_size.rows as usize,
-            clear_bg: gpui::Hsla::transparent_black(),
+            // Clear with the surface background each frame to avoid stale pixel artifacts
+            // (for example dark seams) when default-bg cells are not explicitly repainted.
+            clear_bg: terminal_surface_bg_hsla,
             default_bg: terminal_surface_bg_hsla,
             cursor_color: colors.cursor.into(),
             selection_bg: selection_bg.into(),


### PR DESCRIPTION
Replace gpui::Hsla::transparent_black() with terminal_surface_bg_hsla for clear_bg and add a comment explaining it. This ensures the surface background is used when clearing each frame (matching default_bg) to avoid stale pixel artifacts such as dark seams when default-bg cells aren't explicitly repainted.

# Pull Request

<!-- A clear and concise description of what this PR does and why it's needed. -->

## Description

<!-- Describe the changes made in the PR. -->

- 
-
-
-

## Screenshots/Videos

<!-- If applicable, add screenshots or screen recordings to help explain your changes. -->


## Related Issues

<!-- If this PR closes any issues, use the keyword 'closes' followed by the issue number -->

Closes #

## Checklist

- [ ] I confirmed there is no existing open PR for the same or overlapping changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed visual artifacts and dark seams in the terminal view that appeared during rendering when cells weren't repainted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->