### PR TITLE
feat: improve cmd palette/reuse pane dimming for command palette and close on outside click

### DIFF
--- a/src/terminal_view/command_palette/render.rs
+++ b/src/terminal_view/command_palette/render.rs
@@ -276,10 +276,13 @@ impl TerminalView {
             .top_0()
             .left_0()
             .occlude()
-            .on_click(cx.listener(|this, _event, _window, cx| {
-                this.close_command_palette(cx);
-            }))
-            .child(div().size_full().bg(style.overlay_bg).absolute().top_0().left_0())
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|this, _event, _window, cx| {
+                    this.close_command_palette(cx);
+                    cx.stop_propagation();
+                }),
+            )
             .child(
                 div()
                     .size_full()
@@ -300,9 +303,12 @@ impl TerminalView {
                             .bg(style.panel_bg)
                             .border_1()
                             .border_color(style.panel_border)
-                            .on_click(cx.listener(|_this, _event, _window, cx| {
-                                cx.stop_propagation();
-                            }))
+                            .on_mouse_down(
+                                MouseButton::Left,
+                                cx.listener(|_this, _event, _window, cx| {
+                                    cx.stop_propagation();
+                                }),
+                            )
                             .child(
                                 div()
                                     .w_full()

--- a/src/terminal_view/command_palette/style.rs
+++ b/src/terminal_view/command_palette/style.rs
@@ -1,5 +1,5 @@
 use super::super::{
-    COMMAND_PALETTE_DIM_ALPHA, COMMAND_PALETTE_INPUT_BG_ALPHA, COMMAND_PALETTE_INPUT_SELECTION_ALPHA,
+    COMMAND_PALETTE_INPUT_BG_ALPHA, COMMAND_PALETTE_INPUT_SELECTION_ALPHA,
     COMMAND_PALETTE_INPUT_SOLID_ALPHA, COMMAND_PALETTE_PANEL_BG_ALPHA, COMMAND_PALETTE_PANEL_SOLID_ALPHA,
     COMMAND_PALETTE_ROW_SELECTED_BG_ALPHA, COMMAND_PALETTE_SCROLLBAR_THUMB_ALPHA,
     COMMAND_PALETTE_SCROLLBAR_TRACK_ALPHA, COMMAND_PALETTE_SHORTCUT_BG_ALPHA,
@@ -14,7 +14,6 @@ pub(super) const COMMAND_PALETTE_SHORTCUT_RADIUS: f32 = 0.0;
 
 #[derive(Clone, Copy)]
 pub(super) struct CommandPaletteStyle {
-    pub(super) overlay_bg: gpui::Rgba,
     pub(super) panel_bg: gpui::Rgba,
     pub(super) panel_border: gpui::Rgba,
     pub(super) primary_text: gpui::Rgba,
@@ -40,7 +39,6 @@ pub(super) fn command_palette_border_color(
 impl CommandPaletteStyle {
     pub(super) fn resolve(view: &TerminalView) -> Self {
         let overlay_style = view.overlay_style();
-        let overlay_bg = overlay_style.dim_background(COMMAND_PALETTE_DIM_ALPHA);
         let panel_bg = overlay_style.panel_background_with_floor(
             COMMAND_PALETTE_PANEL_BG_ALPHA,
             COMMAND_PALETTE_PANEL_SOLID_ALPHA,
@@ -64,7 +62,6 @@ impl CommandPaletteStyle {
         let scrollbar_thumb = view.scrollbar_color(overlay_style, COMMAND_PALETTE_SCROLLBAR_THUMB_ALPHA);
 
         Self {
-            overlay_bg,
             panel_bg,
             panel_border,
             primary_text,

--- a/src/terminal_view/mod.rs
+++ b/src/terminal_view/mod.rs
@@ -105,7 +105,6 @@ const TMUX_RESIZE_ERROR_TOAST_DEBOUNCE_MS: u64 = 2000;
 const INPUT_SCROLL_SUPPRESS_MS: u64 = 160;
 const TOAST_COPY_FEEDBACK_MS: u64 = 1200;
 const OVERLAY_PANEL_ALPHA_FLOOR_RATIO: f32 = 0.72;
-const OVERLAY_DIM_MIN_SCALE: f32 = 0.25;
 const OVERLAY_PANEL_BORDER_ALPHA: f32 = 0.24;
 const OVERLAY_PRIMARY_TEXT_ALPHA: f32 = 0.95;
 const OVERLAY_MUTED_TEXT_ALPHA: f32 = 0.62;
@@ -114,7 +113,6 @@ const COMMAND_PALETTE_INPUT_SOLID_ALPHA: f32 = 0.76;
 const COMMAND_PALETTE_ROW_SELECTED_BG_ALPHA: f32 = 0.20;
 const COMMAND_PALETTE_SHORTCUT_BG_ALPHA: f32 = 0.10;
 const COMMAND_PALETTE_SHORTCUT_TEXT_ALPHA: f32 = 0.80;
-const COMMAND_PALETTE_DIM_ALPHA: f32 = 0.78;
 const COMMAND_PALETTE_PANEL_BG_ALPHA: f32 = 0.98;
 const COMMAND_PALETTE_INPUT_BG_ALPHA: f32 = 0.64;
 const COMMAND_PALETTE_INPUT_SELECTION_ALPHA: f32 = 0.28;
@@ -590,12 +588,6 @@ fn scaled_chrome_alpha_for_opacity(base_alpha: f32, background_opacity: f32) -> 
     scaled_background_alpha_for_opacity(base_alpha, background_opacity)
 }
 
-fn adaptive_overlay_dim_alpha_for_opacity(base_alpha: f32, background_opacity: f32) -> f32 {
-    let opacity = background_opacity_factor(background_opacity);
-    let scale = OVERLAY_DIM_MIN_SCALE + (1.0 - OVERLAY_DIM_MIN_SCALE) * opacity;
-    (base_alpha * scale).clamp(0.0, base_alpha)
-}
-
 fn adaptive_overlay_panel_alpha_for_opacity(base_alpha: f32, background_opacity: f32) -> f32 {
     let floor = base_alpha * OVERLAY_PANEL_ALPHA_FLOOR_RATIO;
     scaled_background_alpha_for_opacity(base_alpha, background_opacity)
@@ -693,11 +685,6 @@ impl<'a> OverlayStyleBuilder<'a> {
             colors,
             background_opacity,
         }
-    }
-
-    fn dim_background(self, base_alpha: f32) -> gpui::Rgba {
-        let alpha = adaptive_overlay_dim_alpha_for_opacity(base_alpha, self.background_opacity);
-        self.with_alpha(self.colors.background, alpha)
     }
 
     fn panel_background(self, base_alpha: f32) -> gpui::Rgba {
@@ -1969,14 +1956,6 @@ mod tests {
         let base = 0.92;
         let alpha = scaled_chrome_alpha_for_opacity(base, 0.1);
         assert_eq!(alpha, base * 0.1);
-    }
-
-    #[test]
-    fn overlay_dim_gets_stronger_as_opacity_decreases() {
-        let base = 0.78;
-        let high_opacity = adaptive_overlay_dim_alpha_for_opacity(base, 1.0);
-        let low_opacity = adaptive_overlay_dim_alpha_for_opacity(base, 0.2);
-        assert!(low_opacity < high_opacity);
     }
 
     #[test]

--- a/src/terminal_view/render.rs
+++ b/src/terminal_view/render.rs
@@ -33,6 +33,59 @@ fn desaturate_rgb(color: gpui::Rgba, amount: f32) -> gpui::Rgba {
     }
 }
 
+const COMMAND_PALETTE_BACKDROP_STRENGTH: f32 = 1.0;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+struct CellColorTransform {
+    fg_blend: f32,
+    bg_blend: f32,
+    desaturate: f32,
+}
+
+impl CellColorTransform {
+    fn is_active(self) -> bool {
+        self.fg_blend > f32::EPSILON
+            || self.bg_blend > f32::EPSILON
+            || self.desaturate > f32::EPSILON
+    }
+}
+
+fn command_palette_backdrop_transform() -> CellColorTransform {
+    let preset = pane_focus_preset(PaneFocusEffect::SoftSpotlight)
+        .expect("soft spotlight pane focus preset must exist");
+    CellColorTransform {
+        fg_blend: preset.inactive_fg_blend * COMMAND_PALETTE_BACKDROP_STRENGTH,
+        bg_blend: preset.inactive_bg_blend * COMMAND_PALETTE_BACKDROP_STRENGTH,
+        desaturate: preset.inactive_desaturate * COMMAND_PALETTE_BACKDROP_STRENGTH,
+    }
+}
+
+fn apply_cell_color_transform(
+    fg: gpui::Rgba,
+    bg: gpui::Rgba,
+    transform: CellColorTransform,
+    fg_blend_target: gpui::Rgba,
+    bg_blend_target: gpui::Rgba,
+) -> (gpui::Rgba, gpui::Rgba) {
+    if !transform.is_active() {
+        return (fg, bg);
+    }
+
+    let mut next_fg = fg;
+    let mut next_bg = bg;
+    if transform.fg_blend > f32::EPSILON {
+        next_fg = blend_rgb_only(next_fg, fg_blend_target, transform.fg_blend);
+    }
+    if transform.bg_blend > f32::EPSILON {
+        next_bg = blend_rgb_only(next_bg, bg_blend_target, transform.bg_blend);
+    }
+    if transform.desaturate > f32::EPSILON {
+        next_fg = desaturate_rgb(next_fg, transform.desaturate);
+        next_bg = desaturate_rgb(next_bg, transform.desaturate);
+    }
+    (next_fg, next_bg)
+}
+
 fn effective_pane_focus_active_border_alpha(
     active_border_alpha: f32,
     runtime_uses_tmux: bool,
@@ -552,8 +605,11 @@ impl Render for TerminalView {
         let pane_focus_transition =
             self.pane_focus_transition_snapshot(active_tab_focus_snapshot.map(|(id, _)| id), now);
         let pane_focus_config = self.pane_focus_config();
+        let command_palette_open = self.is_command_palette_open();
+        let palette_backdrop_transform =
+            command_palette_open.then(command_palette_backdrop_transform);
         let terminal_cursor_active =
-            !self.is_command_palette_open() && self.renaming_tab.is_none() && !self.search_open;
+            !command_palette_open && self.renaming_tab.is_none() && !self.search_open;
         let cursor_visible = terminal_cursor_active
             && self.cursor_visible_for_focus(self.focus_handle.is_focused(window));
 
@@ -569,7 +625,8 @@ impl Render for TerminalView {
 
         if let Some(active_tab) = self.tabs.get(self.active_tab) {
             let multi_pane = active_tab.panes.len() > 1;
-            let pane_focus_enabled = multi_pane && pane_focus_config.is_some();
+            let pane_focus_enabled =
+                multi_pane && pane_focus_config.is_some() && !command_palette_open;
             pane_focus_needs_animation = pane_focus_enabled && pane_focus_transition.is_some();
             let max_right_cells = active_tab
                 .panes
@@ -617,23 +674,25 @@ impl Render for TerminalView {
                 } else {
                     (0.0, 0.0)
                 };
-                let (
-                    pane_inactive_fg_blend,
-                    pane_inactive_bg_blend,
-                    pane_inactive_desaturate,
-                    raw_pane_active_border_alpha,
-                ) = if let Some((preset, strength)) = pane_focus_config {
+                let (pane_focus_transform, raw_pane_active_border_alpha) =
+                    if let Some((preset, strength)) = pane_focus_config {
                     let inactive_scale = strength * pane_inactive_focus;
                     let active_scale = strength * pane_active_focus;
                     (
-                        preset.inactive_fg_blend * inactive_scale,
-                        preset.inactive_bg_blend * inactive_scale,
-                        preset.inactive_desaturate * inactive_scale,
+                        CellColorTransform {
+                            fg_blend: preset.inactive_fg_blend * inactive_scale,
+                            bg_blend: preset.inactive_bg_blend * inactive_scale,
+                            desaturate: preset.inactive_desaturate * inactive_scale,
+                        },
                         preset.active_border_alpha * active_scale,
                     )
                 } else {
-                    (0.0, 0.0, 0.0, 0.0)
+                    (CellColorTransform::default(), 0.0)
                 };
+                // Palette backdrop uses the same inactive-pane transform path to keep one
+                // consistent dimming model and avoid a separate full-screen color overlay.
+                let cell_color_transform =
+                    palette_backdrop_transform.unwrap_or(pane_focus_transform);
                 // tmux mode already has pane boundary affordances; layering Termy's active-pane
                 // outline on top creates a second full-frame box around the active pane.
                 let pane_active_border_alpha = effective_pane_focus_active_border_alpha(
@@ -672,16 +731,13 @@ impl Render for TerminalView {
                             fg.b *= DIM_TEXT_FACTOR;
                         }
                         bg.a *= effective_background_opacity;
-                        if pane_inactive_fg_blend > f32::EPSILON {
-                            fg = blend_rgb_only(fg, pane_focus_target_bg, pane_inactive_fg_blend);
-                        }
-                        if pane_inactive_bg_blend > f32::EPSILON {
-                            bg = blend_rgb_only(bg, terminal_surface_bg, pane_inactive_bg_blend);
-                        }
-                        if pane_inactive_desaturate > f32::EPSILON {
-                            fg = desaturate_rgb(fg, pane_inactive_desaturate);
-                            bg = desaturate_rgb(bg, pane_inactive_desaturate);
-                        }
+                        (fg, bg) = apply_cell_color_transform(
+                            fg,
+                            bg,
+                            cell_color_transform,
+                            pane_focus_target_bg,
+                            terminal_surface_bg,
+                        );
 
                         let c = cell_content.c;
                         let is_cursor = show_cursor && col == cursor_col && row == cursor_row;
@@ -1366,6 +1422,59 @@ mod tests {
         assert_eq!(frame.top, surface.origin_y);
         assert_eq!(frame.width, surface.width);
         assert_eq!(frame.height, surface.height);
+    }
+
+    #[test]
+    fn apply_cell_color_transform_is_noop_for_zero_factors() {
+        let fg = gpui::Rgba {
+            r: 0.72,
+            g: 0.64,
+            b: 0.35,
+            a: 0.91,
+        };
+        let bg = gpui::Rgba {
+            r: 0.12,
+            g: 0.17,
+            b: 0.26,
+            a: 0.66,
+        };
+        let fg_target = gpui::Rgba {
+            r: 0.01,
+            g: 0.02,
+            b: 0.03,
+            a: 1.0,
+        };
+        let bg_target = gpui::Rgba {
+            r: 0.98,
+            g: 0.97,
+            b: 0.96,
+            a: 1.0,
+        };
+
+        let (next_fg, next_bg) = apply_cell_color_transform(
+            fg,
+            bg,
+            CellColorTransform::default(),
+            fg_target,
+            bg_target,
+        );
+
+        assert_eq!(next_fg, fg);
+        assert_eq!(next_bg, bg);
+    }
+
+    #[test]
+    fn command_palette_backdrop_transform_uses_soft_spotlight_coefficients() {
+        let preset = pane_focus_preset(PaneFocusEffect::SoftSpotlight)
+            .expect("soft spotlight preset should exist");
+        let transform = command_palette_backdrop_transform();
+        let expected_fg = preset.inactive_fg_blend * COMMAND_PALETTE_BACKDROP_STRENGTH;
+        let expected_bg = preset.inactive_bg_blend * COMMAND_PALETTE_BACKDROP_STRENGTH;
+        let expected_desaturate = preset.inactive_desaturate * COMMAND_PALETTE_BACKDROP_STRENGTH;
+
+        assert!((transform.fg_blend - expected_fg).abs() <= f32::EPSILON);
+        assert!((transform.bg_blend - expected_bg).abs() <= f32::EPSILON);
+        assert!((transform.desaturate - expected_desaturate).abs() <= f32::EPSILON);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
This PR cleans up command palette backdrop behavior by reusing the existing pane-dimming path instead of rendering a separate overlay layer.

## What changed
- Updated command palette outside-click handling to use `on_mouse_down(MouseButton::Left)`:
  - Clicking outside the panel closes the palette.
  - Event propagation is stopped so the click does not leak through.
- Removed the dedicated palette overlay background color from command palette style.
- Removed now-unused overlay dim constants/helpers in `terminal_view/mod.rs`.
- In `terminal_view/render.rs`, introduced a shared `CellColorTransform` path and applied it to:
  - Existing pane-focus dimming.
  - Command palette backdrop dimming (via the same transform model).
- Disabled pane-focus animation/effect while the command palette is open to avoid stacked visual treatments.
- Added targeted tests for:
  - No-op behavior of zeroed color transforms.
  - Command palette backdrop transform coefficients.

## Scope
- `/Users/vincent/projects/termy/src/terminal_view/command_palette/render.rs`
- `/Users/vincent/projects/termy/src/terminal_view/command_palette/style.rs`
- `/Users/vincent/projects/termy/src/terminal_view/mod.rs`
- `/Users/vincent/projects/termy/src/terminal_view/render.rs`

## Notes
- Branch was rebased onto `main`; PR diff is now a clean single-commit change focused only on this behavior.