### PR TITLE
chore(theme-store): simplify Dockerfile and remove layer caching tricks

### DIFF
--- a/Dockerfile.theme-store
+++ b/Dockerfile.theme-store
@@ -2,15 +2,10 @@ FROM rust:bookworm AS builder
 
 WORKDIR /app
 
-COPY Cargo.toml Cargo.lock ./
+COPY Cargo.lock Cargo.lock
 COPY crates/theme-store/Cargo.toml crates/theme-store/Cargo.toml
-
-RUN mkdir -p crates/theme-store/src \
-    && echo "fn main() {}" > crates/theme-store/src/main.rs \
-    && cargo build --release -p termy_theme_store \
-    && rm -rf crates/theme-store/src
-
-COPY crates/theme-store crates/theme-store
+COPY crates/theme-store/src crates/theme-store/src
+COPY crates/theme-store/migrations crates/theme-store/migrations
 COPY theme.schema.json theme.schema.json
 
 ARG DATABASE_URL
@@ -23,8 +18,7 @@ ARG S3_ENDPOINT
 ARG AWS_ACCESS_KEY_ID
 ARG AWS_SECRET_ACCESS_KEY
 
-
-RUN cargo build --release -p termy_theme_store
+RUN cargo build --manifest-path crates/theme-store/Cargo.toml --release
 
 FROM debian:bookworm-slim
 


### PR DESCRIPTION
Remove the dummy main.rs build step previously used for Docker layer caching. The theme-store crate now builds directly from source with dependencies copied explicitly. Also fixes the Cargo.lock copy path and cleans up redundant blank lines.

# Pull Request

<!-- A clear and concise description of what this PR does and why it's needed. -->

## Description

<!-- Describe the changes made in the PR. -->

- 
-
-
-

## Screenshots/Videos

<!-- If applicable, add screenshots or screen recordings to help explain your changes. -->


## Related Issues

<!-- If this PR closes any issues, use the keyword 'closes' followed by the issue number -->

Closes #

## Checklist

- [ ] I confirmed there is no existing open PR for the same or overlapping changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Docker build process efficiency by streamlining build steps and making the build configuration more explicit and maintainable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->