### PR TITLE
Kimi made many of those lol

### DIFF
--- a/crates/config_core/src/default_config.txt
+++ b/crates/config_core/src/default_config.txt
@@ -1,6 +1,8 @@
 # Main settings
 # Current color scheme name
 theme = termy
+# Enable automatic update checks and notifications
+auto_update = true
 # Enable tmux runtime integration
 tmux_enabled = false
 # Reuse tmux tabs and panes across app restarts
@@ -80,11 +82,11 @@ command_palette_show_keybinds = true
 # Provider used for AI input and model listing
 ai_provider = openai
 # API key for OpenAI integration
-# openai_api_key = none
+openai_api_key = none
 # API key for Google Gemini integration
-# gemini_api_key = none
-# Model used for AI input requests (provider-specific)
-# openai_model = gpt-5-mini
+gemini_api_key = none
+# Model used for AI input requests
+openai_model = none
 
 # Keybindings (repeatable)
 # tmux-only keybind actions require an active tmux session
@@ -92,7 +94,7 @@ ai_provider = openai
 # keybind = cmd-c=copy
 # keybind = cmd-c=unbind
 # keybind = clear
-# keybind = secondary-d=split_pane_vertical
+# keybind = secondary-alt-shift-left=resize_pane_left
 
 # Color overrides
 [colors]

--- a/crates/config_core/src/parser.rs
+++ b/crates/config_core/src/parser.rs
@@ -129,6 +129,13 @@ impl AppConfig {
                         );
                     }
                 }
