### PR TITLE
fix: add missed follow-up changes after fix/misc merge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5648,6 +5648,7 @@ name = "termy_search"
 version = "0.1.0"
 dependencies = [
  "regex",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]

--- a/crates/search/Cargo.toml
+++ b/crates/search/Cargo.toml
@@ -5,5 +5,6 @@ edition = "2024"
 
 [dependencies]
 regex = "1"
+unicode-width = "0.2"
 
 [dev-dependencies]

--- a/crates/search/src/engine.rs
+++ b/crates/search/src/engine.rs
@@ -1,4 +1,5 @@
 use regex::{Regex, RegexBuilder};
+use unicode_width::UnicodeWidthChar;
 
 use crate::matcher::{SearchMatch, SearchResults};
 
@@ -92,16 +93,15 @@ impl SearchEngine {
             return Vec::new();
         };
 
-        let mut utf8_char_boundaries: Vec<usize> = text.char_indices().map(|(idx, _)| idx).collect();
-        utf8_char_boundaries.push(text.len());
+        let (utf8_char_boundaries, cell_columns) = compute_cell_columns(text);
 
         regex
             .find_iter(text)
             .map(|m| {
                 SearchMatch::new(
                     line_idx,
-                    byte_offset_to_column(m.start(), &utf8_char_boundaries),
-                    byte_offset_to_column(m.end(), &utf8_char_boundaries),
+                    byte_offset_to_cell_column(m.start(), &utf8_char_boundaries, &cell_columns),
+                    byte_offset_to_cell_column(m.end(), &utf8_char_boundaries, &cell_columns),
                 )
             })
             .collect()
@@ -131,8 +131,33 @@ impl SearchEngine {
     }
 }
 
-fn byte_offset_to_column(byte_offset: usize, utf8_char_boundaries: &[usize]) -> usize {
-    utf8_char_boundaries.partition_point(|boundary| *boundary < byte_offset)
+fn compute_cell_columns(text: &str) -> (Vec<usize>, Vec<usize>) {
+    let mut utf8_char_boundaries = Vec::with_capacity(text.chars().count() + 1);
+    let mut cell_columns = Vec::with_capacity(text.chars().count() + 1);
+    let mut cell_col = 0usize;
+
+    for (idx, ch) in text.char_indices() {
+        utf8_char_boundaries.push(idx);
+        cell_columns.push(cell_col);
+        cell_col += UnicodeWidthChar::width(ch).unwrap_or(0);
+    }
+
+    utf8_char_boundaries.push(text.len());
+    cell_columns.push(cell_col);
+
+    (utf8_char_boundaries, cell_columns)
+}
+
+fn byte_offset_to_cell_column(
+    byte_offset: usize,
+    utf8_char_boundaries: &[usize],
+    cell_columns: &[usize],
+) -> usize {
+    match utf8_char_boundaries.binary_search(&byte_offset) {
+        Ok(index) => cell_columns[index],
+        Err(0) => 0,
+        Err(index) => cell_columns[index - 1],
+    }
 }
 
 #[cfg(test)]
@@ -257,9 +282,9 @@ mod tests {
         let matches = engine.search_line(0, "Hello \u{1F600} World \u{1F600}");
         assert_eq!(matches.len(), 2);
         assert_eq!(matches[0].start_col, 6);
-        assert_eq!(matches[0].end_col, 7);
-        assert_eq!(matches[1].start_col, 14);
-        assert_eq!(matches[1].end_col, 15);
+        assert_eq!(matches[0].end_col, 8);
+        assert_eq!(matches[1].start_col, 15);
+        assert_eq!(matches[1].end_col, 17);
     }
 
     #[test]
@@ -285,5 +310,43 @@ mod tests {
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].start_col, 3);
         assert_eq!(matches[0].end_col, 7);
+    }
+
+    #[test]
+    fn test_literal_search_uses_cell_columns_for_cjk_wide_characters() {
+        let mut engine = SearchEngine::new(SearchConfig::default());
+        engine.set_pattern("界").unwrap();
+
+        let matches = engine.search_line(0, "a界b界");
+        assert_eq!(matches.len(), 2);
+        assert_eq!(matches[0].start_col, 1);
+        assert_eq!(matches[0].end_col, 3);
+        assert_eq!(matches[1].start_col, 4);
+        assert_eq!(matches[1].end_col, 6);
+    }
+
+    #[test]
+    fn test_literal_search_uses_cell_columns_for_combining_characters() {
+        let mut engine = SearchEngine::new(SearchConfig::default());
+        engine.set_pattern("a\u{0301}").unwrap();
+
+        let matches = engine.search_line(0, "x a\u{0301} z");
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].start_col, 2);
+        assert_eq!(matches[0].end_col, 3);
+    }
+
+    #[test]
+    fn test_regex_search_uses_cell_columns_for_emoji_with_combining_mark() {
+        let mut engine = SearchEngine::new(SearchConfig {
+            case_sensitive: false,
+            mode: SearchMode::Regex,
+        });
+        engine.set_pattern("\u{1F600}\u{0301}").unwrap();
+
+        let matches = engine.search_line(0, "ab\u{1F600}\u{0301}cd");
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].start_col, 2);
+        assert_eq!(matches[0].end_col, 4);
     }
 }

