### PR TITLE
Enable transparent titlebar on Windows

### DIFF
--- a/src/app_actions.rs
+++ b/src/app_actions.rs
@@ -27,6 +27,7 @@ pub(crate) fn open_settings_window(cx: &mut App) -> Result<(), String> {
     #[cfg(target_os = "windows")]
     let titlebar = Some(gpui::TitlebarOptions {
         title: Some("Settings".into()),
+        appears_transparent: true,
         ..Default::default()
     });
     #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,6 +81,7 @@ fn main() {
         #[cfg(target_os = "windows")]
         let titlebar = Some(gpui::TitlebarOptions {
             title: None,
+            appears_transparent: true,
             ..Default::default()
         });
         #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]


### PR DESCRIPTION
This pull request makes a small but important UI improvement for Windows users by updating the appearance of titlebars in the application. Specifically, it sets the titlebars to appear transparent in both the settings window and the main application window on Windows.

- UI Improvements for Windows:
  * Set the `appears_transparent` property to `true` in the `gpui::TitlebarOptions` for the settings window in `src/app_actions.rs`.
  * Set the `appears_transparent` property to `true` in the `gpui::TitlebarOptions` for the main window in `src/main.rs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Windows titlebar configuration to enable transparency, ensuring consistent window appearance across all platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->