### PR TITLE
fix: block tmux on windows

### DIFF
--- a/crates/terminal_ui/src/tmux/client.rs
+++ b/crates/terminal_ui/src/tmux/client.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result, anyhow};
-use flume::{Receiver, RecvTimeoutError, Sender, bounded};
+use flume::{Receiver, RecvTimeoutError, Sender};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
@@ -9,12 +9,18 @@ use super::command::{
     tmux_command_line,
 };
 use super::control::{
-    ControlRequest, FATAL_EXIT_QUEUE_BOUND, NOTIFICATION_QUEUE_BOUND, NotificationCoalescer,
-    PENDING_QUEUE_BOUND, REQUEST_QUEUE_BOUND, spawn_control_threads, try_enqueue_control_request,
+    ControlRequest, NotificationCoalescer, try_enqueue_control_request,
+};
+#[cfg(unix)]
+use super::control::{
+    FATAL_EXIT_QUEUE_BOUND, NOTIFICATION_QUEUE_BOUND, PENDING_QUEUE_BOUND, REQUEST_QUEUE_BOUND,
+    spawn_control_threads,
 };
 use super::launch::{
-    SessionLaunchPlan, managed_session_window_option_override_commands, spawn_tmux_control_mode,
+    SessionLaunchPlan, managed_session_window_option_override_commands,
 };
+#[cfg(unix)]
+use super::launch::spawn_tmux_control_mode;
 use super::payload::{
     capture_full_pane_args, sanitize_tmux_payload, unescape_tmux_payload,
 };
@@ -50,18 +56,13 @@ impl TmuxClient {
         super::launch::launch_plan(config)
     }
 