+                RootSettingId::AutoUpdate => {
+                    if let Some(parsed) =
+                        parse_bool_field(&mut diagnostics, line_number, key, value)
+                    {
+                        config.auto_update = parsed;
+                    }
+                }
                 RootSettingId::TmuxEnabled => {
                     if let Some(parsed) =
                         parse_bool_field(&mut diagnostics, line_number, key, value)

--- a/crates/config_core/src/schema.rs
+++ b/crates/config_core/src/schema.rs
@@ -308,6 +308,7 @@ pub const AI_PROVIDER_ENUM_CHOICES: &[EnumChoice] = &[
 
 define_root_settings! {
     (Theme, "theme", [], Appearance, "THEME", "Theme", "Current color scheme name", ["color", "scheme", "appearance"], RootSettingValueKind::Special, false),
+    (AutoUpdate, "auto_update", [], Advanced, "UPDATES", "Auto Update", "Enable automatic update checks and notifications", ["update", "check", "upgrade", "version"], RootSettingValueKind::Boolean, false),
     (TmuxEnabled, "tmux_enabled", [], Terminal, "TMUX", "Tmux Enabled", "Enable tmux runtime integration", ["tmux", "runtime", "integration", "enabled"], RootSettingValueKind::Boolean, false),
     (TmuxPersistence, "tmux_persistence", [], Terminal, "TMUX", "Tmux Persistence", "Reuse tmux tabs and panes across app restarts", ["tmux", "session", "persistence", "restart"], RootSettingValueKind::Boolean, false),
     (TmuxBinary, "tmux_binary", [], Terminal, "TMUX", "Tmux Binary", "tmux executable path or binary name", ["tmux", "binary", "path"], RootSettingValueKind::Text, false),
@@ -405,6 +406,7 @@ pub fn root_setting_enum_choices(id: RootSettingId) -> Option<&'static [EnumChoi
 pub fn root_setting_default_value(config: &AppConfig, id: RootSettingId) -> Option<String> {
     match id {
         RootSettingId::Theme => Some(config.theme.clone()),
+        RootSettingId::AutoUpdate => Some(config.auto_update.to_string()),
         RootSettingId::TmuxEnabled => Some(config.tmux_enabled.to_string()),
         RootSettingId::TmuxPersistence => Some(config.tmux_persistence.to_string()),
         RootSettingId::TmuxBinary => Some(config.tmux_binary.clone()),

--- a/crates/config_core/src/types.rs
+++ b/crates/config_core/src/types.rs
@@ -265,6 +265,7 @@ pub struct CustomColors {
 #[derive(Debug, Clone, PartialEq)]
 pub struct AppConfig {
     pub theme: ThemeId,
+    pub auto_update: bool,
     pub tmux_enabled: bool,
     pub tmux_persistence: bool,
     pub tmux_binary: String,
@@ -315,6 +316,7 @@ impl Default for AppConfig {
     fn default() -> Self {
         Self {
             theme: "termy".to_string(),
+            auto_update: true,
             tmux_enabled: DEFAULT_TMUX_ENABLED,
             tmux_persistence: DEFAULT_TMUX_PERSISTENCE,
             tmux_binary: DEFAULT_TMUX_BINARY.to_string(),

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -185,6 +185,11 @@ Tmux integration is an add-on. Set `tmux_enabled = true` to start in tmux mode b
 
 ## Advanced
 
+`auto_update`
+- Default: `true`
+- Enable automatic update checks and notifications
+- Group: `UPDATES`
+
 `working_dir`
 - Default: unset
 - Initial directory for new sessions
@@ -211,10 +216,27 @@ Tmux integration is an add-on. Set `tmux_enabled = true` to start in tmux mode b
 - Default startup window height in pixels
 - Group: `WINDOW`
 
+`ai_provider`
+- Default: `openai`
+- Provider used for AI input and model listing
+- Group: `AI`
+
 `openai_api_key`
 - Default: unset
 - Aliases: `openai_key`
 - API key for OpenAI integration
+- Group: `AI`
+
+`gemini_api_key`
+- Default: unset
+- Aliases: `google_ai_api_key`
+- API key for Google Gemini integration
+- Group: `AI`
+
+`openai_model`
+- Default: unset
+- Aliases: `ai_model`
+- Model used for AI input requests
 - Group: `AI`
 
 ## Keybindings

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -13,6 +13,15 @@ Termy keybindings use Ghostty-style trigger overrides via repeated `keybind` lin
 - `secondary-p` -> `toggle_command_palette`
 - `secondary-t` -> `new_tab`
 - `secondary-w` -> `close_pane_or_tab`
+- `secondary-1` -> `switch_to_tab_1`
+- `secondary-2` -> `switch_to_tab_2`
+- `secondary-3` -> `switch_to_tab_3`
+- `secondary-4` -> `switch_to_tab_4`
+- `secondary-5` -> `switch_to_tab_5`
+- `secondary-6` -> `switch_to_tab_6`
+- `secondary-7` -> `switch_to_tab_7`
+- `secondary-8` -> `switch_to_tab_8`
+- `secondary-9` -> `switch_to_tab_9`
 - `secondary-d` -> `split_pane_vertical`
 - `secondary-shift-d` -> `split_pane_horizontal`
 - `secondary-o` -> `focus_pane_next`
@@ -44,6 +53,15 @@ Termy keybindings use Ghostty-style trigger overrides via repeated `keybind` lin
 - `secondary-p` -> `toggle_command_palette`
 - `secondary-t` -> `new_tab`
 - `secondary-w` -> `close_pane_or_tab`
+- `secondary-1` -> `switch_to_tab_1`
+- `secondary-2` -> `switch_to_tab_2`
+- `secondary-3` -> `switch_to_tab_3`
+- `secondary-4` -> `switch_to_tab_4`
+- `secondary-5` -> `switch_to_tab_5`
+- `secondary-6` -> `switch_to_tab_6`
+- `secondary-7` -> `switch_to_tab_7`
+- `secondary-8` -> `switch_to_tab_8`
+- `secondary-9` -> `switch_to_tab_9`
 - `secondary-d` -> `split_pane_vertical`
 - `secondary-shift-d` -> `split_pane_horizontal`
 - `secondary-o` -> `focus_pane_next`
@@ -74,6 +92,15 @@ Termy keybindings use Ghostty-style trigger overrides via repeated `keybind` lin
 - `secondary-p` -> `toggle_command_palette`
 - `secondary-t` -> `new_tab`
 - `secondary-w` -> `close_pane_or_tab`
+- `secondary-1` -> `switch_to_tab_1`
+- `secondary-2` -> `switch_to_tab_2`
+- `secondary-3` -> `switch_to_tab_3`
+- `secondary-4` -> `switch_to_tab_4`
+- `secondary-5` -> `switch_to_tab_5`
+- `secondary-6` -> `switch_to_tab_6`
+- `secondary-7` -> `switch_to_tab_7`
+- `secondary-8` -> `switch_to_tab_8`
+- `secondary-9` -> `switch_to_tab_9`
 - `secondary-d` -> `split_pane_vertical`
 - `secondary-shift-d` -> `split_pane_horizontal`
 - `secondary-o` -> `focus_pane_next`
@@ -104,6 +131,15 @@ Termy keybindings use Ghostty-style trigger overrides via repeated `keybind` lin
 - `secondary-p` -> `toggle_command_palette`
 - `secondary-t` -> `new_tab`
 - `secondary-w` -> `close_pane_or_tab`
+- `secondary-1` -> `switch_to_tab_1`
+- `secondary-2` -> `switch_to_tab_2`
+- `secondary-3` -> `switch_to_tab_3`
+- `secondary-4` -> `switch_to_tab_4`
+- `secondary-5` -> `switch_to_tab_5`
+- `secondary-6` -> `switch_to_tab_6`
+- `secondary-7` -> `switch_to_tab_7`
+- `secondary-8` -> `switch_to_tab_8`
+- `secondary-9` -> `switch_to_tab_9`
 - `secondary-d` -> `split_pane_vertical`
 - `secondary-shift-d` -> `split_pane_horizontal`
 - `secondary-o` -> `focus_pane_next`
@@ -158,6 +194,15 @@ Related UI option:
 - `move_tab_right`
 - `switch_tab_left`
 - `switch_tab_right`
+- `switch_to_tab_1`
+- `switch_to_tab_2`
+- `switch_to_tab_3`
+- `switch_to_tab_4`
+- `switch_to_tab_5`
+- `switch_to_tab_6`
+- `switch_to_tab_7`
+- `switch_to_tab_8`
+- `switch_to_tab_9`
 - `manage_tmux_sessions`
 - `split_pane_vertical`
 - `split_pane_horizontal`

--- a/src/settings_view/components.rs
+++ b/src/settings_view/components.rs
@@ -93,7 +93,7 @@ impl SettingsWindow {
                     .child("Reset section")
                     .when(can_reset, |s| {
                         s.on_click(cx.listener(move |view, _, _, cx| {
-                            view.reset_section_to_defaults(section, cx);
+                            view.confirm_reset_section_to_defaults(section, cx);
                         }))
                     }),
             )
@@ -149,7 +149,7 @@ impl SettingsWindow {
             .child("Reset")
             .when(can_reset, |s| {
                 s.on_click(cx.listener(move |view, _, _, cx| {
-                    view.reset_setting_to_default(setting_key, cx);
+                    view.confirm_reset_setting_to_default(setting_key, cx);
                 }))
             })
     }

--- a/src/settings_view/search.rs
+++ b/src/settings_view/search.rs
@@ -578,6 +578,24 @@ impl SettingsWindow {
                         cx,
                     )),
             )
+            .child(div().flex_1())
+            .child(self.render_sidebar_footer(cx))
+    }
+
+    pub(super) fn render_sidebar_footer(&self, _cx: &mut Context<Self>) -> impl IntoElement {
+        let text_muted = self.text_muted();
+        let border_color = self.border_color();
+        div()
+            .border_t_1()
+            .border_color(border_color)
+            .px_4()
+            .py_3()
+            .child(
+                div()
+                    .text_xs()
+                    .text_color(text_muted)
+                    .child(format!("Termy v{}", crate::APP_VERSION)),
+            )
     }
 
     pub(super) fn search_input_content(

--- a/src/settings_view/sections.rs
+++ b/src/settings_view/sections.rs
@@ -1239,6 +1239,28 @@ impl SettingsWindow {
         ];
         let ai_group = self.render_settings_group("AI", ai_rows);
 
+        let auto_update_meta = Self::setting_metadata_or_fallback("auto_update");
+        let auto_update = self.config.auto_update;
+        let updates_rows = vec![self.render_setting_row(
+            "auto_update",
+            "auto_update-toggle",
+            auto_update_meta.title,
+            auto_update_meta.description,
+            auto_update,
+            cx,
+            |view, _cx| {
+                let next = !view.config.auto_update;
+                match config::set_root_setting(RootSettingId::AutoUpdate, &next.to_string()) {
+                    Ok(()) => {
+                        view.config.auto_update = next;
+                        termy_toast::success("Saved");
+                    }
+                    Err(error) => termy_toast::error(error),
+                }
+            },
+        )];
+        let updates_group = self.render_settings_group("UPDATES", updates_rows);
+
         let config_file_card = div()
             .py_4()
             .px_4()
@@ -1301,6 +1323,7 @@ impl SettingsWindow {
             .child(safety_group)
             .child(window_group)
             .child(ai_group)
+            .child(updates_group)
             .child(config_group)
     }
 }

--- a/src/settings_view/state.rs
+++ b/src/settings_view/state.rs
@@ -332,6 +332,64 @@ impl SettingsWindow {
         }
     }
 
+    pub(super) fn confirm_reset_section_to_defaults(
+        &mut self,
+        section: SettingsSection,
+        cx: &mut Context<Self>,
+    ) {
+        let section_name = match section {
+            SettingsSection::Appearance => "Appearance",
+            SettingsSection::Terminal => "Terminal",
+            SettingsSection::Tabs => "Tabs",
+            SettingsSection::Advanced => "Advanced",
+            SettingsSection::Colors => "Colors",
+            SettingsSection::Keybindings => "Keybindings",
+            SettingsSection::ThemeStore => return,
+        };
+        let title = "Reset Section";
+        let message = format!(
+            "Are you sure you want to reset all {} settings to their default values?",
+            section_name
+        );
+
+        cx.spawn(async move |this, cx: &mut AsyncApp| {
+            let confirmed = termy_native_sdk::confirm(title, &message);
+            if !confirmed {
+                return;
+            }
+
+            let _ = cx.update(|cx| {
+                this.update(cx, |view, cx| {
+                    view.reset_section_to_defaults(section, cx);
+                })
+            });
+        })
+        .detach();
+    }
+
+    pub(super) fn confirm_reset_setting_to_default(
+        &mut self,
+        setting_key: &'static str,
+        cx: &mut Context<Self>,
+    ) {
+        let title = "Reset Setting";
+        let message = "Are you sure you want to reset this setting to its default value?";
+
+        cx.spawn(async move |this, cx: &mut AsyncApp| {
+            let confirmed = termy_native_sdk::confirm(title, message);
+            if !confirmed {
+                return;
+            }
+
+            let _ = cx.update(|cx| {
+                this.update(cx, |view, cx| {
+                    view.reset_setting_to_default(setting_key, cx);
+                })
+            });
+        })
+        .detach();
+    }
+
     pub(super) fn reset_section_to_defaults(
         &mut self,
         section: SettingsSection,

--- a/src/terminal_view/mod.rs
+++ b/src/terminal_view/mod.rs
@@ -2012,7 +2012,7 @@ impl TerminalView {
         }
 
         #[cfg(target_os = "macos")]
-        {
+        if config.auto_update {
             let updater = cx.new(|_| AutoUpdater::new(crate::APP_VERSION));
             cx.observe(&updater, |view, updater, cx| {
                 let state = updater.read(cx).state.clone();


### PR DESCRIPTION
This pull request introduces a new `auto_update` configuration option to enable automatic update checks and notifications, and improves the settings UI with confirmation dialogs for reset actions and better organization. It also expands documentation for configuration and keybindings, and adds a sidebar footer to the settings view.

### Configuration and Schema Updates

* Added `auto_update` as a boolean setting to `AppConfig`, configuration schema, and default config, with a default value of `true`. This enables automatic update checks and notifications. [[1]](diffhunk://#diff-689d9d0554e70c785d8b5e785be56a43a316dec6416e4ea53381195b87a774a3R268) [[2]](diffhunk://#diff-689d9d0554e70c785d8b5e785be56a43a316dec6416e4ea53381195b87a774a3R319) [[3]](diffhunk://#diff-1c817464293b116b1ba5830d33be2ee0e5502399c91ca813c2bd8a6e5ccf960aR311) [[4]](diffhunk://#diff-bef00ecd4110c89ae0250f1e38b920ca3c38ae6eb18e426f0063df6722cc53bdR4-R5) [[5]](diffhunk://#diff-bef00ecd4110c89ae0250f1e38b920ca3c38ae6eb18e426f0063df6722cc53bdL83-R97) [[6]](diffhunk://#diff-1c817464293b116b1ba5830d33be2ee0e5502399c91ca813c2bd8a6e5ccf960aR409)
* Updated the auto-update logic in `terminal_view/mod.rs` to conditionally start the updater based on the new config value.

### Settings UI Improvements

* Added confirmation dialogs before resetting individual settings or entire sections to their default values in the settings view. [[1]](diffhunk://#diff-d748ce86f6ad3d9f129ff1087d0e308e24e7248ad088263add05b806c5b730faL96-R96) [[2]](diffhunk://#diff-d748ce86f6ad3d9f129ff1087d0e308e24e7248ad088263add05b806c5b730faL152-R152) [[3]](diffhunk://#diff-58ad16089e58ebf0ec4cbab9da542cace6d3ceb59f48f90601cfc6d07749c5c4R335-R392)
* Introduced an "UPDATES" group in the settings UI to manage the new `auto_update` option. [[1]](diffhunk://#diff-75044ee94d4c18488325a354f5954173a4ad6aed030807928c0804e89a7f0f05R1242-R1263) [[2]](diffhunk://#diff-75044ee94d4c18488325a354f5954173a4ad6aed030807928c0804e89a7f0f05R1326)
* Added a sidebar footer displaying the app version in the settings view.

### Documentation Updates

* Documented the new `auto_update` option and expanded documentation for AI-related settings (`ai_provider`, `openai_api_key`, `gemini_api_key`, `openai_model`). [[1]](diffhunk://#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180R188-R192) [[2]](diffhunk://#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180R219-R241)
* Added missing keybinding documentation for switching directly to tabs 1–9. [[1]](diffhunk://#diff-7a09c586ad6692c2ddfbc629c95f64a2722bba29f24c92eb3613baf03785dc61R16-R24) [[2]](diffhunk://#diff-7a09c586ad6692c2ddfbc629c95f64a2722bba29f24c92eb3613baf03785dc61R56-R64) [[3]](diffhunk://#diff-7a09c586ad6692c2ddfbc629c95f64a2722bba29f24c92eb3613baf03785dc61R95-R103) [[4]](diffhunk://#diff-7a09c586ad6692c2ddfbc629c95f64a2722bba29f24c92eb3613baf03785dc61R134-R142) [[5]](diffhunk://#diff-7a09c586ad6692c2ddfbc629c95f64a2722bba29f24c92eb3613baf03785dc61R197-R205)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Auto Update toggle in settings to control automatic update checks
  * Added confirmation dialogs when resetting settings or sections
  * Added version number display in settings sidebar footer
  * Introduced keyboard shortcuts (Secondary+1-9) for quick tab switching
  * Added AI provider and model configuration options

* **Documentation**
  * Updated configuration guide with auto_update, ai_provider, gemini_api_key, and openai_model settings
  * Added keybindings documentation for tab switching shortcuts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->