### PR TITLE
Add justfile check and clean recipes

### DIFF
--- a/justfile
+++ b/justfile
@@ -10,6 +10,12 @@ run:
 build:
     cargo build --release
 
+check:
+    cargo check --workspace
+
+clean:
+    cargo clean --workspace && rm -rf ./target
+
 # Generate macOS .icns file from assets/termy_icon@1024px.png
 generate-icon:
     ./scripts/generate-icon.sh

--- a/src/terminal_view/interaction/quit.rs
+++ b/src/terminal_view/interaction/quit.rs
@@ -9,6 +9,10 @@ enum CloseRequestTarget {
 }
 
 impl TerminalView {
+    fn should_force_quit_when_prompt_in_flight(target: CloseRequestTarget) -> bool {
+        matches!(target, CloseRequestTarget::Application)
+    }
+
     pub(in super::super) fn execute_quit_command_action(
         &mut self,
         action: CommandAction,
@@ -202,6 +206,12 @@ impl TerminalView {
         cx: &mut Context<Self>,
     ) -> bool {
         if self.quit_prompt_in_flight {
+            if Self::should_force_quit_when_prompt_in_flight(target) {
+                // If the quit confirm prompt is unresponsive, allow a second
+                // Quit shortcut to force-close the app.
+                self.allow_quit_without_prompt = true;
+                cx.quit();
+            }
             return false;
         }
 
@@ -304,5 +314,23 @@ impl TerminalView {
         }
         let tab_id = self.tabs[index].id;
         let _ = self.request_close(CloseRequestTarget::TabClose { tab_id }, window, cx);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CloseRequestTarget, TerminalView};
+
+    #[test]
+    fn prompt_in_flight_force_quit_policy_only_allows_application_target() {
+        assert!(TerminalView::should_force_quit_when_prompt_in_flight(
+            CloseRequestTarget::Application
+        ));
+        assert!(!TerminalView::should_force_quit_when_prompt_in_flight(
+            CloseRequestTarget::WindowClose
+        ));
+        assert!(!TerminalView::should_force_quit_when_prompt_in_flight(
+            CloseRequestTarget::TabClose { tab_id: 1 }
+        ));
     }
 }


### PR DESCRIPTION
This pull request introduces improvements to the quit command handling logic and adds new development utility commands. The most significant changes are the addition of a force-quit policy for the application and the inclusion of targeted tests to ensure correct behavior, along with new `justfile` commands for Rust workspace management.

Quit command logic improvements:

* Added a new method `should_force_quit_when_prompt_in_flight` to `TerminalView`, which restricts force-quit behavior to only the application target, preventing accidental force-quits of windows or tabs.
* Updated the quit command execution to check the force-quit policy and allow force-closing the application if the quit prompt is unresponsive.

Testing:

* Added unit tests for the new force-quit policy to verify that only the application target is allowed for force-quit when a prompt is in flight.

Development utilities:

* Added `check` and `clean` commands to the `justfile` for easier Rust workspace management, including workspace-wide checking and cleaning.