+    #[cfg(unix)]
     pub fn new(
         config: TmuxRuntimeConfig,
         cols: u16,
         rows: u16,
         event_wakeup_tx: Option<Sender<()>>,
     ) -> Result<Self> {
-        #[cfg(not(unix))]
-        {
-            let _ = (cols, rows, event_wakeup_tx);
-            return Err(anyhow!("tmux control mode is only supported on unix targets"));
-        }
-
         let launch_plan = Self::launch_plan(&config);
         let enforce_managed_session_ui =
             matches!(&config.launch, TmuxLaunchTarget::Managed { .. });
@@ -76,17 +77,13 @@ impl TmuxClient {
             launch_plan.attach_existing,
         )?;
 
-        let (request_tx, request_rx) = bounded::<ControlRequest>(REQUEST_QUEUE_BOUND);
-        let (pending_tx, pending_rx) = bounded(PENDING_QUEUE_BOUND);
+        let (request_tx, request_rx) = flume::bounded::<ControlRequest>(REQUEST_QUEUE_BOUND);
+        let (pending_tx, pending_rx) = flume::bounded(PENDING_QUEUE_BOUND);
         let (notifications_tx, notifications_rx) =
-            bounded::<TmuxNotification>(NOTIFICATION_QUEUE_BOUND);
-        let (fatal_exit_tx, fatal_exit_rx) = bounded::<Option<String>>(FATAL_EXIT_QUEUE_BOUND);
-        #[cfg(unix)]
+            flume::bounded::<TmuxNotification>(NOTIFICATION_QUEUE_BOUND);
+        let (fatal_exit_tx, fatal_exit_rx) = flume::bounded::<Option<String>>(FATAL_EXIT_QUEUE_BOUND);
         let control_client_pid = child.id();
-        #[cfg(not(unix))]
-        let control_client_pid = 0;
 
-        #[cfg(unix)]
         spawn_control_threads(
             child,
             child_stdin,
@@ -117,6 +114,17 @@ impl TmuxClient {
         }
         client.set_client_size(cols, rows)?;
         Ok(client)
+    }
+
+    #[cfg(not(unix))]
+    pub fn new(
+        config: TmuxRuntimeConfig,
+        cols: u16,
+        rows: u16,
+        event_wakeup_tx: Option<Sender<()>>,
+    ) -> Result<Self> {
+        let _ = (config, cols, rows, event_wakeup_tx);
+        Err(anyhow!("tmux control mode is only supported on unix targets"))
     }
 
     pub fn set_client_size(&self, cols: u16, rows: u16) -> Result<()> {
@@ -793,6 +801,18 @@ mod tests {
         assert_eq!(
             trim_trailing_line_terminators(b"abc \t"),
             b"abc \t".as_slice()
+        );
+    }
+
+    #[cfg(not(unix))]
+    #[test]
+    fn new_reports_unsupported_platform_on_non_unix() {
+        let error = TmuxClient::new(TmuxRuntimeConfig::default(), 120, 40, None::<flume::Sender<()>>)
+            .expect_err("non-unix targets must reject tmux runtime startup");
+        assert!(
+            error
+                .to_string()
+                .contains("tmux control mode is only supported on unix targets")
         );
     }
 }

--- a/crates/terminal_ui/src/tmux/control/mod.rs
+++ b/crates/terminal_ui/src/tmux/control/mod.rs
@@ -8,4 +8,5 @@ pub(crate) use channel::{
     PENDING_QUEUE_BOUND, REQUEST_QUEUE_BOUND, try_enqueue_control_request,
 };
 pub(crate) use coalescer::NotificationCoalescer;
+#[cfg(unix)]
 pub(crate) use worker::spawn_control_threads;

--- a/crates/terminal_ui/src/tmux/control/worker.rs
+++ b/crates/terminal_ui/src/tmux/control/worker.rs
@@ -1,14 +1,19 @@
 #[cfg(unix)]
 use std::fs::File;
+#[cfg(unix)]
 use std::io::{BufRead, BufReader, Write};
 
+#[cfg(unix)]
 use flume::{Receiver, Sender, TrySendError};
 
+#[cfg(unix)]
 use super::super::command::{
     command_with_completion_token, split_control_completion_token,
 };
+#[cfg(unix)]
 use super::super::types::{TmuxControlError, TmuxNotification};
 
+#[cfg(unix)]
 use super::{
     channel::{
         ActiveControlCommand, ControlRequest, PendingCommand, TrackedPendingCommand,

--- a/crates/terminal_ui/src/tmux/launch.rs
+++ b/crates/terminal_ui/src/tmux/launch.rs
@@ -1,3 +1,4 @@
+#[cfg(unix)]
 use anyhow::{Context, Result, anyhow};
 #[cfg(unix)]
 use std::fs::File;
@@ -7,8 +8,10 @@ use std::{
     os::fd::{FromRawFd, IntoRawFd},
     process::Stdio,
 };
+#[cfg(unix)]
 use std::process::Command;
 
+#[cfg(unix)]
 use super::session::append_socket_args;
 use super::types::{
     TmuxLaunchTarget, TmuxRuntimeConfig, TmuxShutdownMode, TmuxSocketTarget,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -11,19 +11,22 @@ pub type MenuSection = u8;
 pub enum CommandPaletteVisibility {
     Always,
     MacOsOnly,
+    NotWindows,
 }
 
 impl CommandPaletteVisibility {
     pub fn is_visible(self) -> bool {
-        self.is_visible_on_macos(cfg!(target_os = "macos"))
+        self.is_visible_on_platform(cfg!(target_os = "macos"), cfg!(target_os = "windows"))
     }
 
-    pub const fn is_visible_on_macos(self, is_macos: bool) -> bool {
+    pub const fn is_visible_on_platform(self, is_macos: bool, is_windows: bool) -> bool {
         match self {
             Self::Always => true,
             Self::MacOsOnly => is_macos,
+            Self::NotWindows => !is_windows,
         }
     }
+
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -53,19 +56,22 @@ impl MenuRoot {
 pub enum MenuVisibility {
     Always,
     MacOsOnly,
+    NotWindows,
 }
 
 impl MenuVisibility {
     pub fn is_visible(self) -> bool {
-        self.is_visible_on_macos(cfg!(target_os = "macos"))
+        self.is_visible_on_platform(cfg!(target_os = "macos"), cfg!(target_os = "windows"))
     }
 
-    pub const fn is_visible_on_macos(self, is_macos: bool) -> bool {
+    pub const fn is_visible_on_platform(self, is_macos: bool, is_windows: bool) -> bool {
         match self {
             Self::Always => true,
             Self::MacOsOnly => is_macos,
+            Self::NotWindows => !is_windows,
         }
     }
+
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -439,13 +445,13 @@ define_commands!(
         Some(palette(
             "Tmux Sessions",
             "tmux sessions attach switch create manage",
-            CommandPaletteVisibility::Always
+            CommandPaletteVisibility::NotWindows
         )),
         Some(menu(
             MenuRoot::File,
             1,
             "Tmux Sessions",
-            MenuVisibility::Always,
+            MenuVisibility::NotWindows,
             MenuActionRole::Normal
         ))
     ),
@@ -455,13 +461,13 @@ define_commands!(
         Some(palette(
             "Split Pane Vertical",
             "split pane vertical right",
-            CommandPaletteVisibility::Always
+            CommandPaletteVisibility::NotWindows
         )),
         Some(menu(
             MenuRoot::File,
             1,
             "Split Pane Vertical",
-            MenuVisibility::Always,
+            MenuVisibility::NotWindows,
             MenuActionRole::Normal
         ))
     ),
@@ -471,13 +477,13 @@ define_commands!(
         Some(palette(
             "Split Pane Horizontal",
             "split pane horizontal down",
-            CommandPaletteVisibility::Always
+            CommandPaletteVisibility::NotWindows
         )),
         Some(menu(
             MenuRoot::File,
             1,
             "Split Pane Horizontal",
-            MenuVisibility::Always,
+            MenuVisibility::NotWindows,
             MenuActionRole::Normal
         ))
     ),
@@ -487,7 +493,7 @@ define_commands!(
         Some(palette(
             "Close Pane",
             "kill close pane",
-            CommandPaletteVisibility::Always
+            CommandPaletteVisibility::NotWindows
         )),
         None
     ),
@@ -497,7 +503,7 @@ define_commands!(
         Some(palette(
             "Focus Pane Left",
             "focus pane left",
-            CommandPaletteVisibility::Always
+            CommandPaletteVisibility::NotWindows
         )),
         None
     ),
@@ -507,7 +513,7 @@ define_commands!(
         Some(palette(
             "Focus Pane Right",
             "focus pane right",
-            CommandPaletteVisibility::Always
+            CommandPaletteVisibility::NotWindows
         )),
         None
     ),
@@ -517,7 +523,7 @@ define_commands!(
         Some(palette(
             "Focus Pane Up",
             "focus pane up",
-            CommandPaletteVisibility::Always
+            CommandPaletteVisibility::NotWindows
         )),
         None
     ),
@@ -527,7 +533,7 @@ define_commands!(
         Some(palette(
             "Focus Pane Down",
             "focus pane down",
-            CommandPaletteVisibility::Always
+            CommandPaletteVisibility::NotWindows
         )),
         None
     ),
@@ -537,13 +543,13 @@ define_commands!(
         Some(palette(
             "Focus Next Pane",
             "focus pane next cycle",
-            CommandPaletteVisibility::Always
+            CommandPaletteVisibility::NotWindows
         )),
         Some(menu(
             MenuRoot::File,
             1,
             "Focus Next Pane",
-            MenuVisibility::Always,
+            MenuVisibility::NotWindows,
             MenuActionRole::Normal
         ))
     ),
@@ -553,7 +559,7 @@ define_commands!(
         Some(palette(
             "Focus Previous Pane",
             "focus pane previous cycle",
-            CommandPaletteVisibility::Always
+            CommandPaletteVisibility::NotWindows
         )),
         None
     ),
@@ -563,7 +569,7 @@ define_commands!(
         Some(palette(
             "Resize Pane Left",
             "resize pane left",
-            CommandPaletteVisibility::Always
+            CommandPaletteVisibility::NotWindows
         )),
         None
     ),
@@ -573,7 +579,7 @@ define_commands!(
         Some(palette(
             "Resize Pane Right",
             "resize pane right",
-            CommandPaletteVisibility::Always
+            CommandPaletteVisibility::NotWindows
         )),
         None
     ),
@@ -583,7 +589,7 @@ define_commands!(
         Some(palette(
             "Resize Pane Up",
             "resize pane up",
-            CommandPaletteVisibility::Always
+            CommandPaletteVisibility::NotWindows
         )),
         None
     ),
@@ -593,7 +599,7 @@ define_commands!(
         Some(palette(
             "Resize Pane Down",
             "resize pane down",
-            CommandPaletteVisibility::Always
+            CommandPaletteVisibility::NotWindows
         )),
         None
     ),
@@ -603,13 +609,13 @@ define_commands!(
         Some(palette(
             "Toggle Pane Zoom",
             "zoom pane maximize",
-            CommandPaletteVisibility::Always
+            CommandPaletteVisibility::NotWindows
         )),
         Some(menu(
             MenuRoot::View,
             1,
             "Toggle Pane Zoom",
-            MenuVisibility::Always,
+            MenuVisibility::NotWindows,
             MenuActionRole::Normal
         ))
     ),
@@ -970,7 +976,9 @@ pub fn inline_input_keybindings() -> Vec<KeyBinding> {
 
 #[cfg(test)]
 mod tests {
-    use super::{CommandAction, MenuActionRole, MenuRoot, MenuVisibility};
+    use super::{
+        CommandAction, CommandPaletteVisibility, MenuActionRole, MenuRoot, MenuVisibility,
+    };
     use std::collections::HashSet;
     use termy_command_core::{CommandCapabilities, CommandId, CommandUnavailableReason};
 
@@ -1046,6 +1054,7 @@ mod tests {
     fn file_menu_includes_requested_pane_actions() {
         let file_entries = CommandAction::menu_entries_for_root(MenuRoot::File);
 
+        #[cfg(not(target_os = "windows"))]
         for action in [
             CommandAction::ClosePaneOrTab,
             CommandAction::SplitPaneVertical,
@@ -1055,6 +1064,18 @@ mod tests {
             assert!(
                 file_entries.iter().any(|entry| entry.action == action),
                 "missing {action:?} from File menu"
+            );
+        }
+        #[cfg(target_os = "windows")]
+        for action in [
+            CommandAction::ManageTmuxSessions,
+            CommandAction::SplitPaneVertical,
+            CommandAction::SplitPaneHorizontal,
+            CommandAction::FocusPaneNext,
+        ] {
+            assert!(
+                !file_entries.iter().any(|entry| entry.action == action),
+                "unexpected {action:?} in File menu on Windows"
             );
         }
 
@@ -1095,7 +1116,10 @@ mod tests {
             .iter()
             .map(|entry| entry.section)
             .collect::<Vec<_>>();
+        #[cfg(not(target_os = "windows"))]
         assert_eq!(sections, [0, 0, 1, 1, 1, 1, 1]);
+        #[cfg(target_os = "windows")]
+        assert_eq!(sections, [0, 0, 1]);
     }
 
     #[test]
@@ -1126,10 +1150,66 @@ mod tests {
 
     #[test]
     fn menu_visibility_filters_by_platform() {
-        assert!(MenuVisibility::Always.is_visible_on_macos(true));
-        assert!(MenuVisibility::Always.is_visible_on_macos(false));
-        assert!(MenuVisibility::MacOsOnly.is_visible_on_macos(true));
-        assert!(!MenuVisibility::MacOsOnly.is_visible_on_macos(false));
+        assert!(MenuVisibility::Always.is_visible_on_platform(true, true));
+        assert!(MenuVisibility::Always.is_visible_on_platform(false, false));
+        assert!(MenuVisibility::MacOsOnly.is_visible_on_platform(true, false));
+        assert!(!MenuVisibility::MacOsOnly.is_visible_on_platform(false, false));
+        assert!(MenuVisibility::NotWindows.is_visible_on_platform(true, false));
+        assert!(!MenuVisibility::NotWindows.is_visible_on_platform(false, true));
+    }
+
+    #[test]
+    fn palette_visibility_filters_by_platform() {
+        assert!(CommandPaletteVisibility::Always.is_visible_on_platform(true, true));
+        assert!(CommandPaletteVisibility::Always.is_visible_on_platform(false, false));
+        assert!(CommandPaletteVisibility::MacOsOnly.is_visible_on_platform(true, false));
+        assert!(!CommandPaletteVisibility::MacOsOnly.is_visible_on_platform(false, false));
+        assert!(CommandPaletteVisibility::NotWindows.is_visible_on_platform(false, false));
+        assert!(!CommandPaletteVisibility::NotWindows.is_visible_on_platform(false, true));
+    }
+
+    #[test]
+    fn windows_hides_tmux_commands_from_palette_entries() {
+        let entries = CommandAction::palette_entries();
+        #[cfg(target_os = "windows")]
+        {
+            for action in [
+                CommandAction::ManageTmuxSessions,
+                CommandAction::SplitPaneVertical,
+                CommandAction::SplitPaneHorizontal,
+                CommandAction::ClosePane,
+                CommandAction::FocusPaneLeft,
+                CommandAction::FocusPaneRight,
+                CommandAction::FocusPaneUp,
+                CommandAction::FocusPaneDown,
+                CommandAction::FocusPaneNext,
+                CommandAction::FocusPanePrevious,
+                CommandAction::ResizePaneLeft,
+                CommandAction::ResizePaneRight,
+                CommandAction::ResizePaneUp,
+                CommandAction::ResizePaneDown,
+                CommandAction::TogglePaneZoom,
+            ] {
+                assert!(
+                    !entries.iter().any(|entry| entry.action == action),
+                    "unexpected tmux palette action {action:?} on Windows"
+                );
+            }
+        }
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            assert!(
+                entries
+                    .iter()
+                    .any(|entry| entry.action == CommandAction::ManageTmuxSessions)
+            );
+            assert!(
+                entries
+                    .iter()
+                    .any(|entry| entry.action == CommandAction::SplitPaneVertical)
+            );
+        }
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod ui;
 use commands::{OpenConfig, OpenSettings};
 use gpui::{App, Application, Bounds, WindowBounds, WindowOptions, prelude::*, px, size};
 use startup::StartupBlocker;
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 use termy_terminal_ui::TmuxClient;
 use terminal_view::{TerminalView, initial_window_background_appearance};
 
@@ -31,30 +32,31 @@ const WINDOWS_DEFAULT_WINDOW_WIDTH: f32 = 1280.0;
 #[cfg(target_os = "windows")]
 const WINDOWS_DEFAULT_WINDOW_HEIGHT: f32 = 820.0;
 
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn preflight_tmux_runtime(config: &config::AppConfig) -> Result<(), StartupBlocker> {
     if !config.tmux_enabled {
         return Ok(());
     }
 
-    #[cfg(target_os = "windows")]
-    {
-        let _ = config;
-        return Err(StartupBlocker::TmuxPreflight(
-            "tmux runtime is unsupported on Windows; supported platforms are macOS and Linux"
-                .to_string(),
-        ));
-    }
-
-    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-    {
-        let _ = config;
-        return Err(StartupBlocker::TmuxPreflight(
-            "tmux runtime is unsupported on this platform".to_string(),
-        ));
-    }
-
     TmuxClient::verify_tmux_version(config.tmux_binary.as_str(), 3, 3)
         .map_err(|error| StartupBlocker::TmuxPreflight(format!("tmux preflight failed: {error}")))
+}
+
+#[cfg(target_os = "windows")]
+fn preflight_tmux_runtime(config: &config::AppConfig) -> Result<(), StartupBlocker> {
+    let _ = config;
+    Ok(())
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+fn preflight_tmux_runtime(config: &config::AppConfig) -> Result<(), StartupBlocker> {
+    if !config.tmux_enabled {
+        return Ok(());
+    }
+
+    Err(StartupBlocker::TmuxPreflight(
+        "tmux runtime is unsupported on this platform".to_string(),
+    ))
 }
 
 fn main() {
@@ -81,7 +83,13 @@ fn main() {
         if let Err(blocker) = preflight_tmux_runtime(&app_config) {
             blocker.present_and_exit();
         }
-        keybindings::install_keybindings(cx, &app_config, app_config.tmux_enabled);
+        // Keep startup menus/keybinds aligned with the active runtime capability set.
+        let tmux_runtime_active = if cfg!(target_os = "windows") {
+            false
+        } else {
+            app_config.tmux_enabled
+        };
+        keybindings::install_keybindings(cx, &app_config, tmux_runtime_active);
         let window_background = initial_window_background_appearance(&app_config);
         let window_width = app_config.window_width;
         let window_height = app_config.window_height;

--- a/src/menus.rs
+++ b/src/menus.rs
@@ -267,6 +267,7 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
+        #[cfg(not(target_os = "windows"))]
         assert_eq!(
             labels,
             vec![
@@ -282,6 +283,14 @@ mod tests {
             .into_iter()
             .map(ToString::to_string)
             .collect::<Vec<_>>()
+        );
+        #[cfg(target_os = "windows")]
+        assert_eq!(
+            labels,
+            vec!["New Tab", "Rename Tab", "<separator>", "Close Pane or Tab"]
+                .into_iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
         );
     }
 

--- a/src/settings_view/sections.rs
+++ b/src/settings_view/sections.rs
@@ -172,7 +172,7 @@ impl SettingsWindow {
     }
 
     pub(super) fn render_terminal_section(&mut self, cx: &mut Context<Self>) -> impl IntoElement {
-        div()
+        let mut section = div()
             .flex()
             .flex_col()
             .gap_2()
@@ -183,8 +183,14 @@ impl SettingsWindow {
                 cx,
             ))
             .child(self.render_terminal_cursor_group(cx))
-            .child(self.render_terminal_shell_group(cx))
-            .child(self.render_terminal_tmux_group(cx))
+            .child(self.render_terminal_shell_group(cx));
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            section = section.child(self.render_terminal_tmux_group(cx));
+        }
+
+        section
             .child(self.render_terminal_scrolling_group(cx))
             .child(self.render_terminal_ui_group(cx))
     }
@@ -270,6 +276,7 @@ impl SettingsWindow {
         self.render_settings_group("SHELL", rows)
     }
 
+    #[cfg(not(target_os = "windows"))]
     pub(super) fn render_terminal_tmux_group(&mut self, cx: &mut Context<Self>) -> AnyElement {
         let enabled_meta = Self::setting_metadata_or_fallback("tmux_enabled");
         let persistence_meta = Self::setting_metadata_or_fallback("tmux_persistence");

--- a/src/terminal_view/command_palette/mod.rs
+++ b/src/terminal_view/command_palette/mod.rs
@@ -767,7 +767,10 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
+        #[cfg(not(target_os = "windows"))]
         assert_eq!(filtered_actions, vec![CommandAction::ManageTmuxSessions]);
+        #[cfg(target_os = "windows")]
+        assert!(filtered_actions.is_empty());
     }
 
     #[test]
@@ -778,10 +781,18 @@ mod tests {
             .find_map(|item| match item.kind {
                 CommandPaletteItemKind::Command(CommandAction::SplitPaneVertical) => Some(item),
                 _ => None,
-            })
-            .expect("missing split pane command");
-        assert!(!split.enabled);
-        assert_eq!(split.status_hint, Some("tmux required"));
+            });
+        #[cfg(not(target_os = "windows"))]
+        {
+            let split = split.expect("missing split pane command");
+            assert!(!split.enabled);
+            assert_eq!(split.status_hint, Some("tmux required"));
+        }
+        #[cfg(target_os = "windows")]
+        assert!(
+            split.is_none(),
+            "split pane command should be hidden from Windows command palette"
+        );
     }
 
     #[test]

--- a/src/terminal_view/interaction/actions.rs
+++ b/src/terminal_view/interaction/actions.rs
@@ -21,6 +21,15 @@ impl TerminalView {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        #[cfg(target_os = "windows")]
+        if action == CommandAction::ManageTmuxSessions || action.to_command_id().is_tmux_only() {
+            // Defensive guard: custom keybinds can still target tmux actions even when
+            // Windows UI entries are hidden.
+            termy_toast::info("tmux integration is unsupported on Windows");
+            cx.notify();
+            return;
+        }
+
         // Keep runtime command gating aligned with command_core so every UI surface
         // and execution path applies the same capability rules.
         let availability = action.availability(CommandCapabilities {

--- a/src/terminal_view/mod.rs
+++ b/src/terminal_view/mod.rs
@@ -102,6 +102,9 @@ const SEARCH_BAR_WIDTH: f32 = 320.0;
 const SEARCH_BAR_HEIGHT: f32 = 36.0;
 const SEARCH_DEBOUNCE_MS: u64 = 50;
 const TMUX_RESIZE_ERROR_TOAST_DEBOUNCE_MS: u64 = 2000;
+#[cfg(target_os = "windows")]
+const TMUX_UNSUPPORTED_WINDOWS_TOAST: &str =
+    "tmux integration is unsupported on Windows; using native runtime instead.";
 const INPUT_SCROLL_SUPPRESS_MS: u64 = 160;
 const TOAST_COPY_FEEDBACK_MS: u64 = 1200;
 const OVERLAY_PANEL_ALPHA_FLOOR_RATIO: f32 = 0.72;
@@ -1572,6 +1575,11 @@ impl TerminalView {
             #[cfg(target_os = "macos")]
             update_check_toast_id: None,
         };
+        #[cfg(target_os = "windows")]
+        if config.tmux_enabled {
+            // Surface explicit feedback when a synced/shared config requests tmux on Windows.
+            termy_toast::warning(TMUX_UNSUPPORTED_WINDOWS_TOAST);
+        }
         match initial_snapshot {
             Some(initial_snapshot) => view.apply_tmux_snapshot(initial_snapshot),
             None => {
@@ -1631,8 +1639,16 @@ impl TerminalView {
             enabled: self.tab_title.shell_integration,
             explicit_prefix: self.tab_title.explicit_prefix.clone(),
         };
+        #[cfg(target_os = "windows")]
+        if !self.tmux_enabled_config && config.tmux_enabled {
+            // Keep this visible on config reload so users understand why runtime did not switch.
+            termy_toast::warning(TMUX_UNSUPPORTED_WINDOWS_TOAST);
+        }
+        #[cfg(not(target_os = "windows"))]
         let next_runtime_kind = Self::runtime_kind_from_app_config(&config);
+        #[cfg(not(target_os = "windows"))]
         let tmux_enabled_changed = config.tmux_enabled != self.tmux_enabled_config;
+        #[cfg(not(target_os = "windows"))]
         if next_runtime_kind != self.runtime_kind() && tmux_enabled_changed {
             termy_toast::info(
                 "tmux startup default saved. Use Tmux Sessions to switch runtime now.",
@@ -2062,9 +2078,15 @@ mod tests {
         );
 
         config.tmux_enabled = true;
+        #[cfg(not(target_os = "windows"))]
         assert_eq!(
             TerminalView::runtime_kind_from_app_config(&config),
             RuntimeKind::Tmux
+        );
+        #[cfg(target_os = "windows")]
+        assert_eq!(
+            TerminalView::runtime_kind_from_app_config(&config),
+            RuntimeKind::Native
         );
     }
 

--- a/src/terminal_view/runtime/mod.rs
+++ b/src/terminal_view/runtime/mod.rs
@@ -40,6 +40,13 @@ impl RuntimeKind {
     }
 
     pub(super) const fn from_app_config(config: &AppConfig) -> Self {
+        #[cfg(target_os = "windows")]
+        {
+            let _ = config;
+            // Hard cutover: tmux runtime is unsupported on Windows, regardless of config value.
+            return Self::Native;
+        }
+
         if config.tmux_enabled {
             Self::Tmux
         } else {


### PR DESCRIPTION
**Summary**
- Fix Unix-only tmux symbol/import gating so non-Unix builds don’t fail on unresolved imports.
- Split `TmuxClient::new` by platform:
  - Unix: existing tmux startup path.
  - Non-Unix: fail-fast with clear unsupported-platform error.
- Add `NotWindows` command visibility and hide tmux entries from command palette/menus on Windows.
- Force native runtime on Windows even when `tmux_enabled = true`.
- Replace Windows startup tmux hard-fail with warning-based behavior.
- Add a Windows runtime guard for tmux actions (covers custom keybind edge cases).
- Hide TMUX settings group on Windows.
- Update tests for visibility/runtime behavior and add non-Unix constructor test coverage.

**Validation**
- `cargo check -p termy_terminal_ui`
- `cargo check -p termy`
- `cargo test -p termy --no-run`
- `cargo test -p termy_terminal_ui`
- Targeted app tests for commands/menus/command-palette/runtime all pass.
- `cargo check --target x86_64-pc-windows-msvc` requires MSVC tooling (`lib.exe`) and must run on a Windows/MSVC runner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced platform-aware visibility system for commands and menu items with explicit Windows support detection.

* **Refactor**
  * Reorganized tmux integration as exclusive to Unix/Linux/macOS; Windows receives graceful error messaging for unsupported operations.
  * Dynamically adjusted settings interface and command palette to reflect platform-specific capabilities.
  * Improved application startup validation with platform-specific tmux requirement enforcement.
  * Restructured tmux client initialization with platform guards and appropriate fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->