### PR TITLE
Revert "Clear frame with terminal surface background"

### DIFF
--- a/src/terminal_view/render.rs
+++ b/src/terminal_view/render.rs
@@ -524,9 +524,7 @@ impl Render for TerminalView {
             cell_size,
             cols: terminal_size.cols as usize,
             rows: terminal_size.rows as usize,
-            // Clear with the surface background each frame to avoid stale pixel artifacts
-            // (for example dark seams) when default-bg cells are not explicitly repainted.
-            clear_bg: terminal_surface_bg_hsla,
+            clear_bg: gpui::Hsla::transparent_black(),
             default_bg: terminal_surface_bg_hsla,
             cursor_color: colors.cursor.into(),
             selection_bg: selection_bg.into(),


### PR DESCRIPTION
Reverts lassejlv/termy#99 due to #104 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal view background rendering for more consistent visual display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->