--- a/src/app_actions.rs
+++ b/src/app_actions.rs
@@ -13,19 +13,31 @@ fn focus_existing_settings_window(cx: &mut App) -> bool {
         .into_iter()
         .find_map(|handle| handle.downcast::<SettingsWindow>())
     {
-        let _ = settings_window.update(cx, |_view, window, _cx| {
-            window.activate_window();
-        });
-        true
+        settings_window
+            .update(cx, |_view, window, _cx| {
+                window.activate_window();
+            })
+            .is_ok()
     } else {
         false
     }
+}
+
+fn has_settings_window(cx: &App) -> bool {
+    cx.windows()
+        .into_iter()
+        .any(|handle| handle.downcast::<SettingsWindow>().is_some())
 }
 
 pub(crate) fn open_settings_window(cx: &mut App) -> Result<(), String> {
     // Key-repeat and repeated action dispatch should raise the existing settings window,
     // not spawn duplicate windows.
     if focus_existing_settings_window(cx) {
+        return Ok(());
+    }
+    // If a settings window still exists after a failed focus attempt (for example,
+    // during a re-entrant update), do not open a duplicate.
+    if has_settings_window(cx) {
         return Ok(());
     }
 

--- a/src/terminal_view/interaction/selection.rs
+++ b/src/terminal_view/interaction/selection.rs
@@ -549,4 +549,91 @@ mod tests {
             Some(("%left".to_string(), CellPos { col: 2, row: 3 }))
         );
     }
+
+    #[test]
+    fn clamped_pane_lookup_falls_back_to_active_pane_when_pointer_outside_all_panes() {
+        let rows = 6u16;
+        let left_cols = 8u16;
+        let right_cols = 8u16;
+        let left_terminal = Terminal::new_tmux(
+            TerminalSize {
+                cols: left_cols,
+                rows,
+                ..TerminalSize::default()
+            },
+            128,
+        );
+        let right_terminal = Terminal::new_tmux(
+            TerminalSize {
+                cols: right_cols,
+                rows,
+                ..TerminalSize::default()
+            },
+            128,
+        );
+
+        let panes = vec![
+            TerminalPane {
+                id: "%left".to_string(),
+                left: 0,
+                top: 0,
+                width: left_cols,
+                height: rows,
+                degraded: false,
+                terminal: left_terminal,
+            },
+            TerminalPane {
+                id: "%right".to_string(),
+                left: left_cols,
+                top: 0,
+                width: right_cols,
+                height: rows,
+                degraded: false,
+                terminal: right_terminal,
+            },
+        ];
+
+        let active_pane = &panes[0];
+        let size = active_pane.terminal.size();
+        let cell_width: f32 = size.cell_width.into();
+        let cell_height: f32 = size.cell_height.into();
+        let padding_x = 0.0;
+        let padding_y = 0.0;
+        let active_origin_x = padding_x + (f32::from(active_pane.left) * cell_width);
+        let active_origin_y = padding_y + (f32::from(active_pane.top) * cell_height);
+        let active_width = f32::from(active_pane.width) * cell_width;
+        let active_height = f32::from(active_pane.height) * cell_height;
+
+        // Outside both panes (to the far right and below) while clamp=true should
+        // still return a clamped position in the active pane.
+        let pointer_x = active_origin_x + active_width + (f32::from(right_cols) * cell_width);
+        let pointer_y = active_origin_y + active_height + (2.0 * cell_height);
+
+        let clamped_x = (pointer_x - active_origin_x).clamp(0.0, active_width - f32::EPSILON);
+        let clamped_y = (pointer_y - active_origin_y).clamp(0.0, active_height - f32::EPSILON);
+        let expected_col =
+            ((clamped_x / cell_width).floor() as i32).clamp(0, i32::from(size.cols) - 1) as usize;
+        let expected_row = ((clamped_y / cell_height).floor() as i32)
+            .clamp(0, i32::from(size.rows) - 1) as usize;
+
+        let resolved = resolve_pane_cell_for_position(
+            &panes,
+            Some("%left"),
+            pointer_x,
+            pointer_y,
+            padding_x,
+            padding_y,
+            true,
+        );
+        assert_eq!(
+            resolved,
+            Some((
+                "%left".to_string(),
+                CellPos {
+                    col: expected_col,
+                    row: expected_row,
+                },
+            ))
+        );
+    }
 }


### PR DESCRIPTION
**Description**  
This PR adds the changes that were intended to land with the `fix/misc` work but were committed afterward.

## What’s included
- `src/terminal_view/interaction/selection.rs`
  - Fixes active-pane clamped lookup regression affecting mouse drag selection.
  - Extracts pane hit-testing into small helpers for targeted testing.
  - Adds regression test:
    - `clamped_pane_lookup_returns_active_pane_when_pointer_inside_active_pane`
- `crates/search/src/engine.rs`
  - Includes missed search engine follow-up changes.
- `src/app_actions.rs`
  - Includes missed app action follow-up changes.
- `crates/search/Cargo.toml` and `Cargo.lock`
  - Dependency/lockfile updates required by the above.

## Why
`fix/misc` was already merged into `main`; these changes were left uncommitted at the time. This PR cleanly layers the missed work on top of current `main` without rewriting history.

## Verification
- `cargo test -p termy clamped_pane_lookup_returns_active_pane_when_pointer_inside_active_pane`
- `cargo check -p termy`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Resolved issue where the settings window could open multiple duplicate instances
* Improved search results accuracy and display positioning for Unicode content, including wide characters (CJK scripts), emoji, and combining diacritical marks through proper cell-width calculations

## Tests
* Expanded test coverage for edge cases in pointer-based pane selection when the cursor is positioned outside pane boundaries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->