### PR TITLE
Refactor pane commands to work natively without tmux

### DIFF
--- a/crates/cli/src/commands/providers.rs
+++ b/crates/cli/src/commands/providers.rs
@@ -1,8 +1,8 @@
 use std::path::PathBuf;
 
 use termy_command_core::{
-    CommandCapabilities, CommandId, CommandUnavailableReason, KeybindLineRef, default_resolved_keybinds,
-    parse_keybind_directives_from_iter, resolve_keybinds,
+    CommandCapabilities, CommandId, CommandUnavailableReason, KeybindLineRef,
+    default_resolved_keybinds, parse_keybind_directives_from_iter, resolve_keybinds,
 };
 use termy_config_core::{AppConfig, config_path};
 use termy_theme_core::{ANSI_COLOR_NAMES, format_hex};
@@ -178,13 +178,11 @@ fn command_capabilities(tmux_enabled: bool, install_cli_available: bool) -> Comm
     }
 }
 
-fn command_metadata_for_id(
-    id: CommandId,
-    capabilities: CommandCapabilities,
-) -> (bool, bool, bool) {
+fn command_metadata_for_id(id: CommandId, capabilities: CommandCapabilities) -> (bool, bool, bool) {
     let availability = id.availability(capabilities);
     let tmux_required = id.is_tmux_only();
-    let restart_required = availability.reason == Some(CommandUnavailableReason::RequiresTmuxRuntime);
+    let restart_required =
+        availability.reason == Some(CommandUnavailableReason::RequiresTmuxRuntime);
     (availability.enabled, tmux_required, restart_required)
 }
 
@@ -274,8 +272,9 @@ fn list_fonts_impl() -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        action_lines_for_capabilities, action_lines_for_tmux_enabled, keybind_lines_for_capabilities,
-        keybind_lines_for_tmux_enabled, list_theme_lines, resolve_keybinds_for_lines,
+        action_lines_for_capabilities, action_lines_for_tmux_enabled,
+        keybind_lines_for_capabilities, keybind_lines_for_tmux_enabled, list_theme_lines,
+        resolve_keybinds_for_lines,
     };
     use termy_command_core::{
         CommandId, KeybindLineRef, default_resolved_keybinds, parse_keybind_directives_from_iter,
@@ -307,13 +306,13 @@ mod tests {
     #[test]
     fn list_actions_includes_tmux_metadata_when_runtime_is_disabled() {
         let actions = action_lines_for_tmux_enabled(false);
-        let split_pane_line = actions
+        let resize_pane_line = actions
             .iter()
-            .find(|line| line.starts_with(CommandId::SplitPaneVertical.config_name()))
-            .expect("missing split_pane_vertical action metadata");
-        assert!(split_pane_line.contains("available=false"));
-        assert!(split_pane_line.contains("tmux_required=true"));
-        assert!(split_pane_line.contains("restart_required=true"));
+            .find(|line| line.starts_with(CommandId::ResizePaneLeft.config_name()))
+            .expect("missing resize_pane_left action metadata");
+        assert!(resize_pane_line.contains("available=false"));
+        assert!(resize_pane_line.contains("tmux_required=true"));
+        assert!(resize_pane_line.contains("restart_required=true"));
     }
 
     #[test]
@@ -331,13 +330,13 @@ mod tests {
     #[test]
     fn list_actions_reports_restart_not_required_when_tmux_runtime_is_active() {
         let actions = action_lines_for_capabilities(true, true);
-        let split_pane_line = actions
+        let resize_pane_line = actions
             .iter()
-            .find(|line| line.starts_with(CommandId::SplitPaneVertical.config_name()))
-            .expect("missing split_pane_vertical action metadata");
-        assert!(split_pane_line.contains("available=true"));
-        assert!(split_pane_line.contains("tmux_required=true"));
-        assert!(split_pane_line.contains("restart_required=false"));
+            .find(|line| line.starts_with(CommandId::ResizePaneLeft.config_name()))
+            .expect("missing resize_pane_left action metadata");
+        assert!(resize_pane_line.contains("available=true"));
+        assert!(resize_pane_line.contains("tmux_required=true"));
+        assert!(resize_pane_line.contains("restart_required=false"));
     }
 
     #[test]
@@ -370,13 +369,13 @@ mod tests {
     #[test]
     fn list_keybinds_includes_tmux_metadata_when_runtime_is_disabled() {
         let keybind_lines = keybind_lines_for_tmux_enabled(&[], false);
-        let split_pane_line = keybind_lines
+        let resize_pane_line = keybind_lines
             .iter()
-            .find(|line| line.starts_with("secondary-d = split_pane_vertical"))
-            .expect("missing secondary-d split pane keybind metadata");
-        assert!(split_pane_line.contains("available=false"));
-        assert!(split_pane_line.contains("tmux_required=true"));
-        assert!(split_pane_line.contains("restart_required=true"));
+            .find(|line| line.starts_with("secondary-alt-shift-left = resize_pane_left"))
+            .expect("missing secondary-alt-shift-left resize pane keybind metadata");
+        assert!(resize_pane_line.contains("available=false"));
+        assert!(resize_pane_line.contains("tmux_required=true"));
+        assert!(resize_pane_line.contains("restart_required=true"));
     }
 
     #[test]
@@ -403,18 +402,18 @@ mod tests {
         let keybind_lines = keybind_lines_for_capabilities(
             &[KeybindConfigLine {
                 line_number: 1,
-                value: "Secondary-D=split_pane_vertical".to_string(),
+                value: "Secondary-Alt-Shift-Left=resize_pane_left".to_string(),
             }],
             true,
             true,
         );
-        let split_pane_line = keybind_lines
+        let resize_pane_line = keybind_lines
             .iter()
-            .find(|line| line.starts_with("secondary-d = split_pane_vertical"))
-            .expect("missing split_pane_vertical keybind metadata");
-        assert!(split_pane_line.contains("available=true"));
-        assert!(split_pane_line.contains("tmux_required=true"));
-        assert!(split_pane_line.contains("restart_required=false"));
+            .find(|line| line.starts_with("secondary-alt-shift-left = resize_pane_left"))
+            .expect("missing resize_pane_left keybind metadata");
+        assert!(resize_pane_line.contains("available=true"));
+        assert!(resize_pane_line.contains("tmux_required=true"));
+        assert!(resize_pane_line.contains("restart_required=false"));
     }
 
     #[test]

--- a/crates/cli/src/commands/validate_config.rs
+++ b/crates/cli/src/commands/validate_config.rs
@@ -169,22 +169,29 @@ mod tests {
     fn tmux_only_keybind_warns_when_tmux_is_disabled() {
         let report = validate_contents(
             "tmux_enabled = false\n\
-             keybind = secondary-d=split_pane_vertical\n\
+             keybind = secondary-alt-shift-left=resize_pane_left\n\
              keybind = secondary-c=copy\n",
         );
 
-        assert!(report.errors.is_empty(), "unexpected errors: {:?}", report.errors);
+        assert!(
+            report.errors.is_empty(),
+            "unexpected errors: {:?}",
+            report.errors
+        );
         assert!(
             report.warnings.iter().any(|warning| {
                 warning.contains("Line 2:")
-                    && warning.contains("split_pane_vertical")
+                    && warning.contains("resize_pane_left")
                     && warning.contains("tmux_enabled=true")
             }),
             "expected tmux-only keybind warning, got {:?}",
             report.warnings
         );
         assert!(
-            !report.warnings.iter().any(|warning| warning.contains("copy")),
+            !report
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("copy")),
             "non-tmux keybind should not warn: {:?}",
             report.warnings
         );
@@ -194,10 +201,18 @@ mod tests {
     fn tmux_only_keybind_does_not_warn_when_tmux_is_enabled() {
         let report = validate_contents(
             "tmux_enabled = true\n\
-             keybind = secondary-d=split_pane_vertical\n",
+             keybind = secondary-alt-shift-left=resize_pane_left\n",
         );
 
-        assert!(report.errors.is_empty(), "unexpected errors: {:?}", report.errors);
-        assert!(report.warnings.is_empty(), "unexpected warnings: {:?}", report.warnings);
+        assert!(
+            report.errors.is_empty(),
+            "unexpected errors: {:?}",
+            report.errors
+        );
+        assert!(
+            report.warnings.is_empty(),
+            "unexpected warnings: {:?}",
+            report.warnings
+        );
     }
 }

--- a/crates/command_core/src/availability.rs
+++ b/crates/command_core/src/availability.rs
@@ -52,7 +52,7 @@ mod tests {
             tmux_runtime_active: false,
             install_cli_available: true,
         };
-        let availability = CommandId::SplitPaneVertical.availability(caps);
+        let availability = CommandId::ResizePaneLeft.availability(caps);
         assert!(!availability.enabled);
         assert_eq!(
             availability.reason,

--- a/crates/command_core/src/catalog.rs
+++ b/crates/command_core/src/catalog.rs
@@ -27,7 +27,6 @@ macro_rules! termy_command_catalog {
             (MinimizeWindow, "minimize_window"),
             (RenameTab, "rename_tab"),
             (AppInfo, "app_info"),
-            (NativeSdkExample, "native_sdk_example"),
             (RestartApp, "restart_app"),
             (OpenConfig, "open_config"),
             (OpenSettings, "open_settings"),
@@ -103,16 +102,7 @@ macro_rules! define_command_catalog {
             pub const fn is_tmux_only(self) -> bool {
                 matches!(
                     self,
-                    Self::SplitPaneVertical
-                        | Self::SplitPaneHorizontal
-                        | Self::ClosePane
-                        | Self::FocusPaneLeft
-                        | Self::FocusPaneRight
-                        | Self::FocusPaneUp
-                        | Self::FocusPaneDown
-                        | Self::FocusPaneNext
-                        | Self::FocusPanePrevious
-                        | Self::ResizePaneLeft
+                    Self::ResizePaneLeft
                         | Self::ResizePaneRight
                         | Self::ResizePaneUp
                         | Self::ResizePaneDown
@@ -173,19 +163,10 @@ mod tests {
         actual.sort_unstable();
 
         let mut expected = vec![
-            "close_pane",
-            "focus_pane_down",
-            "focus_pane_left",
-            "focus_pane_next",
-            "focus_pane_previous",
-            "focus_pane_right",
-            "focus_pane_up",
             "resize_pane_down",
             "resize_pane_left",
             "resize_pane_right",
             "resize_pane_up",
-            "split_pane_horizontal",
-            "split_pane_vertical",
             "toggle_pane_zoom",
         ];
         expected.sort_unstable();

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -32,7 +32,12 @@ fn run() -> Result<()> {
     match command.as_str() {
         "generate-keybindings-doc" => {
             let contents = render_keybindings_doc();
-            write_or_check(&docs_keybindings_path()?, &contents, check_only, "keybindings docs")
+            write_or_check(
+                &docs_keybindings_path()?,
+                &contents,
+                check_only,
+                "keybindings docs",
+            )
         }
         "generate-config-doc" => {
             let config_doc = render_configuration_doc();
@@ -76,7 +81,8 @@ fn write_or_check(path: &Path, contents: &str, check_only: bool, label: &str) ->
         );
     }
 
-    std::fs::write(path, contents).with_context(|| format!("failed to write {}", path.display()))?;
+    std::fs::write(path, contents)
+        .with_context(|| format!("failed to write {}", path.display()))?;
     println!("updated {}", path.display());
     Ok(())
 }
@@ -90,7 +96,9 @@ fn docs_configuration_path() -> Result<PathBuf> {
 }
 
 fn default_config_template_path() -> Result<PathBuf> {
-    Ok(workspace_root().with_context(|| "workspace root")?.join("crates/config_core/src/default_config.txt"))
+    Ok(workspace_root()
+        .with_context(|| "workspace root")?
+        .join("crates/config_core/src/default_config.txt"))
 }
 
 fn workspace_root() -> Result<PathBuf> {
@@ -180,7 +188,10 @@ fn render_configuration_doc() -> String {
         SettingsSection::Keybindings,
     ] {
         output.push_str(&format!("## {}\n\n", section.label()));
-        for spec in root_setting_specs().iter().filter(|spec| spec.section == section) {
+        for spec in root_setting_specs()
+            .iter()
+            .filter(|spec| spec.section == section)
+        {
             output.push_str(&format!("`{}`\n", spec.key));
             output.push_str(&format!(
                 "- Default: {}\n",
@@ -239,7 +250,9 @@ fn render_default_config_template() -> String {
 
         let value = match spec.id {
             RootSettingId::WorkingDirFallback => "home".to_string(),
-            _ => root_setting_default_value(&defaults, spec.id).unwrap_or_else(|| "none".to_string()),
+            _ => {
+                root_setting_default_value(&defaults, spec.id).unwrap_or_else(|| "none".to_string())
+            }
         };
 
         if should_comment {
@@ -255,7 +268,7 @@ fn render_default_config_template() -> String {
     output.push_str("# keybind = cmd-c=copy\n");
     output.push_str("# keybind = cmd-c=unbind\n");
     output.push_str("# keybind = clear\n");
-    output.push_str("# keybind = secondary-d=split_pane_vertical\n");
+    output.push_str("# keybind = secondary-alt-shift-left=resize_pane_left\n");
 
     output.push_str("\n# Color overrides\n");
     output.push_str("[colors]\n");
@@ -296,7 +309,7 @@ mod tests {
     #[test]
     fn keybindings_doc_marks_tmux_only_actions() {
         let out = render_keybindings_doc();
-        assert!(out.contains("split_pane_vertical` (tmux required)"));
+        assert!(out.contains("resize_pane_left` (tmux required)"));
         assert!(out.contains("toggle_command_palette`"));
     }
 

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -13,13 +13,13 @@ Termy keybindings use Ghostty-style trigger overrides via repeated `keybind` lin
 - `secondary-p` -> `toggle_command_palette`
 - `secondary-t` -> `new_tab`
 - `secondary-w` -> `close_pane_or_tab`
-- `secondary-d` -> `split_pane_vertical` (tmux required)
-- `secondary-shift-d` -> `split_pane_horizontal` (tmux required)
-- `secondary-o` -> `focus_pane_next` (tmux required)
-- `secondary-alt-left` -> `focus_pane_left` (tmux required)
-- `secondary-alt-right` -> `focus_pane_right` (tmux required)
-- `secondary-alt-up` -> `focus_pane_up` (tmux required)
-- `secondary-alt-down` -> `focus_pane_down` (tmux required)
+- `secondary-d` -> `split_pane_vertical`
+- `secondary-shift-d` -> `split_pane_horizontal`
+- `secondary-o` -> `focus_pane_next`
+- `secondary-alt-left` -> `focus_pane_left`
+- `secondary-alt-right` -> `focus_pane_right`
+- `secondary-alt-up` -> `focus_pane_up`
+- `secondary-alt-down` -> `focus_pane_down`
 - `secondary-alt-shift-left` -> `resize_pane_left` (tmux required)
 - `secondary-alt-shift-right` -> `resize_pane_right` (tmux required)
 - `secondary-alt-shift-up` -> `resize_pane_up` (tmux required)
@@ -44,13 +44,13 @@ Termy keybindings use Ghostty-style trigger overrides via repeated `keybind` lin
 - `secondary-p` -> `toggle_command_palette`
 - `secondary-t` -> `new_tab`
 - `secondary-w` -> `close_pane_or_tab`
-- `secondary-d` -> `split_pane_vertical` (tmux required)
-- `secondary-shift-d` -> `split_pane_horizontal` (tmux required)
-- `secondary-o` -> `focus_pane_next` (tmux required)
-- `secondary-alt-left` -> `focus_pane_left` (tmux required)
-- `secondary-alt-right` -> `focus_pane_right` (tmux required)
-- `secondary-alt-up` -> `focus_pane_up` (tmux required)
-- `secondary-alt-down` -> `focus_pane_down` (tmux required)
+- `secondary-d` -> `split_pane_vertical`
+- `secondary-shift-d` -> `split_pane_horizontal`
+- `secondary-o` -> `focus_pane_next`
+- `secondary-alt-left` -> `focus_pane_left`
+- `secondary-alt-right` -> `focus_pane_right`
+- `secondary-alt-up` -> `focus_pane_up`
+- `secondary-alt-down` -> `focus_pane_down`
 - `secondary-alt-shift-left` -> `resize_pane_left` (tmux required)
 - `secondary-alt-shift-right` -> `resize_pane_right` (tmux required)
 - `secondary-alt-shift-up` -> `resize_pane_up` (tmux required)
@@ -74,13 +74,13 @@ Termy keybindings use Ghostty-style trigger overrides via repeated `keybind` lin
 - `secondary-p` -> `toggle_command_palette`
 - `secondary-t` -> `new_tab`
 - `secondary-w` -> `close_pane_or_tab`
-- `secondary-d` -> `split_pane_vertical` (tmux required)
-- `secondary-shift-d` -> `split_pane_horizontal` (tmux required)
-- `secondary-o` -> `focus_pane_next` (tmux required)
-- `secondary-alt-left` -> `focus_pane_left` (tmux required)
-- `secondary-alt-right` -> `focus_pane_right` (tmux required)
-- `secondary-alt-up` -> `focus_pane_up` (tmux required)
-- `secondary-alt-down` -> `focus_pane_down` (tmux required)
+- `secondary-d` -> `split_pane_vertical`
+- `secondary-shift-d` -> `split_pane_horizontal`
+- `secondary-o` -> `focus_pane_next`
+- `secondary-alt-left` -> `focus_pane_left`
+- `secondary-alt-right` -> `focus_pane_right`
+- `secondary-alt-up` -> `focus_pane_up`
+- `secondary-alt-down` -> `focus_pane_down`
 - `secondary-alt-shift-left` -> `resize_pane_left` (tmux required)
 - `secondary-alt-shift-right` -> `resize_pane_right` (tmux required)
 - `secondary-alt-shift-up` -> `resize_pane_up` (tmux required)
@@ -104,13 +104,13 @@ Termy keybindings use Ghostty-style trigger overrides via repeated `keybind` lin
 - `secondary-p` -> `toggle_command_palette`
 - `secondary-t` -> `new_tab`
 - `secondary-w` -> `close_pane_or_tab`
-- `secondary-d` -> `split_pane_vertical` (tmux required)
-- `secondary-shift-d` -> `split_pane_horizontal` (tmux required)
-- `secondary-o` -> `focus_pane_next` (tmux required)
-- `secondary-alt-left` -> `focus_pane_left` (tmux required)
-- `secondary-alt-right` -> `focus_pane_right` (tmux required)
-- `secondary-alt-up` -> `focus_pane_up` (tmux required)
-- `secondary-alt-down` -> `focus_pane_down` (tmux required)
+- `secondary-d` -> `split_pane_vertical`
+- `secondary-shift-d` -> `split_pane_horizontal`
+- `secondary-o` -> `focus_pane_next`
+- `secondary-alt-left` -> `focus_pane_left`
+- `secondary-alt-right` -> `focus_pane_right`
+- `secondary-alt-up` -> `focus_pane_up`
+- `secondary-alt-down` -> `focus_pane_down`
 - `secondary-alt-shift-left` -> `resize_pane_left` (tmux required)
 - `secondary-alt-shift-right` -> `resize_pane_right` (tmux required)
 - `secondary-alt-shift-up` -> `resize_pane_up` (tmux required)
@@ -159,15 +159,15 @@ Related UI option:
 - `switch_tab_left`
 - `switch_tab_right`
 - `manage_tmux_sessions`
-- `split_pane_vertical` (tmux required)
-- `split_pane_horizontal` (tmux required)
-- `close_pane` (tmux required)
-- `focus_pane_left` (tmux required)
-- `focus_pane_right` (tmux required)
-- `focus_pane_up` (tmux required)
-- `focus_pane_down` (tmux required)
-- `focus_pane_next` (tmux required)
-- `focus_pane_previous` (tmux required)
+- `split_pane_vertical`
+- `split_pane_horizontal`
+- `close_pane`
+- `focus_pane_left`
+- `focus_pane_right`
+- `focus_pane_up`
+- `focus_pane_down`
+- `focus_pane_next`
+- `focus_pane_previous`
 - `resize_pane_left` (tmux required)
 - `resize_pane_right` (tmux required)
 - `resize_pane_up` (tmux required)
@@ -176,7 +176,6 @@ Related UI option:
 - `minimize_window`
 - `rename_tab`
 - `app_info`
-- `native_sdk_example`
 - `restart_app`
 - `open_config`
 - `open_settings`

--- a/site/src/content/keybindings.md
+++ b/site/src/content/keybindings.md
@@ -113,7 +113,6 @@ Related UI option:
 - `minimize_window`
 - `rename_tab`
 - `app_info`
-- `native_sdk_example`
 - `restart_app`
 - `open_config`
 - `open_settings`

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -26,7 +26,6 @@ impl CommandPaletteVisibility {
             Self::NotWindows => !is_windows,
         }
     }
-
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -71,7 +70,6 @@ impl MenuVisibility {
             Self::NotWindows => !is_windows,
         }
     }
-
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -353,12 +351,7 @@ define_commands!(
             MenuActionRole::Normal
         ))
     ),
-    (
-        CloseTab,
-        TERMINAL_CONTEXT,
-        None,
-        None
-    ),
+    (CloseTab, TERMINAL_CONTEXT, None, None),
     (
         ClosePaneOrTab,
         TERMINAL_CONTEXT,
@@ -662,16 +655,6 @@ define_commands!(
             MenuVisibility::Always,
             MenuActionRole::Normal
         ))
-    ),
-    (
-        NativeSdkExample,
-        TERMINAL_CONTEXT,
-        Some(palette(
-            "Native SDK Example",
-            "native sdk modal popup confirm dialog example",
-            CommandPaletteVisibility::Always
-        )),
-        None
     ),
     (
         RestartApp,
@@ -1254,7 +1237,7 @@ mod tests {
             tmux_runtime_active: false,
             install_cli_available: true,
         };
-        let availability = CommandAction::SplitPaneVertical.availability(caps);
+        let availability = CommandAction::ResizePaneLeft.availability(caps);
         assert!(!availability.enabled);
         assert_eq!(
             availability.reason,
@@ -1286,15 +1269,6 @@ mod tests {
         actual.sort_unstable();
 
         let mut expected = vec![
-            "split_pane_vertical",
-            "split_pane_horizontal",
-            "close_pane",
-            "focus_pane_left",
-            "focus_pane_right",
-            "focus_pane_up",
-            "focus_pane_down",
-            "focus_pane_next",
-            "focus_pane_previous",
             "resize_pane_left",
             "resize_pane_right",
             "resize_pane_up",

--- a/src/keybindings/mod.rs
+++ b/src/keybindings/mod.rs
@@ -262,7 +262,11 @@ mod tests {
 
         assert_eq!(first_copy.trigger, "ctrl-shift-c");
         assert_eq!(first_paste.trigger, "secondary-v");
-        assert!(reordered.iter().any(|binding| binding.trigger == "secondary-c"));
+        assert!(
+            reordered
+                .iter()
+                .any(|binding| binding.trigger == "secondary-c")
+        );
     }
 
     #[test]
@@ -282,19 +286,25 @@ mod tests {
 
         let (tmux_resolved, tmux_warnings) = resolve_keybinds_for_config(&config, true);
         assert!(tmux_warnings.is_empty());
-        assert!(tmux_resolved
-            .iter()
-            .any(|binding| binding.action.is_tmux_only()));
+        assert!(
+            tmux_resolved
+                .iter()
+                .any(|binding| binding.action.is_tmux_only())
+        );
 
         let (native_resolved, native_warnings) = resolve_keybinds_for_config(&config, false);
         assert_eq!(native_warnings.len(), 1);
         assert_eq!(native_warnings[0].line_number, 0);
-        assert!(native_warnings[0]
-            .message
-            .contains("tmux-only keybind(s) ignored while tmux is disabled"));
-        assert!(native_resolved
-            .iter()
-            .all(|binding| !binding.action.is_tmux_only()));
+        assert!(
+            native_warnings[0]
+                .message
+                .contains("tmux-only keybind(s) ignored while tmux is disabled")
+        );
+        assert!(
+            native_resolved
+                .iter()
+                .all(|binding| !binding.action.is_tmux_only())
+        );
     }
 
     #[test]
@@ -309,7 +319,7 @@ mod tests {
     }
 
     #[test]
-    fn keybind_resolution_emits_tmux_suppression_warning_when_tmux_disabled() {
+    fn keybind_resolution_keeps_non_tmux_actions_when_tmux_disabled() {
         let mut config = AppConfig::default();
         config.keybind_lines = vec![
             KeybindConfigLine {
@@ -323,11 +333,13 @@ mod tests {
         ];
 
         let (resolved, warnings) = resolve_keybinds_for_config(&config, false);
-        assert!(resolved.is_empty());
-        assert_eq!(warnings.len(), 1);
-        assert_eq!(warnings[0].line_number, 0);
-        assert!(warnings[0]
-            .message
-            .contains("1 tmux-only keybind(s) ignored while tmux is disabled"));
+        assert!(warnings.is_empty());
+        assert_eq!(
+            resolved,
+            vec![ResolvedKeybind {
+                trigger: "secondary-d".to_string(),
+                action: CommandId::SplitPaneVertical,
+            }]
+        );
     }
 }

--- a/src/menus.rs
+++ b/src/menus.rs
@@ -1,14 +1,11 @@
 use crate::commands::{CommandAction, CommandMenuEntry, MenuRoot};
-use gpui::{Menu, MenuItem};
 #[cfg(target_os = "macos")]
 use gpui::SystemMenuType;
+use gpui::{Menu, MenuItem};
 use termy_command_core::{CommandAvailability, CommandCapabilities, CommandUnavailableReason};
 
 const INSTALL_CLI_TITLE: &str = "Install CLI";
 const INSTALL_CLI_INSTALLED_TITLE: &str = "Install CLI (Installed)";
-const SPLIT_PANE_VERTICAL_TMUX_REQUIRED_TITLE: &str = "Split Pane Vertical (tmux required)";
-const SPLIT_PANE_HORIZONTAL_TMUX_REQUIRED_TITLE: &str = "Split Pane Horizontal (tmux required)";
-const FOCUS_NEXT_PANE_TMUX_REQUIRED_TITLE: &str = "Focus Next Pane (tmux required)";
 
 pub(crate) fn app_menus(install_cli_available: bool, tmux_enabled: bool) -> Vec<Menu> {
     let capabilities = CommandCapabilities {
@@ -79,9 +76,7 @@ fn menu_item_title(
     }
 
     match availability.reason {
-        // Keep only the requested pane actions visible in native mode and label
-        // them explicitly so users understand why those rows are unavailable.
-        Some(CommandUnavailableReason::RequiresTmuxRuntime) => tmux_required_menu_title(entry.action),
+        Some(CommandUnavailableReason::RequiresTmuxRuntime) => None,
         Some(CommandUnavailableReason::InstallCliAlreadyInstalled) => {
             Some(INSTALL_CLI_INSTALLED_TITLE)
         }
@@ -89,22 +84,9 @@ fn menu_item_title(
     }
 }
 
-fn tmux_required_menu_title(action: CommandAction) -> Option<&'static str> {
-    match action {
-        CommandAction::SplitPaneVertical => Some(SPLIT_PANE_VERTICAL_TMUX_REQUIRED_TITLE),
-        CommandAction::SplitPaneHorizontal => Some(SPLIT_PANE_HORIZONTAL_TMUX_REQUIRED_TITLE),
-        CommandAction::FocusPaneNext => Some(FOCUS_NEXT_PANE_TMUX_REQUIRED_TITLE),
-        _ => None,
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{
-        FOCUS_NEXT_PANE_TMUX_REQUIRED_TITLE, INSTALL_CLI_INSTALLED_TITLE, INSTALL_CLI_TITLE,
-        SPLIT_PANE_HORIZONTAL_TMUX_REQUIRED_TITLE, SPLIT_PANE_VERTICAL_TMUX_REQUIRED_TITLE,
-        app_menus,
-    };
+    use super::{INSTALL_CLI_INSTALLED_TITLE, INSTALL_CLI_TITLE, app_menus};
     use crate::commands::CommandAction;
     use gpui::{MenuItem, OsAction};
     use termy_command_core::{CommandCapabilities, CommandUnavailableReason};
@@ -215,7 +197,10 @@ mod tests {
                 .collect::<Vec<_>>()
         };
 
-        assert_eq!(install_cli_titles(&help_menu_available), [INSTALL_CLI_TITLE]);
+        assert_eq!(
+            install_cli_titles(&help_menu_available),
+            [INSTALL_CLI_TITLE]
+        );
         assert_eq!(
             install_cli_titles(&help_menu_installed),
             [INSTALL_CLI_INSTALLED_TITLE]
@@ -232,7 +217,7 @@ mod tests {
     }
 
     #[test]
-    fn file_menu_shows_tmux_required_pane_actions_when_tmux_is_disabled() {
+    fn file_menu_keeps_native_pane_actions_when_tmux_is_disabled() {
         let caps = CommandCapabilities {
             tmux_runtime_active: false,
             install_cli_available: true,
@@ -243,10 +228,8 @@ mod tests {
             CommandAction::FocusPaneNext,
         ] {
             let availability = action.availability(caps);
-            assert_eq!(
-                availability.reason,
-                Some(CommandUnavailableReason::RequiresTmuxRuntime)
-            );
+            assert!(availability.enabled);
+            assert_eq!(availability.reason, None);
         }
         let close_pane_or_tab_availability = CommandAction::ClosePaneOrTab.availability(caps);
         assert!(close_pane_or_tab_availability.enabled);
@@ -276,9 +259,9 @@ mod tests {
                 "<separator>",
                 "Close Pane or Tab",
                 "Tmux Sessions",
-                SPLIT_PANE_VERTICAL_TMUX_REQUIRED_TITLE,
-                SPLIT_PANE_HORIZONTAL_TMUX_REQUIRED_TITLE,
-                FOCUS_NEXT_PANE_TMUX_REQUIRED_TITLE,
+                "Split Pane Vertical",
+                "Split Pane Horizontal",
+                "Focus Next Pane",
             ]
             .into_iter()
             .map(ToString::to_string)
@@ -295,7 +278,7 @@ mod tests {
     }
 
     #[test]
-    fn tmux_only_actions_outside_requested_file_set_remain_hidden_when_tmux_is_disabled() {
+    fn tmux_only_actions_remain_hidden_when_tmux_is_disabled() {
         let all_menu_titles = app_menus(true, false)
             .into_iter()
             .flat_map(|menu| menu.items)
@@ -307,16 +290,9 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
-        assert!(
-            !all_menu_titles.iter().any(|title| matches!(
-                title.as_str(),
-                "Split Pane Vertical"
-                    | "Split Pane Horizontal"
-                    | "Close Pane"
-                    | "Focus Next Pane"
-                    | "Focus Previous Pane"
-                    | "Toggle Pane Zoom"
-            ))
-        );
+        assert!(!all_menu_titles.iter().any(|title| matches!(
+            title.as_str(),
+            "Close Pane" | "Focus Previous Pane" | "Toggle Pane Zoom"
+        )));
     }
 }

--- a/src/terminal_view/command_palette/mod.rs
+++ b/src/terminal_view/command_palette/mod.rs
@@ -615,7 +615,6 @@ impl TerminalView {
             | CommandAction::SwitchTheme
             | CommandAction::ManageTmuxSessions
             | CommandAction::AppInfo
-            | CommandAction::NativeSdkExample
             | CommandAction::RestartApp
             | CommandAction::RenameTab
             | CommandAction::MoveTabLeft
@@ -777,24 +776,22 @@ mod tests {
     }
 
     #[test]
-    fn tmux_commands_are_present_but_disabled_when_tmux_runtime_is_off() {
+    fn tmux_only_commands_are_present_but_disabled_when_tmux_runtime_is_off() {
         let items = TerminalView::command_palette_command_items_for_state(false, false);
-        let split = items
-            .iter()
-            .find_map(|item| match item.kind {
-                CommandPaletteItemKind::Command(CommandAction::SplitPaneVertical) => Some(item),
-                _ => None,
-            });
+        let resize = items.iter().find_map(|item| match item.kind {
+            CommandPaletteItemKind::Command(CommandAction::ResizePaneLeft) => Some(item),
+            _ => None,
+        });
         #[cfg(not(target_os = "windows"))]
         {
-            let split = split.expect("missing split pane command");
-            assert!(!split.enabled);
-            assert_eq!(split.status_hint, Some("tmux required"));
+            let resize = resize.expect("missing resize pane command");
+            assert!(!resize.enabled);
+            assert_eq!(resize.status_hint, Some("tmux required"));
         }
         #[cfg(target_os = "windows")]
         assert!(
-            split.is_none(),
-            "split pane command should be hidden from Windows command palette"
+            resize.is_none(),
+            "resize pane command should be hidden from Windows command palette"
         );
     }
 
@@ -814,7 +811,7 @@ mod tests {
     fn tmux_disabled_message_matches_expected_copy() {
         assert_eq!(
             TerminalView::command_palette_disabled_action_message_for_state(
-                CommandAction::SplitPaneVertical,
+                CommandAction::ResizePaneLeft,
                 true,
                 false,
             ),

--- a/src/terminal_view/interaction/actions.rs
+++ b/src/terminal_view/interaction/actions.rs
@@ -76,8 +76,9 @@ impl TerminalView {
                     self.open_command_palette_in_mode(mode, cx);
                 }
             }
-            CommandAction::ManageTmuxSessions => self
-                .open_tmux_session_palette_with_intent(TmuxSessionIntent::AttachOrSwitch, cx),
+            CommandAction::ManageTmuxSessions => {
+                self.open_tmux_session_palette_with_intent(TmuxSessionIntent::AttachOrSwitch, cx)
+            }
             CommandAction::Quit => {
                 self.execute_quit_command_action(action, window, cx);
             }
@@ -85,7 +86,6 @@ impl TerminalView {
             CommandAction::OpenConfig
             | CommandAction::ImportColors
             | CommandAction::AppInfo
-            | CommandAction::NativeSdkExample
             | CommandAction::OpenSettings
             | CommandAction::CheckForUpdates => {
                 self.execute_app_system_command_action(action, cx);
@@ -181,15 +181,6 @@ impl TerminalView {
         cx: &mut Context<Self>,
     ) {
         self.execute_command_action(CommandAction::AppInfo, true, window, cx);
-    }
-
-    pub(in super::super) fn handle_native_sdk_example_action(
-        &mut self,
-        _: &commands::NativeSdkExample,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
-        self.execute_command_action(CommandAction::NativeSdkExample, true, window, cx);
     }
 
     pub(in super::super) fn handle_restart_app_action(

--- a/src/terminal_view/interaction/app.rs
+++ b/src/terminal_view/interaction/app.rs
@@ -19,10 +19,6 @@ impl TerminalView {
                 self.app_info_action(cx);
                 true
             }
-            CommandAction::NativeSdkExample => {
-                self.native_sdk_example_action(cx);
-                true
-            }
             CommandAction::OpenSettings => {
                 self.open_settings_action(cx);
                 true
@@ -91,31 +87,6 @@ impl TerminalView {
         );
         termy_toast::info(message);
         cx.notify();
-    }
-
-    fn native_sdk_example_action(&mut self, cx: &mut Context<Self>) {
-        cx.spawn(async move |this, cx: &mut AsyncApp| {
-            termy_native_sdk::show_alert(
-                "Update Available",
-                "A new Termy update is available and ready to install.",
-            );
-            let confirmed = termy_native_sdk::confirm(
-                "Install Update",
-                "Would you like to install the latest update now?",
-            );
-
-            let _ = cx.update(|cx| {
-                this.update(cx, |_view, cx| {
-                    if confirmed {
-                        termy_toast::success("Update install confirmed");
-                    } else {
-                        termy_toast::info("Update installation postponed");
-                    }
-                    cx.notify();
-                })
-            });
-        })
-        .detach();
     }
 
     fn open_settings_action(&mut self, cx: &mut Context<Self>) {

--- a/src/terminal_view/interaction/layout.rs
+++ b/src/terminal_view/interaction/layout.rs
@@ -1,6 +1,91 @@
 use super::*;
 
 impl TerminalView {
+    fn scale_native_pane_edge(edge: u16, old_extent: u16, new_extent: u16) -> u16 {
+        if old_extent <= 1 || new_extent == 0 {
+            return 0;
+        }
+        if edge == 0 {
+            return 0;
+        }
+        if edge >= old_extent {
+            return new_extent;
+        }
+
+        let numerator = u32::from(edge) * u32::from(new_extent) + (u32::from(old_extent) / 2);
+        let scaled = numerator / u32::from(old_extent);
+        scaled.min(u32::from(new_extent)) as u16
+    }
+
+    fn sync_native_tab_pane_geometry(tab: &mut TerminalTab, cols: u16, rows: u16) {
+        if tab.panes.is_empty() {
+            return;
+        }
+
+        let cols = cols.max(1);
+        let rows = rows.max(1);
+
+        if tab.panes.len() == 1 {
+            if let Some(only) = tab.panes.first_mut() {
+                only.left = 0;
+                only.top = 0;
+                only.width = cols;
+                only.height = rows;
+                tab.active_pane_id = only.id.clone();
+            }
+            return;
+        }
+
+        let old_cols = tab
+            .panes
+            .iter()
+            .map(|pane| pane.left.saturating_add(pane.width))
+            .max()
+            .unwrap_or(cols)
+            .max(1);
+        let old_rows = tab
+            .panes
+            .iter()
+            .map(|pane| pane.top.saturating_add(pane.height))
+            .max()
+            .unwrap_or(rows)
+            .max(1);
+
+        for pane in &mut tab.panes {
+            let old_left = pane.left;
+            let old_top = pane.top;
+            let old_right = pane.left.saturating_add(pane.width);
+            let old_bottom = pane.top.saturating_add(pane.height);
+
+            let mut new_left =
+                Self::scale_native_pane_edge(old_left, old_cols, cols).min(cols.saturating_sub(1));
+            let mut new_top =
+                Self::scale_native_pane_edge(old_top, old_rows, rows).min(rows.saturating_sub(1));
+            let mut new_right = Self::scale_native_pane_edge(old_right, old_cols, cols).min(cols);
+            let mut new_bottom = Self::scale_native_pane_edge(old_bottom, old_rows, rows).min(rows);
+
+            if new_right <= new_left {
+                new_right = (new_left + 1).min(cols);
+                new_left = new_right.saturating_sub(1);
+            }
+            if new_bottom <= new_top {
+                new_bottom = (new_top + 1).min(rows);
+                new_top = new_bottom.saturating_sub(1);
+            }
+
+            pane.left = new_left;
+            pane.top = new_top;
+            pane.width = new_right.saturating_sub(new_left).max(1);
+            pane.height = new_bottom.saturating_sub(new_top).max(1);
+        }
+
+        if !tab.panes.iter().any(|pane| pane.id == tab.active_pane_id)
+            && let Some(pane) = tab.panes.first()
+        {
+            tab.active_pane_id = pane.id.clone();
+        }
+    }
+
     fn should_emit_tmux_resize_error_toast(&mut self, now: Instant) -> bool {
         let debounce_window = Duration::from_millis(TMUX_RESIZE_ERROR_TOAST_DEBOUNCE_MS);
         match self.last_tmux_resize_error_at {
@@ -20,10 +105,16 @@ impl TerminalView {
         let y: f32 = position.y.into();
         // Mouse coordinates arrive in window space; subtract chrome so terminal hit-testing
         // stays aligned with rendered rows in both native and tmux runtimes.
-        (x, Self::window_y_to_terminal_content_y(y, self.chrome_height()))
+        (
+            x,
+            Self::window_y_to_terminal_content_y(y, self.chrome_height()),
+        )
     }
 
-    pub(in super::super) fn window_y_to_terminal_content_y(window_y: f32, chrome_height: f32) -> f32 {
+    pub(in super::super) fn window_y_to_terminal_content_y(
+        window_y: f32,
+        chrome_height: f32,
+    ) -> f32 {
         window_y - chrome_height
     }
 
@@ -65,7 +156,11 @@ impl TerminalView {
         cx.notify();
     }
 
-    pub(in super::super) fn calculate_cell_size(&mut self, window: &mut Window, _cx: &App) -> Size<Pixels> {
+    pub(in super::super) fn calculate_cell_size(
+        &mut self,
+        window: &mut Window,
+        _cx: &App,
+    ) -> Size<Pixels> {
         if let Some(cell_size) = self.cell_size {
             return cell_size;
         }
@@ -94,7 +189,11 @@ impl TerminalView {
         cell_size
     }
 
-    pub(in super::super) fn sync_terminal_size(&mut self, window: &Window, cell_size: Size<Pixels>) {
+    pub(in super::super) fn sync_terminal_size(
+        &mut self,
+        window: &Window,
+        cell_size: Size<Pixels>,
+    ) {
         let (padding_x, padding_y) = self.effective_terminal_padding();
         let viewport = window.viewport_size();
         let viewport_width: f32 = viewport.width.into();
@@ -142,17 +241,7 @@ impl TerminalView {
             }
             RuntimeKind::Native => {
                 for tab in &mut self.tabs {
-                    for pane in &mut tab.panes {
-                        pane.left = 0;
-                        pane.top = 0;
-                        pane.width = cols.max(1);
-                        pane.height = rows.max(1);
-                    }
-                    if !tab.panes.iter().any(|pane| pane.id == tab.active_pane_id)
-                        && let Some(pane) = tab.panes.first()
-                    {
-                        tab.active_pane_id = pane.id.clone();
-                    }
+                    Self::sync_native_tab_pane_geometry(tab, cols, rows);
                 }
             }
         }
@@ -204,16 +293,25 @@ mod tests {
 
     #[test]
     fn window_y_to_terminal_content_y_subtracts_non_zero_chrome() {
-        assert_eq!(TerminalView::window_y_to_terminal_content_y(120.0, 34.0), 86.0);
+        assert_eq!(
+            TerminalView::window_y_to_terminal_content_y(120.0, 34.0),
+            86.0
+        );
     }
 
     #[test]
     fn window_y_to_terminal_content_y_is_identity_when_chrome_is_zero() {
-        assert_eq!(TerminalView::window_y_to_terminal_content_y(120.0, 0.0), 120.0);
+        assert_eq!(
+            TerminalView::window_y_to_terminal_content_y(120.0, 0.0),
+            120.0
+        );
     }
 
     #[test]
     fn window_y_to_terminal_content_y_can_be_negative_when_cursor_is_above_chrome() {
-        assert_eq!(TerminalView::window_y_to_terminal_content_y(20.0, 40.0), -20.0);
+        assert_eq!(
+            TerminalView::window_y_to_terminal_content_y(20.0, 40.0),
+            -20.0
+        );
     }
 }

--- a/src/terminal_view/mod.rs
+++ b/src/terminal_view/mod.rs
@@ -1,8 +1,8 @@
 use crate::colors::TerminalColors;
 use crate::commands::{self, CommandAction};
 use crate::config::{
-    self, AppConfig, CursorStyle as AppCursorStyle, TabCloseVisibility, TabTitleConfig,
-    PaneFocusEffect, TabTitleSource, TabWidthMode, TerminalScrollbarStyle,
+    self, AppConfig, CursorStyle as AppCursorStyle, PaneFocusEffect, TabCloseVisibility,
+    TabTitleConfig, TabTitleSource, TabWidthMode, TerminalScrollbarStyle,
     TerminalScrollbarVisibility,
 };
 use crate::keybindings;
@@ -1031,8 +1031,10 @@ impl TerminalView {
             .unwrap_or(DEFAULT_TAB_TITLE)
             .to_string();
         let title_text_width = 0.0;
-        let sticky_title_width =
-            Self::tab_display_width_for_text_px_without_close_with_max(title_text_width, TAB_MAX_WIDTH);
+        let sticky_title_width = Self::tab_display_width_for_text_px_without_close_with_max(
+            title_text_width,
+            TAB_MAX_WIDTH,
+        );
         let display_width =
             Self::tab_display_width_for_text_px_with_max(title_text_width, TAB_MAX_WIDTH);
         let pane_id = format!("%native-{tab_id}");
@@ -1081,7 +1083,9 @@ impl TerminalView {
     }
 
     fn active_pane_id(&self) -> Option<&str> {
-        self.tabs.get(self.active_tab).and_then(|tab| tab.active_pane_id())
+        self.tabs
+            .get(self.active_tab)
+            .and_then(|tab| tab.active_pane_id())
     }
 
     fn active_tab_ref(&self) -> Option<&TerminalTab> {
@@ -1179,8 +1183,9 @@ impl TerminalView {
             self.pane_focus_transition = None;
             return None;
         }
-        let progress =
-            pane_focus_ease_out(elapsed.as_secs_f32() / PANE_FOCUS_ANIMATION_DURATION.as_secs_f32());
+        let progress = pane_focus_ease_out(
+            elapsed.as_secs_f32() / PANE_FOCUS_ANIMATION_DURATION.as_secs_f32(),
+        );
         Some((
             transition.from_pane_id.clone(),
             transition.to_pane_id.clone(),
@@ -1722,7 +1727,10 @@ impl TerminalView {
         self.configured_working_dir = config.working_dir.clone();
         self.terminal_runtime = Self::runtime_config_from_app_config(&config);
         let reconnect_managed_tmux = self.runtime_uses_tmux()
-            && matches!(self.tmux_runtime().config.launch, TmuxLaunchTarget::Managed { .. });
+            && matches!(
+                self.tmux_runtime().config.launch,
+                TmuxLaunchTarget::Managed { .. }
+            );
         if reconnect_managed_tmux {
             self.reconnect_tmux_runtime(Self::tmux_runtime_from_app_config(&config));
         } else if self.runtime_uses_tmux() {
@@ -1907,30 +1915,36 @@ impl TerminalView {
         let active_tab = self.active_tab;
 
         for index in 0..self.tabs.len() {
-            let Some(terminal) = self.tabs[index].active_terminal() else {
-                continue;
-            };
-            let events = terminal.process_events();
-            for event in events {
-                match event {
-                    TerminalEvent::Wakeup | TerminalEvent::Bell | TerminalEvent::Exit => {
-                        if index == active_tab {
-                            should_redraw = true;
+            let active_pane_id = self.tabs[index].active_pane_id.clone();
+
+            for pane_index in 0..self.tabs[index].panes.len() {
+                let pane_id = self.tabs[index].panes[pane_index].id.clone();
+                let pane_is_active = pane_id == active_pane_id;
+                let events = self.tabs[index].panes[pane_index].terminal.process_events();
+
+                for event in events {
+                    match event {
+                        TerminalEvent::Wakeup | TerminalEvent::Bell | TerminalEvent::Exit => {
+                            if index == active_tab {
+                                should_redraw = true;
+                            }
                         }
-                    }
-                    TerminalEvent::Title(title) => {
-                        if self.apply_terminal_title(index, &title, cx) {
-                            should_redraw = true;
+                        TerminalEvent::Title(title) => {
+                            if pane_is_active && self.apply_terminal_title(index, &title, cx) {
+                                should_redraw = true;
+                            }
                         }
-                    }
-                    TerminalEvent::ResetTitle => {
-                        if self.clear_terminal_titles(index) {
-                            should_redraw = true;
+                        TerminalEvent::ResetTitle => {
+                            if pane_is_active && self.clear_terminal_titles(index) {
+                                should_redraw = true;
+                            }
                         }
-                    }
-                    TerminalEvent::ClipboardStore(text) => {
-                        self.pending_clipboard = Some(text);
-                        should_redraw = true;
+                        TerminalEvent::ClipboardStore(text) => {
+                            if index == active_tab && pane_is_active {
+                                self.pending_clipboard = Some(text);
+                                should_redraw = true;
+                            }
+                        }
                     }
                 }
             }
@@ -2088,12 +2102,10 @@ mod tests {
         let high_strength = pane_focus_strength_factor(0.8);
 
         assert!(
-            (preset.inactive_fg_blend * high_strength)
-                > (preset.inactive_fg_blend * low_strength)
+            (preset.inactive_fg_blend * high_strength) > (preset.inactive_fg_blend * low_strength)
         );
         assert!(
-            (preset.inactive_bg_blend * high_strength)
-                > (preset.inactive_bg_blend * low_strength)
+            (preset.inactive_bg_blend * high_strength) > (preset.inactive_bg_blend * low_strength)
         );
         assert!(
             (preset.active_border_alpha * high_strength)

--- a/src/terminal_view/render.rs
+++ b/src/terminal_view/render.rs
@@ -1,8 +1,8 @@
 use super::scrollbar as terminal_scrollbar;
 use super::*;
+use crate::ui::scrollbar::{self as ui_scrollbar, ScrollbarPaintStyle};
 use alacritty_terminal::grid::Dimensions;
 use alacritty_terminal::index::{Column, Line};
-use crate::ui::scrollbar::{self as ui_scrollbar, ScrollbarPaintStyle};
 use gpui::prelude::FluentBuilder;
 use std::sync::Arc;
 
@@ -72,7 +72,9 @@ fn pane_cache_update_strategy(
     }
     match damage {
         TerminalDamageSnapshot::Full => PaneCacheUpdateStrategy::Full,
-        TerminalDamageSnapshot::Partial(spans) if spans.is_empty() => PaneCacheUpdateStrategy::Reuse,
+        TerminalDamageSnapshot::Partial(spans) if spans.is_empty() => {
+            PaneCacheUpdateStrategy::Reuse
+        }
         TerminalDamageSnapshot::Partial(_) => PaneCacheUpdateStrategy::Partial,
     }
 }
@@ -190,11 +192,13 @@ fn effective_pane_focus_active_border_alpha(
     runtime_uses_tmux: bool,
     tmux_show_active_pane_border: bool,
 ) -> f32 {
-    if runtime_uses_tmux && !tmux_show_active_pane_border {
-        0.0
-    } else {
-        active_border_alpha
+    if !runtime_uses_tmux {
+        return 0.0;
     }
+    if !tmux_show_active_pane_border {
+        return 0.0;
+    }
+    active_border_alpha
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -205,7 +209,9 @@ struct TerminalScrollbarOverlayFrame {
     height: f32,
 }
 
-fn terminal_scrollbar_overlay_frame(surface: TerminalViewportGeometry) -> TerminalScrollbarOverlayFrame {
+fn terminal_scrollbar_overlay_frame(
+    surface: TerminalViewportGeometry,
+) -> TerminalScrollbarOverlayFrame {
     let surface_width = surface.width.max(0.0);
     let effective_gutter = TERMINAL_SCROLLBAR_GUTTER_WIDTH.min(surface_width);
     let left = (surface.origin_x + surface_width - effective_gutter).max(surface.origin_x);
@@ -297,7 +303,10 @@ impl TerminalView {
     ) -> TerminalPaneRenderCacheKey {
         let (search_results_revision, search_position) = if search_active && is_active_pane {
             let results = self.search_state.results();
-            (Some(self.search_state.results_revision()), results.position())
+            (
+                Some(self.search_state.results_revision()),
+                results.position(),
+            )
         } else {
             (None, None)
         };
@@ -382,9 +391,8 @@ impl TerminalView {
             return Arc::new((0..rows).map(|_| Arc::new(Vec::new())).collect());
         }
 
-        let mut row_cells: Vec<Vec<CellRenderInfo>> = (0..rows)
-            .map(|_| Vec::with_capacity(cols))
-            .collect();
+        let mut row_cells: Vec<Vec<CellRenderInfo>> =
+            (0..rows).map(|_| Vec::with_capacity(cols)).collect();
         let mut expected_row = 0usize;
         let mut expected_col = 0usize;
         let mut ordering_failed = false;
@@ -398,7 +406,8 @@ impl TerminalView {
                     ordering_failed = true;
                     return;
                 }
-                let Some(row) = Self::viewport_row_from_term_line(term_line, cell_display_offset) else {
+                let Some(row) = Self::viewport_row_from_term_line(term_line, cell_display_offset)
+                else {
                     ordering_failed = true;
                     return;
                 };
@@ -407,8 +416,13 @@ impl TerminalView {
                     return;
                 }
 
-                row_cells[row]
-                    .push(self.build_cell_render_info(col, row, term_line, cell_content, context));
+                row_cells[row].push(self.build_cell_render_info(
+                    col,
+                    row,
+                    term_line,
+                    cell_content,
+                    context,
+                ));
 
                 expected_col += 1;
                 if expected_col == cols {
@@ -470,7 +484,8 @@ impl TerminalView {
                 if cell_display_offset != display_offset || col >= cols {
                     return;
                 }
-                let Some(row) = Self::viewport_row_from_term_line(term_line, cell_display_offset) else {
+                let Some(row) = Self::viewport_row_from_term_line(term_line, cell_display_offset)
+                else {
                     return;
                 };
                 if row >= rows {
@@ -571,7 +586,8 @@ impl TerminalView {
         match strategy {
             PaneCacheUpdateStrategy::Reuse => {}
             PaneCacheUpdateStrategy::Full => {
-                cache.cells = self.rebuild_pane_render_cache(terminal, cols, rows, display_offset, context);
+                cache.cells =
+                    self.rebuild_pane_render_cache(terminal, cols, rows, display_offset, context);
             }
             PaneCacheUpdateStrategy::Partial => {
                 let TerminalDamageSnapshot::Partial(spans) = damage else {
@@ -1148,7 +1164,8 @@ impl Render for TerminalView {
                 }
                 let is_active_pane = active_pane_id.as_deref() == Some(pane.id.as_str());
                 let (pane_inactive_focus, pane_active_focus) = if pane_focus_enabled {
-                    if let Some((from_pane_id, to_pane_id, progress)) = pane_focus_transition.as_ref()
+                    if let Some((from_pane_id, to_pane_id, progress)) =
+                        pane_focus_transition.as_ref()
                     {
                         if pane.id == *from_pane_id {
                             (*progress, 1.0 - *progress)
@@ -1167,19 +1184,19 @@ impl Render for TerminalView {
                 };
                 let (pane_focus_transform, raw_pane_active_border_alpha) =
                     if let Some((preset, strength)) = pane_focus_config {
-                    let inactive_scale = strength * pane_inactive_focus;
-                    let active_scale = strength * pane_active_focus;
-                    (
-                        CellColorTransform {
-                            fg_blend: preset.inactive_fg_blend * inactive_scale,
-                            bg_blend: preset.inactive_bg_blend * inactive_scale,
-                            desaturate: preset.inactive_desaturate * inactive_scale,
-                        },
-                        preset.active_border_alpha * active_scale,
-                    )
-                } else {
-                    (CellColorTransform::default(), 0.0)
-                };
+                        let inactive_scale = strength * pane_inactive_focus;
+                        let active_scale = strength * pane_active_focus;
+                        (
+                            CellColorTransform {
+                                fg_blend: preset.inactive_fg_blend * inactive_scale,
+                                bg_blend: preset.inactive_bg_blend * inactive_scale,
+                                desaturate: preset.inactive_desaturate * inactive_scale,
+                            },
+                            preset.active_border_alpha * active_scale,
+                        )
+                    } else {
+                        (CellColorTransform::default(), 0.0)
+                    };
                 // Palette backdrop uses the same inactive-pane transform path to keep one
                 // consistent dimming model and avoid a separate full-screen color overlay.
                 let cell_color_transform =
@@ -1270,11 +1287,13 @@ impl Render for TerminalView {
 
                 // Keep divider-boundary comparisons in the same geometry space as the
                 // pane pixels computed above to avoid drift from mixed sources.
-                let pane_right_cells =
-                    ((pane_left + pane_width - effective_padding_x) / cell_width).round().max(0.0) as u32;
-                let pane_bottom_cells =
-                    ((pane_top + pane_height - effective_padding_y) / cell_height).round().max(0.0)
-                        as u32;
+                let pane_right_cells = ((pane_left + pane_width - effective_padding_x) / cell_width)
+                    .round()
+                    .max(0.0) as u32;
+                let pane_bottom_cells = ((pane_top + pane_height - effective_padding_y)
+                    / cell_height)
+                    .round()
+                    .max(0.0) as u32;
 
                 if multi_pane && pane_right_cells < max_right_cells {
                     if let Some(gap_cells) = Self::pane_right_gap_cells(pane, &active_tab.panes) {
@@ -1321,7 +1340,7 @@ impl Render for TerminalView {
                         .into_any_element(),
                 );
 
-                if pane_active_border_alpha > f32::EPSILON {
+                if multi_pane && pane_active_border_alpha > f32::EPSILON {
                     let mut accent = blend_rgb_only(colors.cursor, colors.foreground, 0.18);
                     accent.a = self.scaled_chrome_alpha(pane_active_border_alpha);
                     let accent_hsla: gpui::Hsla = accent.into();
@@ -1350,7 +1369,10 @@ impl Render for TerminalView {
                     };
                     pane_focus_accents.push(
                         div()
-                            .id(SharedString::from(format!("pane-degraded-accent-{}", pane.id)))
+                            .id(SharedString::from(format!(
+                                "pane-degraded-accent-{}",
+                                pane.id
+                            )))
                             .absolute()
                             .left(px(pane_left))
                             .top(px(pane_top))
@@ -1728,7 +1750,6 @@ impl Render for TerminalView {
                     .on_action(cx.listener(Self::handle_import_colors_action))
                     .on_action(cx.listener(Self::handle_switch_theme_action))
                     .on_action(cx.listener(Self::handle_app_info_action))
-                    .on_action(cx.listener(Self::handle_native_sdk_example_action))
                     .on_action(cx.listener(Self::handle_restart_app_action))
                     .on_action(cx.listener(Self::handle_rename_tab_action))
                     .on_action(cx.listener(Self::handle_check_for_updates_action))
@@ -1740,19 +1761,18 @@ impl Render for TerminalView {
                     .on_action(cx.listener(Self::handle_switch_tab_left_action))
                     .on_action(cx.listener(Self::handle_switch_tab_right_action))
                     .on_action(cx.listener(Self::handle_manage_tmux_sessions_action))
-                    // GPUI grays out unavailable menu actions, so we only register
-                    // File menu pane handlers when the tmux runtime is active.
+                    .on_action(cx.listener(Self::handle_split_pane_vertical_action))
+                    .on_action(cx.listener(Self::handle_split_pane_horizontal_action))
+                    .on_action(cx.listener(Self::handle_close_pane_action))
+                    .on_action(cx.listener(Self::handle_focus_pane_next_action))
+                    .on_action(cx.listener(Self::handle_focus_pane_left_action))
+                    .on_action(cx.listener(Self::handle_focus_pane_right_action))
+                    .on_action(cx.listener(Self::handle_focus_pane_up_action))
+                    .on_action(cx.listener(Self::handle_focus_pane_down_action))
+                    .on_action(cx.listener(Self::handle_focus_pane_previous_action))
+                    // Resize/zoom remain tmux-only actions.
                     .when(self.runtime_uses_tmux(), |s| {
-                        s.on_action(cx.listener(Self::handle_split_pane_vertical_action))
-                            .on_action(cx.listener(Self::handle_split_pane_horizontal_action))
-                            .on_action(cx.listener(Self::handle_close_pane_action))
-                            .on_action(cx.listener(Self::handle_focus_pane_next_action))
-                            .on_action(cx.listener(Self::handle_focus_pane_left_action))
-                            .on_action(cx.listener(Self::handle_focus_pane_right_action))
-                            .on_action(cx.listener(Self::handle_focus_pane_up_action))
-                            .on_action(cx.listener(Self::handle_focus_pane_down_action))
-                            .on_action(cx.listener(Self::handle_focus_pane_previous_action))
-                            .on_action(cx.listener(Self::handle_resize_pane_left_action))
+                        s.on_action(cx.listener(Self::handle_resize_pane_left_action))
                             .on_action(cx.listener(Self::handle_resize_pane_right_action))
                             .on_action(cx.listener(Self::handle_resize_pane_up_action))
                             .on_action(cx.listener(Self::handle_resize_pane_down_action))
@@ -1964,13 +1984,8 @@ mod tests {
             a: 1.0,
         };
 
-        let (next_fg, next_bg) = apply_cell_color_transform(
-            fg,
-            bg,
-            CellColorTransform::default(),
-            fg_target,
-            bg_target,
-        );
+        let (next_fg, next_bg) =
+            apply_cell_color_transform(fg, bg, CellColorTransform::default(), fg_target, bg_target);
 
         assert_eq!(next_fg, fg);
         assert_eq!(next_bg, bg);
@@ -2005,7 +2020,10 @@ mod tests {
         let base = tmux_test_pane("%1", 0, 0, 10, 6);
         let adjacent = tmux_test_pane("%2", 10, 2, 5, 2);
         let panes = vec![base, adjacent];
-        assert_eq!(TerminalView::pane_right_gap_cells(&panes[0], &panes), Some(0));
+        assert_eq!(
+            TerminalView::pane_right_gap_cells(&panes[0], &panes),
+            Some(0)
+        );
     }
 
     #[test]
@@ -2023,7 +2041,10 @@ mod tests {
         let near = tmux_test_pane("%3", 12, 1, 3, 2);
         let non_overlap = tmux_test_pane("%4", 11, 7, 3, 2);
         let panes = vec![base, far, near, non_overlap];
-        assert_eq!(TerminalView::pane_right_gap_cells(&panes[0], &panes), Some(2));
+        assert_eq!(
+            TerminalView::pane_right_gap_cells(&panes[0], &panes),
+            Some(2)
+        );
     }
 
     #[test]
@@ -2031,7 +2052,10 @@ mod tests {
         let base = tmux_test_pane("%1", 0, 0, 10, 6);
         let adjacent = tmux_test_pane("%2", 2, 6, 3, 3);
         let panes = vec![base, adjacent];
-        assert_eq!(TerminalView::pane_bottom_gap_cells(&panes[0], &panes), Some(0));
+        assert_eq!(
+            TerminalView::pane_bottom_gap_cells(&panes[0], &panes),
+            Some(0)
+        );
     }
 
     #[test]
@@ -2049,7 +2073,10 @@ mod tests {
         let near = tmux_test_pane("%3", 3, 8, 2, 2);
         let non_overlap = tmux_test_pane("%4", 11, 9, 2, 2);
         let panes = vec![base, far, near, non_overlap];
-        assert_eq!(TerminalView::pane_bottom_gap_cells(&panes[0], &panes), Some(2));
+        assert_eq!(
+            TerminalView::pane_bottom_gap_cells(&panes[0], &panes),
+            Some(2)
+        );
     }
 
     #[test]

--- a/src/terminal_view/tab_strip/constants.rs
+++ b/src/terminal_view/tab_strip/constants.rs
@@ -5,10 +5,6 @@ pub(crate) const TOP_STRIP_MACOS_TRAFFIC_LIGHT_PADDING: f32 = 78.0;
 #[cfg(not(macos_sdk_26))]
 pub(crate) const TOP_STRIP_MACOS_TRAFFIC_LIGHT_PADDING: f32 = 71.0;
 pub(crate) const TOP_STRIP_CONTENT_OFFSET_Y: f32 = 0.0;
-pub(crate) const TOP_STRIP_TERMY_BRANDING_TEXT: &str = "termy";
-pub(crate) const TOP_STRIP_TERMY_BRANDING_FONT_SIZE: f32 = 12.0;
-pub(crate) const TOP_STRIP_TERMY_BRANDING_SIDE_PADDING: f32 = 10.0;
-pub(crate) const TOP_STRIP_TERMY_BRANDING_TAB_GAP: f32 = 8.0;
 pub(crate) const TAB_HORIZONTAL_PADDING: f32 = 0.0;
 pub(crate) const TAB_ITEM_HEIGHT: f32 = 32.0;
 pub(crate) const TAB_ITEM_GAP: f32 = 0.0;

--- a/src/terminal_view/tab_strip/render.rs
+++ b/src/terminal_view/tab_strip/render.rs
@@ -311,30 +311,6 @@ impl TerminalView {
         widths
     }
 
-    fn termy_branding_reserved_width(
-        &mut self,
-        window: &Window,
-        font_family: &SharedString,
-        font_family_key: &str,
-    ) -> f32 {
-        if !cfg!(target_os = "macos") || !self.show_termy_in_titlebar {
-            return 0.0;
-        }
-
-        let text_width = self.measure_text_width(
-            window,
-            font_family,
-            font_family_key,
-            TOP_STRIP_TERMY_BRANDING_TEXT,
-            TOP_STRIP_TERMY_BRANDING_FONT_SIZE,
-        );
-        if text_width <= f32::EPSILON {
-            return 0.0;
-        }
-
-        text_width + (TOP_STRIP_TERMY_BRANDING_SIDE_PADDING * 2.0)
-    }
-
     fn resolve_tab_strip_palette(
         &self,
         colors: &TerminalColors,
@@ -477,12 +453,8 @@ impl TerminalView {
         width: f32,
         tab_baseline_y: f32,
         tab_stroke_color: gpui::Rgba,
-        font_family: &SharedString,
-        termy_branding_slot_start_x: f32,
-        termy_branding_slot_width: f32,
-        termy_branding_text_color: gpui::Rgba,
     ) -> AnyElement {
-        let lane = div()
+        div()
             .id("tabbar-left-inset")
             .relative()
             .flex_none()
@@ -496,33 +468,8 @@ impl TerminalView {
                     .top(px(tab_baseline_y))
                     .h(px(TAB_STROKE_THICKNESS))
                     .bg(tab_stroke_color),
-            );
-
-        if termy_branding_slot_width <= f32::EPSILON {
-            return lane.into_any_element();
-        }
-
-        lane.child(
-            div()
-                .id("tabbar-termy-branding")
-                .absolute()
-                .left(px(termy_branding_slot_start_x.max(0.0)))
-                .top_0()
-                .bottom_0()
-                .w(px(termy_branding_slot_width.max(0.0)))
-                .overflow_hidden()
-                .flex()
-                .items_center()
-                .justify_center()
-                .child(
-                    div()
-                        .font_family(font_family.clone())
-                        .text_size(px(TOP_STRIP_TERMY_BRANDING_FONT_SIZE))
-                        .text_color(termy_branding_text_color)
-                        .child(TOP_STRIP_TERMY_BRANDING_TEXT),
-                ),
-        )
-        .into_any_element()
+            )
+            .into_any_element()
     }
 
     fn render_gutter_lane(
@@ -991,26 +938,8 @@ impl TerminalView {
         self.sync_tab_title_text_widths(&measured_title_widths);
 
         let base_left_inset_width = Self::titlebar_left_padding_for_platform();
-        let termy_branding_reserved_width =
-            self.termy_branding_reserved_width(window, font_family, font_family_key.as_str());
-        let termy_branding_tab_gap = if termy_branding_reserved_width > f32::EPSILON {
-            TOP_STRIP_TERMY_BRANDING_TAB_GAP
-        } else {
-            0.0
-        };
-        let state = self.build_tab_strip_render_state(
-            window,
-            base_left_inset_width + termy_branding_reserved_width + termy_branding_tab_gap,
-        );
+        let state = self.build_tab_strip_render_state(window, base_left_inset_width);
         let palette = self.resolve_tab_strip_palette(colors, tabbar_bg);
-        let termy_branding_slot_start_x =
-            base_left_inset_width.min(state.geometry.left_inset_width);
-        let termy_branding_slot_width = (state.geometry.left_inset_width
-            - termy_branding_slot_start_x)
-            .max(0.0)
-            .min(termy_branding_reserved_width.max(0.0));
-        let mut termy_branding_text_color = palette.inactive_tab_text;
-        termy_branding_text_color.a = termy_branding_text_color.a.max(0.82);
         let tabs_scroll_content = self.build_tabs_scroll_content(
             window,
             &state,
@@ -1041,10 +970,6 @@ impl TerminalView {
                     state.geometry.left_inset_width,
                     state.chrome_layout.baseline_y,
                     palette.tab_stroke_color,
-                    font_family,
-                    termy_branding_slot_start_x,
-                    termy_branding_slot_width,
-                    termy_branding_text_color,
                 )
             }))
             .child(

--- a/src/terminal_view/tabs/lifecycle.rs
+++ b/src/terminal_view/tabs/lifecycle.rs
@@ -1,9 +1,24 @@
 use super::*;
+use std::cmp::Reverse;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ClosePaneOrTabTarget {
     ClosePane,
     CloseTab,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum NativeSplitAxis {
+    Vertical,
+    Horizontal,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum NativeFocusDirection {
+    Left,
+    Right,
+    Up,
+    Down,
 }
 
 impl TerminalView {
@@ -62,19 +77,18 @@ impl TerminalView {
         }
     }
 
-    fn close_pane_or_tab_target(runtime_kind: RuntimeKind, pane_count: usize) -> ClosePaneOrTabTarget {
-        if runtime_kind.uses_tmux() && pane_count > 1 {
+    fn close_pane_or_tab_target(
+        _runtime_kind: RuntimeKind,
+        pane_count: usize,
+    ) -> ClosePaneOrTabTarget {
+        if pane_count > 1 {
             ClosePaneOrTabTarget::ClosePane
         } else {
             ClosePaneOrTabTarget::CloseTab
         }
     }
 
-    fn adjacent_tab_index(
-        active_tab: usize,
-        tab_count: usize,
-        to_right: bool,
-    ) -> Option<usize> {
+    fn adjacent_tab_index(active_tab: usize, tab_count: usize, to_right: bool) -> Option<usize> {
         if tab_count <= 1 || active_tab >= tab_count {
             return None;
         }
@@ -226,8 +240,10 @@ impl TerminalView {
                     self.configured_working_dir.as_deref(),
                     self.terminal_runtime.working_dir_fallback,
                 );
-                let predicted_title =
-                    Self::predicted_prompt_seed_title(&self.tab_title, predicted_prompt_cwd.as_deref());
+                let predicted_title = Self::predicted_prompt_seed_title(
+                    &self.tab_title,
+                    predicted_prompt_cwd.as_deref(),
+                );
 
                 let tab_id = self.allocate_tab_id();
                 self.tabs.push(Self::create_native_tab(
@@ -391,19 +407,31 @@ impl TerminalView {
     }
 
     pub(crate) fn focus_pane_target(&mut self, pane_id: &str, cx: &mut Context<Self>) -> bool {
-        self.tmux_focus_pane_target(pane_id, cx)
+        match self.runtime_kind() {
+            RuntimeKind::Tmux => self.tmux_focus_pane_target(pane_id, cx),
+            RuntimeKind::Native => self.native_focus_pane_target(pane_id, cx),
+        }
     }
 
     pub(crate) fn split_active_pane_vertical(&mut self, cx: &mut Context<Self>) -> bool {
-        self.tmux_split_active_pane_vertical(cx)
+        match self.runtime_kind() {
+            RuntimeKind::Tmux => self.tmux_split_active_pane_vertical(cx),
+            RuntimeKind::Native => self.native_split_active_pane(NativeSplitAxis::Vertical, cx),
+        }
     }
 
     pub(crate) fn split_active_pane_horizontal(&mut self, cx: &mut Context<Self>) -> bool {
-        self.tmux_split_active_pane_horizontal(cx)
+        match self.runtime_kind() {
+            RuntimeKind::Tmux => self.tmux_split_active_pane_horizontal(cx),
+            RuntimeKind::Native => self.native_split_active_pane(NativeSplitAxis::Horizontal, cx),
+        }
     }
 
     pub(crate) fn close_active_pane(&mut self, cx: &mut Context<Self>) -> bool {
-        self.tmux_close_active_pane(cx)
+        match self.runtime_kind() {
+            RuntimeKind::Tmux => self.tmux_close_active_pane(cx),
+            RuntimeKind::Native => self.native_close_active_pane(cx),
+        }
     }
 
     pub(crate) fn close_active_pane_or_tab(
@@ -411,7 +439,10 @@ impl TerminalView {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> bool {
-        let pane_count = self.tabs.get(self.active_tab).map_or(0, |tab| tab.panes.len());
+        let pane_count = self
+            .tabs
+            .get(self.active_tab)
+            .map_or(0, |tab| tab.panes.len());
         match Self::close_pane_or_tab_target(self.runtime_kind(), pane_count) {
             ClosePaneOrTabTarget::ClosePane => self.close_active_pane(cx),
             ClosePaneOrTabTarget::CloseTab => {
@@ -424,26 +455,36 @@ impl TerminalView {
     }
 
     pub(crate) fn focus_pane_left(&mut self, cx: &mut Context<Self>) -> bool {
-        self.tmux_focus_pane_left(cx)
+        match self.runtime_kind() {
+            RuntimeKind::Tmux => self.tmux_focus_pane_left(cx),
+            RuntimeKind::Native => self.native_focus_pane_direction(NativeFocusDirection::Left, cx),
+        }
     }
 
     pub(crate) fn focus_pane_right(&mut self, cx: &mut Context<Self>) -> bool {
-        self.tmux_focus_pane_right(cx)
+        match self.runtime_kind() {
+            RuntimeKind::Tmux => self.tmux_focus_pane_right(cx),
+            RuntimeKind::Native => {
+                self.native_focus_pane_direction(NativeFocusDirection::Right, cx)
+            }
+        }
     }
 
     pub(crate) fn focus_pane_up(&mut self, cx: &mut Context<Self>) -> bool {
-        self.tmux_focus_pane_up(cx)
+        match self.runtime_kind() {
+            RuntimeKind::Tmux => self.tmux_focus_pane_up(cx),
+            RuntimeKind::Native => self.native_focus_pane_direction(NativeFocusDirection::Up, cx),
+        }
     }
 
     pub(crate) fn focus_pane_down(&mut self, cx: &mut Context<Self>) -> bool {
-        self.tmux_focus_pane_down(cx)
+        match self.runtime_kind() {
+            RuntimeKind::Tmux => self.tmux_focus_pane_down(cx),
+            RuntimeKind::Native => self.native_focus_pane_direction(NativeFocusDirection::Down, cx),
+        }
     }
 
     fn focus_pane_cycle(&mut self, step: i32, cx: &mut Context<Self>) -> bool {
-        if !self.runtime_kind().uses_tmux() {
-            return false;
-        }
-
         let Some(tab) = self.tabs.get(self.active_tab) else {
             return false;
         };
@@ -486,6 +527,396 @@ impl TerminalView {
 
     pub(crate) fn toggle_pane_zoom(&mut self, cx: &mut Context<Self>) -> bool {
         self.tmux_toggle_active_pane_zoom(cx)
+    }
+
+    fn native_allocate_pane_id(&self) -> String {
+        let mut next = 1u64;
+        loop {
+            let candidate = format!("%native-pane-{next}");
+            if self.pane_terminal_by_id(candidate.as_str()).is_none() {
+                return candidate;
+            }
+            next = next.saturating_add(1);
+        }
+    }
+
+    fn native_make_terminal(&self, cols: u16, rows: u16) -> Result<Terminal, String> {
+        Terminal::new_native(
+            TerminalSize {
+                cols: cols.max(1),
+                rows: rows.max(1),
+                ..TerminalSize::default()
+            },
+            self.configured_working_dir.as_deref(),
+            Some(self.event_wakeup_tx.clone()),
+            Some(&self.tab_shell_integration),
+            Some(&self.terminal_runtime),
+        )
+        .map_err(|error| format!("Failed to split pane: {error}"))
+    }
+
+    fn native_focus_pane_target(&mut self, pane_id: &str, cx: &mut Context<Self>) -> bool {
+        let Some(tab) = self.tabs.get_mut(self.active_tab) else {
+            return false;
+        };
+        if tab.active_pane_id == pane_id {
+            return false;
+        }
+        if !tab.panes.iter().any(|pane| pane.id == pane_id) {
+            return false;
+        }
+
+        tab.active_pane_id = pane_id.to_string();
+        self.clear_selection();
+        self.clear_hovered_link();
+        cx.notify();
+        true
+    }
+
+    fn native_split_active_pane(&mut self, axis: NativeSplitAxis, cx: &mut Context<Self>) -> bool {
+        let Some((active_pane_id, left, top, width, height)) =
+            self.tabs.get(self.active_tab).and_then(|tab| {
+                let index = tab.active_pane_index()?;
+                let pane = tab.panes.get(index)?;
+                Some((
+                    pane.id.clone(),
+                    pane.left,
+                    pane.top,
+                    pane.width,
+                    pane.height,
+                ))
+            })
+        else {
+            return false;
+        };
+
+        let (current_size, split_size) = match axis {
+            NativeSplitAxis::Vertical => {
+                if width <= 1 {
+                    return false;
+                }
+                let current_width = (width / 2).max(1);
+                let split_width = width.saturating_sub(current_width).max(1);
+                (
+                    (left, top, current_width, height),
+                    (left.saturating_add(current_width), top, split_width, height),
+                )
+            }
+            NativeSplitAxis::Horizontal => {
+                if height <= 1 {
+                    return false;
+                }
+                let current_height = (height / 2).max(1);
+                let split_height = height.saturating_sub(current_height).max(1);
+                (
+                    (left, top, width, current_height),
+                    (
+                        left,
+                        top.saturating_add(current_height),
+                        width,
+                        split_height,
+                    ),
+                )
+            }
+        };
+
+        let terminal = match self.native_make_terminal(split_size.2, split_size.3) {
+            Ok(terminal) => terminal,
+            Err(error) => {
+                termy_toast::error(error);
+                return false;
+            }
+        };
+        terminal.set_scrollback_history(self.terminal_runtime.scrollback_history);
+
+        let pane_id = self.native_allocate_pane_id();
+        let Some(tab) = self.tabs.get_mut(self.active_tab) else {
+            return false;
+        };
+        let Some(active_index) = tab.panes.iter().position(|pane| pane.id == active_pane_id) else {
+            return false;
+        };
+
+        if let Some(active_pane) = tab.panes.get_mut(active_index) {
+            active_pane.left = current_size.0;
+            active_pane.top = current_size.1;
+            active_pane.width = current_size.2;
+            active_pane.height = current_size.3;
+        }
+
+        let split_pane = TerminalPane {
+            id: pane_id.clone(),
+            left: split_size.0,
+            top: split_size.1,
+            width: split_size.2,
+            height: split_size.3,
+            degraded: false,
+            terminal,
+            render_cache: RefCell::new(TerminalPaneRenderCache::default()),
+        };
+
+        tab.panes.insert(active_index + 1, split_pane);
+        tab.active_pane_id = pane_id;
+        self.clear_selection();
+        self.clear_hovered_link();
+        cx.notify();
+        true
+    }
+
+    fn native_overlap_cells(a_start: u16, a_end: u16, b_start: u16, b_end: u16) -> u16 {
+        let start = a_start.max(b_start);
+        let end = a_end.min(b_end);
+        end.saturating_sub(start)
+    }
+
+    fn native_close_expand_neighbors(panes: &mut [TerminalPane], removed: &TerminalPane) {
+        if panes.is_empty() {
+            return;
+        }
+
+        let removed_left = removed.left;
+        let removed_top = removed.top;
+        let removed_right = removed.left.saturating_add(removed.width);
+        let removed_bottom = removed.top.saturating_add(removed.height);
+        let removed_width = removed.width;
+        let removed_height = removed.height;
+
+        let mut left_candidates = Vec::<(usize, u16)>::new();
+        let mut right_candidates = Vec::<(usize, u16)>::new();
+        let mut top_candidates = Vec::<(usize, u16)>::new();
+        let mut bottom_candidates = Vec::<(usize, u16)>::new();
+
+        for (index, pane) in panes.iter().enumerate() {
+            let pane_left = pane.left;
+            let pane_top = pane.top;
+            let pane_right = pane.left.saturating_add(pane.width);
+            let pane_bottom = pane.top.saturating_add(pane.height);
+
+            if pane_right == removed_left {
+                let overlap =
+                    Self::native_overlap_cells(pane_top, pane_bottom, removed_top, removed_bottom);
+                if overlap > 0 {
+                    left_candidates.push((index, overlap));
+                }
+            }
+
+            if pane_left == removed_right {
+                let overlap =
+                    Self::native_overlap_cells(pane_top, pane_bottom, removed_top, removed_bottom);
+                if overlap > 0 {
+                    right_candidates.push((index, overlap));
+                }
+            }
+
+            if pane_bottom == removed_top {
+                let overlap =
+                    Self::native_overlap_cells(pane_left, pane_right, removed_left, removed_right);
+                if overlap > 0 {
+                    top_candidates.push((index, overlap));
+                }
+            }
+
+            if pane_top == removed_bottom {
+                let overlap =
+                    Self::native_overlap_cells(pane_left, pane_right, removed_left, removed_right);
+                if overlap > 0 {
+                    bottom_candidates.push((index, overlap));
+                }
+            }
+        }
+
+        let sum_overlap = |candidates: &[(usize, u16)]| -> u16 {
+            candidates.iter().map(|(_, overlap)| *overlap).sum()
+        };
+        let vertical_cover_target = removed_bottom.saturating_sub(removed_top);
+        let horizontal_cover_target = removed_right.saturating_sub(removed_left);
+
+        let mut candidates = Vec::<(&str, u16)>::new();
+        let left_cover = sum_overlap(&left_candidates);
+        let right_cover = sum_overlap(&right_candidates);
+        let top_cover = sum_overlap(&top_candidates);
+        let bottom_cover = sum_overlap(&bottom_candidates);
+
+        if left_cover > 0 {
+            candidates.push(("left", left_cover));
+        }
+        if right_cover > 0 {
+            candidates.push(("right", right_cover));
+        }
+        if top_cover > 0 {
+            candidates.push(("top", top_cover));
+        }
+        if bottom_cover > 0 {
+            candidates.push(("bottom", bottom_cover));
+        }
+
+        candidates.sort_by_key(|(_, coverage)| Reverse(*coverage));
+
+        let selected = candidates.into_iter().find_map(|(direction, coverage)| {
+            let target = match direction {
+                "left" | "right" => vertical_cover_target,
+                _ => horizontal_cover_target,
+            };
+            (coverage >= target).then_some(direction)
+        });
+        let selected = selected.or_else(|| {
+            ["left", "right", "top", "bottom"]
+                .into_iter()
+                .find(|direction| match *direction {
+                    "left" => !left_candidates.is_empty(),
+                    "right" => !right_candidates.is_empty(),
+                    "top" => !top_candidates.is_empty(),
+                    _ => !bottom_candidates.is_empty(),
+                })
+        });
+
+        match selected {
+            Some("left") => {
+                for (index, _) in left_candidates {
+                    panes[index].width = panes[index].width.saturating_add(removed_width);
+                }
+            }
+            Some("right") => {
+                for (index, _) in right_candidates {
+                    panes[index].left = panes[index].left.saturating_sub(removed_width);
+                    panes[index].width = panes[index].width.saturating_add(removed_width);
+                }
+            }
+            Some("top") => {
+                for (index, _) in top_candidates {
+                    panes[index].height = panes[index].height.saturating_add(removed_height);
+                }
+            }
+            Some("bottom") => {
+                for (index, _) in bottom_candidates {
+                    panes[index].top = panes[index].top.saturating_sub(removed_height);
+                    panes[index].height = panes[index].height.saturating_add(removed_height);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn native_close_active_pane(&mut self, cx: &mut Context<Self>) -> bool {
+        let Some(tab) = self.tabs.get_mut(self.active_tab) else {
+            return false;
+        };
+        if tab.panes.len() <= 1 {
+            return false;
+        }
+        let Some(active_index) = tab.active_pane_index() else {
+            return false;
+        };
+
+        let removed = tab.panes.remove(active_index);
+        Self::native_close_expand_neighbors(&mut tab.panes, &removed);
+
+        let next_index = active_index.min(tab.panes.len().saturating_sub(1));
+        if let Some(next) = tab.panes.get(next_index) {
+            tab.active_pane_id = next.id.clone();
+        }
+
+        self.clear_selection();
+        self.clear_hovered_link();
+        cx.notify();
+        true
+    }
+
+    fn native_focus_pane_direction(
+        &mut self,
+        direction: NativeFocusDirection,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        let Some(tab) = self.tabs.get(self.active_tab) else {
+            return false;
+        };
+        let Some(active_index) = tab.active_pane_index() else {
+            return false;
+        };
+        let Some(active) = tab.panes.get(active_index) else {
+            return false;
+        };
+
+        let active_left = active.left;
+        let active_top = active.top;
+        let active_right = active.left.saturating_add(active.width);
+        let active_bottom = active.top.saturating_add(active.height);
+
+        let mut best: Option<(u16, Reverse<u16>, String)> = None;
+        for pane in &tab.panes {
+            if pane.id == active.id {
+                continue;
+            }
+
+            let pane_left = pane.left;
+            let pane_top = pane.top;
+            let pane_right = pane.left.saturating_add(pane.width);
+            let pane_bottom = pane.top.saturating_add(pane.height);
+
+            let (distance, overlap) = match direction {
+                NativeFocusDirection::Left => {
+                    let overlap = Self::native_overlap_cells(
+                        active_top,
+                        active_bottom,
+                        pane_top,
+                        pane_bottom,
+                    );
+                    if overlap == 0 || pane_right > active_left {
+                        continue;
+                    }
+                    (active_left.saturating_sub(pane_right), overlap)
+                }
+                NativeFocusDirection::Right => {
+                    let overlap = Self::native_overlap_cells(
+                        active_top,
+                        active_bottom,
+                        pane_top,
+                        pane_bottom,
+                    );
+                    if overlap == 0 || pane_left < active_right {
+                        continue;
+                    }
+                    (pane_left.saturating_sub(active_right), overlap)
+                }
+                NativeFocusDirection::Up => {
+                    let overlap = Self::native_overlap_cells(
+                        active_left,
+                        active_right,
+                        pane_left,
+                        pane_right,
+                    );
+                    if overlap == 0 || pane_bottom > active_top {
+                        continue;
+                    }
+                    (active_top.saturating_sub(pane_bottom), overlap)
+                }
+                NativeFocusDirection::Down => {
+                    let overlap = Self::native_overlap_cells(
+                        active_left,
+                        active_right,
+                        pane_left,
+                        pane_right,
+                    );
+                    if overlap == 0 || pane_top < active_bottom {
+                        continue;
+                    }
+                    (pane_top.saturating_sub(active_bottom), overlap)
+                }
+            };
+
+            let candidate = (distance, Reverse(overlap), pane.id.clone());
+            if best
+                .as_ref()
+                .is_none_or(|current| (candidate.0, candidate.1) < (current.0, current.1))
+            {
+                best = Some(candidate);
+            }
+        }
+
+        let Some((_, _, pane_id)) = best else {
+            return false;
+        };
+        self.native_focus_pane_target(pane_id.as_str(), cx)
     }
 }
 
@@ -559,7 +990,7 @@ mod tests {
     }
 
     #[test]
-    fn close_pane_or_tab_target_falls_back_to_tab_when_last_or_non_tmux() {
+    fn close_pane_or_tab_target_falls_back_to_tab_when_last_pane() {
         assert_eq!(
             TerminalView::close_pane_or_tab_target(RuntimeKind::Tmux, 1),
             ClosePaneOrTabTarget::CloseTab
@@ -568,9 +999,13 @@ mod tests {
             TerminalView::close_pane_or_tab_target(RuntimeKind::Tmux, 0),
             ClosePaneOrTabTarget::CloseTab
         );
+    }
+
+    #[test]
+    fn close_pane_or_tab_target_prefers_pane_when_multiple_exist() {
         assert_eq!(
             TerminalView::close_pane_or_tab_target(RuntimeKind::Native, 3),
-            ClosePaneOrTabTarget::CloseTab
+            ClosePaneOrTabTarget::ClosePane
         );
     }
 }


### PR DESCRIPTION
This pull request updates the handling and documentation of tmux-only keybindings in the Termy CLI and related modules. The main change is a shift in tests and documentation to focus on the `resize_pane_left` command as the canonical example of a tmux-only keybinding, replacing previous references to `split_pane_vertical`. Additionally, there are minor formatting improvements for code clarity and maintainability.

**Keybinding and Command Metadata Updates**

* All tests and documentation that previously referenced `split_pane_vertical` as a tmux-only keybinding now use `resize_pane_left` instead. This affects CLI tests, config validation, and documentation generation, ensuring consistency and clarity around which keybindings require tmux. [[1]](diffhunk://#diff-deda2f5c76ece87367c9ea66ea67349dabf989dfec7f13b6e10a56b6ad5eb517L310-R315) [[2]](diffhunk://#diff-deda2f5c76ece87367c9ea66ea67349dabf989dfec7f13b6e10a56b6ad5eb517L334-R339) [[3]](diffhunk://#diff-deda2f5c76ece87367c9ea66ea67349dabf989dfec7f13b6e10a56b6ad5eb517L373-R378) [[4]](diffhunk://#diff-deda2f5c76ece87367c9ea66ea67349dabf989dfec7f13b6e10a56b6ad5eb517L406-R416) [[5]](diffhunk://#diff-17c7fd6895225e4bce1d37eaae75c190e0ea594cee9e1d4ad8fdb68d924e1d2cL172-R194) [[6]](diffhunk://#diff-17c7fd6895225e4bce1d37eaae75c190e0ea594cee9e1d4ad8fdb68d924e1d2cL197-R216) [[7]](diffhunk://#diff-8e5510b528f2608b78445513cbdaab2ccaaaba031f18b384d06292ef148998daL258-R271) [[8]](diffhunk://#diff-8e5510b528f2608b78445513cbdaab2ccaaaba031f18b384d06292ef148998daL299-R312) [[9]](diffhunk://#diff-9f5875f21c84dddb7cd582203a34403903daa805e40ebaee2e6a026ace87c320L55-R55)

* The documentation (`docs/keybindings.md`) now clearly marks only the `resize_pane_left`, `resize_pane_right`, and `resize_pane_up/down` keybindings as tmux-required, removing the tmux-required annotation from other keybindings that do not strictly require tmux. [[1]](diffhunk://#diff-7a09c586ad6692c2ddfbc629c95f64a2722bba29f24c92eb3613baf03785dc61L16-R22) [[2]](diffhunk://#diff-7a09c586ad6692c2ddfbc629c95f64a2722bba29f24c92eb3613baf03785dc61L47-R53) [[3]](diffhunk://#diff-7a09c586ad6692c2ddfbc629c95f64a2722bba29f24c92eb3613baf03785dc61L77-R83)

**Command Catalog and Core Logic Adjustments**

* The command catalog and its tests have been updated to reflect the new set of tmux-only commands, removing `split_pane_vertical` and related commands from the tmux-only list and focusing on resize commands. [[1]](diffhunk://#diff-3f57944454704711b3e57f0e3998b6d416f24e9fc58550d8c39565f5bb2f36a7L106-R105) [[2]](diffhunk://#diff-3f57944454704711b3e57f0e3998b6d416f24e9fc58550d8c39565f5bb2f36a7L176-L188)

**Code Formatting and Maintenance**

* Several functions in `crates/xtask/src/main.rs` have been reformatted for readability, including improved line breaks and formatting in multi-parameter function calls and iterator chains. [[1]](diffhunk://#diff-8e5510b528f2608b78445513cbdaab2ccaaaba031f18b384d06292ef148998daL35-R40) [[2]](diffhunk://#diff-8e5510b528f2608b78445513cbdaab2ccaaaba031f18b384d06292ef148998daL79-R85) [[3]](diffhunk://#diff-8e5510b528f2608b78445513cbdaab2ccaaaba031f18b384d06292ef148998daL93-R101) [[4]](diffhunk://#diff-8e5510b528f2608b78445513cbdaab2ccaaaba031f18b384d06292ef148998daL183-R194) [[5]](diffhunk://#diff-8e5510b528f2608b78445513cbdaab2ccaaaba031f18b384d06292ef148998daL242-R255)

**Minor Cleanup**

* Removed the unused `NativeSdkExample` command from the command catalog macro.

These changes collectively improve clarity and consistency around tmux-only keybindings, enhance documentation accuracy, and maintain code quality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native pane management without tmux: split, close, and focus panes in native sessions.

* **Bug Fixes**
  * Improved pane geometry handling and border rendering in multi-pane layouts.

* **Changes**
  * Removed "(tmux required)" annotations from keybinding documentation for clarity.
  * Removed Termy branding from the tab strip interface.
  * Removed CloseTab and NativeSdkExample commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->