### PR TITLE
Update README with simplified download section and add navigation links

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5535,7 +5535,7 @@ dependencies = [
 
 [[package]]
 name = "termy"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/README.md
+++ b/README.md
@@ -2,85 +2,16 @@
   <img src="assets/termy_icon@1024px.png" width="120" alt="Termy icon" />
   <h1>Termy</h1>
   <p>A minimal terminal emulator built with <a href="https://gpui.rs">GPUI</a> and <a href="https://alacritty.org">alacritty_terminal</a>.</p>
+  <p>
+    <a href="https://termy.run/docs">Documentation</a> •
+    <a href="https://github.com/lassejlv/termy/releases/latest">Download</a> •
+    <a href="https://github.com/lassejlv/termy">GitHub</a>
+  </p>
 </div>
 
----
+## Download
 
-## Installation
-
-### macOS — Homebrew (recommended)
-
-```sh
-brew tap lassejlv/termy https://github.com/lassejlv/termy
-brew install --cask termy
-```
-
-### macOS — Direct download
-
-Download the latest `.dmg` from the [Releases](https://github.com/lassejlv/termy/releases/latest) page:
-
-- **Apple Silicon (arm64):** `Termy-<version>-macos-arm64.dmg`
-- **Intel (x86_64):** `Termy-<version>-macos-x86_64.dmg`
-
-### Linux
-
-Download the latest tarball from the [Releases](https://github.com/lassejlv/termy/releases/latest) page:
-
-- `Termy-<version>-linux-x86_64.tar.gz`
-
-Extract and run the binary:
-
-```sh
-tar -xzf Termy-*-linux-x86_64.tar.gz
-./termy
-```
-
-### Arch Linux
-
-```sh
-paru -S termy-bin
-```
-
-### Windows
-
-Download the latest installer from the [Releases](https://github.com/lassejlv/termy/releases/latest) page:
-
-- `Termy-<version>-x64-Setup.exe`
-
-Run the installer and follow the setup wizard.
-
-### Build from source
-
-> Requires Rust (stable).
-
-```sh
-cargo run --release
-```
-
-Developer tests: see [docs/development.md](docs/development.md).
-
-## Configuration
-
-Config file: `~/.config/termy/config.txt`
-
-```txt
-theme = termy
-font_family = "JetBrains Mono"
-font_size = 14
-window_width = 1100
-window_height = 720
-keybind = cmd-p=toggle_command_palette
-```
-
-See [`docs/configuration.md`](docs/configuration.md) and [`docs/keybindings.md`](docs/keybindings.md) for the full reference.
-
-## Building packages
-
-| Platform | Command |
-|----------|---------|
-| macOS DMG | `./scripts/build-dmg.sh` |
-| macOS signed DMG | `./scripts/build-dmg-signed.sh --sign-identity "..." --notary-profile TERMY_NOTARY` |
-| Windows Setup.exe | `./scripts/build-setup.ps1 -Version 0.1.0 -Arch x64 -Target x86_64-pc-windows-msvc` |
+[Download Termy](https://termy.run/#download) for your platform at termy.run
 
 ## License
 


### PR DESCRIPTION
This pull request updates the `README.md` to simplify the installation and download instructions for Termy. The main change is a significant reduction and streamlining of the installation section, replacing detailed platform-specific instructions with a single link to the main download page. Additionally, quick-access links for documentation, download, and GitHub are added to the top of the README for convenience.

Documentation and navigation improvements:

* Added a new paragraph with quick links to Documentation, Download, and GitHub at the top of the README for easier access.

Installation and download section simplification:

* Removed all detailed platform-specific installation instructions and replaced them with a single link to the main download page at termy.run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured README to consolidate multiple platform-specific installation instructions and configuration sections into a single Download Termy resource link
  * Removed installation guidance for macOS Homebrew, direct downloads, Linux tarball, Arch Linux, Windows, and build-from-source methods
  * Added Documentation/Download/GitHub reference link block at the top of the README

<!-- end of auto-generated comment: release notes by coderabbit.ai -->