### PR TITLE
fix: starship/zsh Cursor Drift by Enforcing UTF-8 PTY Locale (Unix)

### DIFF
--- a/crates/terminal_ui/src/runtime.rs
+++ b/crates/terminal_ui/src/runtime.rs
@@ -337,10 +337,11 @@ fn utf8_locale_override_plan(
     lc_ctype: Option<&str>,
     lang: Option<&str>,
 ) -> Utf8LocaleOverridePlan {
-    let has_utf8_locale = [lc_all, lc_ctype, lang]
-        .into_iter()
-        .flatten()
-        .any(locale_has_utf8_tag);
+    // Follow POSIX locale precedence for classification decisions:
+    // LC_ALL overrides LC_CTYPE and LANG; LC_CTYPE overrides LANG.
+    // We therefore evaluate UTF-8 status from only the single effective locale.
+    let has_utf8_locale = effective_locale_for_decision(lc_all, lc_ctype, lang)
+        .is_some_and(locale_has_utf8_tag);
     if has_utf8_locale {
         return Utf8LocaleOverridePlan::None;
     }
@@ -350,6 +351,19 @@ fn utf8_locale_override_plan(
     } else {
         Utf8LocaleOverridePlan::LcCtypeOnly
     }
+}
+
+#[cfg(unix)]
+fn effective_locale_for_decision<'a>(
+    lc_all: Option<&'a str>,
+    lc_ctype: Option<&'a str>,
+    lang: Option<&'a str>,
+) -> Option<&'a str> {
+    [lc_all, lc_ctype, lang]
+        .into_iter()
+        .flatten()
+        .map(str::trim)
+        .find(|value| !value.is_empty())
 }
 
 #[cfg(unix)]
@@ -928,6 +942,19 @@ mod tests {
         assert_eq!(
             super::utf8_locale_override_plan(Some("en_US.UTF-8"), Some("C"), Some("")),
             super::Utf8LocaleOverridePlan::None
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn locale_override_plan_prefers_lc_all_over_lang() {
+        assert_eq!(
+            super::utf8_locale_override_plan(
+                Some("fr_FR.ISO8859-1"),
+                Some("C"),
+                Some("en_US.UTF-8")
+            ),
+            super::Utf8LocaleOverridePlan::LcAllAndLcCtype
         );
     }
 


### PR DESCRIPTION
## Summary
This branch fixes the Starship/zsh completion drift by addressing the real root cause: PTY sessions starting with a non-UTF-8 locale.

## Root Cause
`zsh` prompt width logic depends on libc locale (`wcwidth`).  
When Termy launches with `C`/non-UTF-8 locale, multibyte prompt glyphs like `❯` can be miscounted, which drifts cursor/completion positioning.

## What Changed
- Added Unix-only UTF-8 locale normalization in [`crates/terminal_ui/src/runtime.rs`](/Users/vincent/projects/termy/crates/terminal_ui/src/runtime.rs).
- Locale override policy is hybrid:
- If any of `LC_ALL`, `LC_CTYPE`, or `LANG` is already UTF-8, do nothing.
- If `LC_ALL` is set and non-UTF8, set both `LC_ALL` and `LC_CTYPE`.
- Otherwise set only `LC_CTYPE`.
- Locale forcing preserves user language/region when possible:
- Example: `fr_FR.ISO8859-1` -> `fr_FR.UTF-8`.
- Falls back to platform default only for `C`/`POSIX`-style inputs.
- UTF-8 detection is now strict:
- Parse locale encoding component (`.<encoding>`) and only accept exact `utf8`/`utf-8` (case-insensitive).
- Added explicit in-code comment documenting why this override is intentionally Unix-only (native Windows shells do not use the same locale contract).

## Tests Added/Updated
- 4 cursor-advance parity tests (> vs ❯, plus ANSI + OSC BEL/ST)
- 5 locale override-plan tests (including strict false-positive + modifier cases)
- 3 locale-conversion tests (preferred_utf8_locale behavior)


## Why This Approach
- Minimal, targeted fix for the proven root cause.
- Keeps code simple and avoids speculative renderer/search refactors.
- Maintains non-English locale behavior instead of forcing US-English locale values.

## Validation
- `cargo test -p termy_terminal_ui` passed
- `cargo test -p termy_search` passed
- `cargo test -p termy --no-run` passed
- `cargo check -p termy` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UTF-8 locale detection and override behavior on Unix so terminal UI renders characters and positions the cursor more reliably across varied LC_ALL/LC_CTYPE/LANG settings.

* **Tests**
  * Added thorough tests for locale selection logic and character-advancement cases including special glyphs and control-sequence terminators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->