### PR TITLE
Add handling for termy:// deeplinks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7306,6 +7306,7 @@ dependencies = [
  "termy_themes",
  "termy_toast",
  "ureq",
+ "url",
  "winresource",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ rfd = "0.15"
 
 # JSON parsing
 serde_json = "1.0"
+url = "2.5"
 
 # File I/O
 tempfile = "3"

--- a/installer/termy.iss
+++ b/installer/termy.iss
@@ -47,5 +47,11 @@ Source: "..\target\{#MyTarget}\release\{#MyExeName}"; DestDir: "{app}"; Flags: i
 Name: "{group}\Termy"; Filename: "{app}\{#MyExeName}"
 Name: "{autodesktop}\Termy"; Filename: "{app}\{#MyExeName}"
 
+[Registry]
+Root: HKCR; Subkey: "termy"; ValueType: string; ValueName: ""; ValueData: "URL:Termy Protocol"; Flags: uninsdeletekey
+Root: HKCR; Subkey: "termy"; ValueType: string; ValueName: "URL Protocol"; ValueData: ""
+Root: HKCR; Subkey: "termy\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\{#MyExeName},0"
+Root: HKCR; Subkey: "termy\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\{#MyExeName}"" ""%1"""
+
 [Run]
 Filename: "{app}\{#MyExeName}"; Description: "Launch Termy"; Flags: nowait postinstall skipifsilent

--- a/packaging/linux/termy.desktop
+++ b/packaging/linux/termy.desktop
@@ -2,9 +2,10 @@
 Name=Termy
 GenericName=Terminal Emulator
 Comment=Minimal GPUI-powered terminal
-Exec=termy
+Exec=termy %u
 Icon=termy
 Terminal=false
 Type=Application
 Categories=System;TerminalEmulator;
 Keywords=shell;prompt;command;commandline;cmd;
+MimeType=x-scheme-handler/termy;

--- a/scripts/build-dmg-signed.sh
+++ b/scripts/build-dmg-signed.sh
@@ -51,6 +51,23 @@ require_cmd() {
   command -v "$1" >/dev/null 2>&1 || die "'$1' is required"
 }
 
+ensure_termy_url_scheme() {
+  local app_path="$1"
+  local plist_path="$app_path/Contents/Info.plist"
+  local plist_buddy="/usr/libexec/PlistBuddy"
+
+  [[ -f "$plist_path" ]] || die "App bundle Info.plist not found at $plist_path"
+  [[ -x "$plist_buddy" ]] || die "PlistBuddy is required to patch $plist_path"
+
+  "$plist_buddy" -c "Delete :CFBundleURLTypes" "$plist_path" >/dev/null 2>&1 || true
+  "$plist_buddy" -c "Add :CFBundleURLTypes array" "$plist_path"
+  "$plist_buddy" -c "Add :CFBundleURLTypes:0 dict" "$plist_path"
+  "$plist_buddy" -c "Add :CFBundleURLTypes:0:CFBundleURLName string com.example.termy.deeplink" "$plist_path"
+  "$plist_buddy" -c "Add :CFBundleURLTypes:0:CFBundleURLSchemes array" "$plist_path"
+  "$plist_buddy" -c "Add :CFBundleURLTypes:0:CFBundleURLSchemes:0 string termy" "$plist_path"
+  /usr/bin/plutil -lint "$plist_path" >/dev/null
+}
+
 read_version_from_cargo_toml() {
   awk '
     /^\[package\]$/ { in_package = 1; next }
@@ -272,6 +289,9 @@ else
 fi
 [[ -n "$APP_PATH" && -d "$APP_PATH" ]] || die "Could not find built app bundle"
 
+log "Registering termy:// URL scheme in app bundle"
+ensure_termy_url_scheme "$APP_PATH"
+
 log "Signing app bundle"
 xattr -rc "$APP_PATH"
 CODESIGN_APP_ARGS=(
@@ -301,6 +321,7 @@ hdiutil create \
   -volname "$VOLUME_NAME" \
   -srcfolder "$DMG_ROOT" \
   -ov \
+  -fs HFS+ \
   -format UDRW \
   "$RW_DMG" >/dev/null
 
@@ -315,8 +336,10 @@ cleanup() {
 trap cleanup EXIT
 
 ATTACH_INFO="$(hdiutil attach -readwrite -noverify -noautoopen "$RW_DMG")"
-IFS=$'\t' read -r DEVICE MOUNT_POINT <<< "$(printf '%s\n' "$ATTACH_INFO" | awk '/\/Volumes\// {print $1 "\t" $NF; exit}')"
-[[ -n "$DEVICE" && -n "$MOUNT_POINT" && -d "$MOUNT_POINT" ]] || die "Failed to mount temporary DMG"
+ATTACH_LINE="$(printf '%s\n' "$ATTACH_INFO" | awk '/\/Volumes\// {print; exit}')"
+DEVICE="${ATTACH_LINE%%[[:space:]]*}"
+MOUNT_POINT="$(printf '%s\n' "$ATTACH_LINE" | sed -E 's@.*(/Volumes/.*)$@\1@')"
+[[ -n "$DEVICE" && -n "$MOUNT_POINT" && -d "$MOUNT_POINT" ]] || die "Failed to mount temporary DMG. hdiutil output: $ATTACH_INFO"
 
 if [[ "$SKIP_LAYOUT" -eq 0 && -x "/usr/bin/osascript" ]]; then
   log "Applying Finder layout"

--- a/scripts/build-dmg.sh
+++ b/scripts/build-dmg.sh
@@ -33,6 +33,23 @@ require_cmd() {
   command -v "$1" >/dev/null 2>&1 || die "'$1' is required"
 }
 
+ensure_termy_url_scheme() {
+  local app_path="$1"
+  local plist_path="$app_path/Contents/Info.plist"
+  local plist_buddy="/usr/libexec/PlistBuddy"
+
+  [[ -f "$plist_path" ]] || die "App bundle Info.plist not found at $plist_path"
+  [[ -x "$plist_buddy" ]] || die "PlistBuddy is required to patch $plist_path"
+
+  "$plist_buddy" -c "Delete :CFBundleURLTypes" "$plist_path" >/dev/null 2>&1 || true
+  "$plist_buddy" -c "Add :CFBundleURLTypes array" "$plist_path"
+  "$plist_buddy" -c "Add :CFBundleURLTypes:0 dict" "$plist_path"
+  "$plist_buddy" -c "Add :CFBundleURLTypes:0:CFBundleURLName string com.example.termy.deeplink" "$plist_path"
+  "$plist_buddy" -c "Add :CFBundleURLTypes:0:CFBundleURLSchemes array" "$plist_path"
+  "$plist_buddy" -c "Add :CFBundleURLTypes:0:CFBundleURLSchemes:0 string termy" "$plist_path"
+  /usr/bin/plutil -lint "$plist_path" >/dev/null
+}
+
 read_version_from_cargo_toml() {
   awk '
     /^\[package\]$/ { in_package = 1; next }
@@ -161,6 +178,9 @@ else
 fi
 [[ -n "$APP_PATH" && -d "$APP_PATH" ]] || die "Could not find built app bundle"
 
+log "Registering termy:// URL scheme in app bundle"
+ensure_termy_url_scheme "$APP_PATH"
+
 # Copy CLI binary into app bundle
 log "Copying CLI binary into app bundle"
 CLI_BIN="$TARGET_RELEASE_DIR/termy-cli"
@@ -186,6 +206,7 @@ hdiutil create \
   -volname "$VOLUME_NAME" \
   -srcfolder "$DMG_ROOT" \
   -ov \
+  -fs HFS+ \
   -format UDRW \
   "$RW_DMG" >/dev/null
 
@@ -200,8 +221,10 @@ cleanup() {
 trap cleanup EXIT
 
 ATTACH_INFO="$(hdiutil attach -readwrite -noverify -noautoopen "$RW_DMG")"
-IFS=$'\t' read -r DEVICE MOUNT_POINT <<< "$(printf '%s\n' "$ATTACH_INFO" | awk '/\/Volumes\// {print $1 "\t" $NF; exit}')"
-[[ -n "$DEVICE" && -n "$MOUNT_POINT" && -d "$MOUNT_POINT" ]] || die "Failed to mount temporary DMG"
+ATTACH_LINE="$(printf '%s\n' "$ATTACH_INFO" | awk '/\/Volumes\// {print; exit}')"
+DEVICE="${ATTACH_LINE%%[[:space:]]*}"
+MOUNT_POINT="$(printf '%s\n' "$ATTACH_LINE" | sed -E 's@.*(/Volumes/.*)$@\1@')"
+[[ -n "$DEVICE" && -n "$MOUNT_POINT" && -d "$MOUNT_POINT" ]] || die "Failed to mount temporary DMG. hdiutil output: $ATTACH_INFO"
 
 if [[ "$SKIP_LAYOUT" -eq 0 && -x "/usr/bin/osascript" ]]; then
   log "Applying Finder layout"

--- a/site/src/routes/themes/$slug.tsx
+++ b/site/src/routes/themes/$slug.tsx
@@ -14,6 +14,10 @@ export const Route = createFileRoute("/themes/$slug")({
   component: ThemeDetailPage,
 });
 
+function buildThemeInstallHref(slug: string): string {
+  return `termy://store/theme-install?slug=${encodeURIComponent(slug)}`;
+}
+
 function ThemeDetailPage(): JSX.Element {
   const { slug } = Route.useParams();
 
@@ -128,6 +132,21 @@ function ThemeDetailPage(): JSX.Element {
               <span className="rounded bg-primary/10 px-2 py-0.5 text-xs text-primary">
                 Latest {theme.latestVersion}
               </span>
+            )}
+          </div>
+          <div
+            className="mt-6 flex flex-wrap items-center justify-center gap-3 animate-blur-in"
+            style={{ animationDelay: "250ms" }}
+          >
+            <Button asChild>
+              <a href={buildThemeInstallHref(theme.slug)}>Install in Termy</a>
+            </Button>
+            {latestFileUrl && (
+              <Button asChild variant="outline">
+                <a href={latestFileUrl} target="_blank" rel="noreferrer">
+                  Download JSON
+                </a>
+              </Button>
             )}
           </div>
         </div>

--- a/site/src/routes/themes/index.tsx
+++ b/site/src/routes/themes/index.tsx
@@ -16,6 +16,10 @@ export const Route = createFileRoute("/themes/")({
   component: ThemeStorePage,
 });
 
+function buildThemeInstallHref(slug: string): string {
+  return `termy://store/theme-install?slug=${encodeURIComponent(slug)}`;
+}
+
 function ThemeColorSwatch({ fileUrl }: { fileUrl: string | null }): JSX.Element {
   const [palette, setPalette] = useState<ThemePalette | null>(null);
   const [loading, setLoading] = useState(true);
@@ -161,39 +165,46 @@ function ThemeStorePage(): JSX.Element {
         {/* Theme cards */}
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {themes.map((theme, i) => (
-            <Link
+            <div
               key={theme.id}
-              to="/themes/$slug"
-              params={{ slug: theme.slug }}
               className="animate-blur-in group flex flex-col rounded-xl border border-border/40 bg-card/30 transition-all duration-300 hover:border-primary/20 hover:bg-card/60 overflow-hidden"
               style={{ animationDelay: `${(i + 1) * 100}ms` }}
             >
-              {/* Swatch mockup area */}
-              <ThemeColorSwatch fileUrl={theme.fileUrl} />
+              <Link
+                to="/themes/$slug"
+                params={{ slug: theme.slug }}
+                className="flex flex-col"
+              >
+                <ThemeColorSwatch fileUrl={theme.fileUrl} />
 
-              {/* Divider */}
-              <div className="mx-4 sm:mx-5 border-t border-border/30" />
+                <div className="mx-4 sm:mx-5 border-t border-border/30" />
 
-              {/* Text content */}
-              <div className="p-4 sm:p-5 mt-auto flex flex-col gap-2">
-                <div className="flex items-center justify-between gap-2">
-                  <h3 className="text-[15px] font-semibold text-foreground leading-tight truncate">
-                    {theme.name}
-                  </h3>
-                  {theme.latestVersion && (
-                    <span className="shrink-0 rounded bg-primary/10 px-2 py-0.5 text-xs text-primary">
-                      {theme.latestVersion}
-                    </span>
-                  )}
+                <div className="p-4 sm:p-5 mt-auto flex flex-col gap-2">
+                  <div className="flex items-center justify-between gap-2">
+                    <h3 className="text-[15px] font-semibold text-foreground leading-tight truncate">
+                      {theme.name}
+                    </h3>
+                    {theme.latestVersion && (
+                      <span className="shrink-0 rounded bg-primary/10 px-2 py-0.5 text-xs text-primary">
+                        {theme.latestVersion}
+                      </span>
+                    )}
+                  </div>
+                  <p className="line-clamp-2 text-sm text-muted-foreground/80 leading-relaxed">
+                    {theme.description || "No description provided."}
+                  </p>
+                  <span className="text-[11px] text-primary/50 font-mono tracking-wide mt-1">
+                    @{theme.githubUsernameClaim}
+                  </span>
                 </div>
-                <p className="line-clamp-2 text-sm text-muted-foreground/80 leading-relaxed">
-                  {theme.description || "No description provided."}
-                </p>
-                <span className="text-[11px] text-primary/50 font-mono tracking-wide mt-1">
-                  @{theme.githubUsernameClaim}
-                </span>
+              </Link>
+
+              <div className="px-4 pb-4 sm:px-5 sm:pb-5">
+                <Button asChild size="sm" className="w-full">
+                  <a href={buildThemeInstallHref(theme.slug)}>Install</a>
+                </Button>
               </div>
-            </Link>
+            </div>
           ))}
         </div>
 

--- a/src/app_actions.rs
+++ b/src/app_actions.rs
@@ -7,13 +7,13 @@ pub(crate) fn open_config_file() -> Result<(), String> {
     config::open_config_file().map_err(|error| error.to_string())
 }
 
-fn focus_existing_settings_window(cx: &mut App) -> bool {
-    if let Some(settings_window) = cx
+pub(crate) fn focus_existing_window<V: 'static>(cx: &mut App) -> bool {
+    if let Some(window_handle) = cx
         .windows()
         .into_iter()
-        .find_map(|handle| handle.downcast::<SettingsWindow>())
+        .find_map(|handle| handle.downcast::<V>())
     {
-        settings_window
+        window_handle
             .update(cx, |_view, window, _cx| {
                 window.activate_window();
             })
@@ -23,21 +23,34 @@ fn focus_existing_settings_window(cx: &mut App) -> bool {
     }
 }
 
-fn has_settings_window(cx: &App) -> bool {
+pub(crate) fn has_window<V: 'static>(cx: &App) -> bool {
     cx.windows()
         .into_iter()
-        .any(|handle| handle.downcast::<SettingsWindow>().is_some())
+        .any(|handle| handle.downcast::<V>().is_some())
+}
+
+pub(crate) fn update_open_settings_windows(
+    cx: &mut App,
+    mut update: impl FnMut(&mut SettingsWindow, &mut gpui::Context<SettingsWindow>),
+) {
+    for settings_window in cx
+        .windows()
+        .into_iter()
+        .filter_map(|handle| handle.downcast::<SettingsWindow>())
+    {
+        let _ = settings_window.update(cx, |view, _window, cx| update(view, cx));
+    }
 }
 
 pub(crate) fn open_settings_window(cx: &mut App) -> Result<(), String> {
     // Key-repeat and repeated action dispatch should raise the existing settings window,
     // not spawn duplicate windows.
-    if focus_existing_settings_window(cx) {
+    if focus_existing_window::<SettingsWindow>(cx) {
         return Ok(());
     }
     // If a settings window still exists after a failed focus attempt (for example,
     // during a re-entrant update), do not open a duplicate.
-    if has_settings_window(cx) {
+    if has_window::<SettingsWindow>(cx) {
         return Ok(());
     }
 

--- a/src/deeplink.rs
+++ b/src/deeplink.rs
@@ -1,0 +1,148 @@
+use url::Url;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DeepLinkRoute {
+    Activate,
+    Settings,
+    OpenConfig,
+    ThemeInstall,
+}
+
+impl DeepLinkRoute {
+    pub(crate) fn parse(raw: &str) -> Result<(Self, Option<String>), String> {
+        let url = Url::parse(raw).map_err(|error| format!("Invalid Termy deeplink: {error}"))?;
+
+        if url.scheme() != "termy" {
+            return Err(format!(
+                "Unsupported deeplink scheme \"{}\"; expected termy://",
+                url.scheme()
+            ));
+        }
+
+        if !url.username().is_empty() || url.password().is_some() || url.port().is_some() {
+            return Err("Termy deeplinks do not support user info or ports".to_string());
+        }
+
+        let mut segments = Vec::new();
+        if let Some(host) = url.host_str()
+            && !host.is_empty()
+        {
+            segments.push(host);
+        }
+        segments.extend(
+            url.path_segments()
+                .into_iter()
+                .flatten()
+                .filter(|segment| !segment.is_empty()),
+        );
+
+        match segments.as_slice() {
+            [] => Ok((Self::Activate, None)),
+            ["settings"] => Ok((Self::Settings, None)),
+            ["open", "config"] => Ok((Self::OpenConfig, None)),
+            ["store", "theme-install"] => {
+                let slug = url
+                    .query_pairs()
+                    .find_map(|(key, value)| {
+                        (key.eq_ignore_ascii_case("slug") && !value.trim().is_empty())
+                            .then(|| value.into_owned())
+                    })
+                    .ok_or_else(|| {
+                        "Theme install deeplink requires ?slug=<theme-slug>".to_string()
+                    })?;
+                Ok((Self::ThemeInstall, Some(slug)))
+            }
+            _ => Err(format!(
+                "Unsupported Termy deeplink route: {}",
+                segments.join("/")
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DeepLinkRoute, DeepLinkRoute::*};
+
+    #[test]
+    fn parses_bare_scheme_as_activate_route() {
+        assert_eq!(DeepLinkRoute::parse("termy://"), Ok((Activate, None)));
+        assert_eq!(DeepLinkRoute::parse("termy:///"), Ok((Activate, None)));
+    }
+
+    #[test]
+    fn parses_settings_route() {
+        assert_eq!(
+            DeepLinkRoute::parse("termy://settings"),
+            Ok((Settings, None))
+        );
+        assert_eq!(
+            DeepLinkRoute::parse("termy:///settings"),
+            Ok((Settings, None))
+        );
+        assert_eq!(
+            DeepLinkRoute::parse("termy://settings?tab=general#section"),
+            Ok((Settings, None))
+        );
+    }
+
+    #[test]
+    fn parses_open_config_route() {
+        assert_eq!(
+            DeepLinkRoute::parse("termy://open/config"),
+            Ok((OpenConfig, None))
+        );
+        assert_eq!(
+            DeepLinkRoute::parse("termy:///open/config"),
+            Ok((OpenConfig, None))
+        );
+        assert_eq!(
+            DeepLinkRoute::parse("termy://open/config?source=browser#top"),
+            Ok((OpenConfig, None))
+        );
+    }
+
+    #[test]
+    fn parses_theme_install_route() {
+        assert_eq!(
+            DeepLinkRoute::parse("termy://store/theme-install?slug=catppuccin-mocha"),
+            Ok((ThemeInstall, Some("catppuccin-mocha".to_string())))
+        );
+    }
+
+    #[test]
+    fn rejects_theme_install_without_slug() {
+        let error = DeepLinkRoute::parse("termy://store/theme-install")
+            .expect_err("theme install without slug should be rejected");
+        assert!(error.contains("requires ?slug"));
+    }
+
+    #[test]
+    fn rejects_wrong_scheme() {
+        let error =
+            DeepLinkRoute::parse("https://settings").expect_err("scheme should be rejected");
+        assert!(error.contains("Unsupported deeplink scheme"));
+    }
+
+    #[test]
+    fn rejects_unknown_route() {
+        let error =
+            DeepLinkRoute::parse("termy://workspace").expect_err("route should be rejected");
+        assert!(error.contains("Unsupported Termy deeplink route"));
+    }
+
+    #[test]
+    fn parses_bare_scheme_with_query_and_fragment_as_activate_route() {
+        assert_eq!(
+            DeepLinkRoute::parse("termy://?source=browser#noop"),
+            Ok((Activate, None))
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_url() {
+        let error =
+            DeepLinkRoute::parse("termy://[").expect_err("malformed deeplink should be rejected");
+        assert!(error.contains("Invalid Termy deeplink"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod app_actions;
 mod colors;
 mod commands;
 mod config;
+mod deeplink;
 mod keybindings;
 mod menus;
 mod plugins;
@@ -11,10 +12,13 @@ mod settings_view;
 mod startup;
 mod terminal_view;
 mod text_input;
+mod theme_store;
 mod ui;
 
 use commands::{OpenConfig, OpenSettings};
-use gpui::{App, Application, Bounds, WindowBounds, WindowOptions, prelude::*, px, size};
+use deeplink::DeepLinkRoute;
+use flume::Receiver;
+use gpui::{App, Application, AsyncApp, Bounds, WindowBounds, WindowOptions, prelude::*, px, size};
 use startup::StartupBlocker;
 use terminal_view::{TerminalView, initial_window_background_appearance};
 #[cfg(any(target_os = "macos", target_os = "linux"))]
@@ -158,15 +162,156 @@ fn reopen_main_window(cx: &mut App) {
     }
 }
 
+fn focus_or_open_main_window<V: 'static>(
+    cx: &mut App,
+    mut open_window: impl FnMut(&mut App),
+) -> bool {
+    if app_actions::focus_existing_window::<V>(cx) {
+        return false;
+    }
+
+    if app_actions::has_window::<V>(cx) {
+        return false;
+    }
+
+    open_window(cx);
+    true
+}
+
+fn start_theme_install_from_deeplink(cx: &mut App, slug: String) {
+    let loading_id = termy_toast::loading(format!("Fetching theme \"{slug}\"..."));
+
+    cx.spawn(async move |cx: &mut AsyncApp| {
+        let fetch_result = cx
+            .background_executor()
+            .spawn(async move { theme_store::fetch_theme_for_deeplink_blocking(&slug) })
+            .await;
+
+        termy_toast::dismiss_toast(loading_id);
+
+        match fetch_result {
+            Ok(theme) => {
+                let title = "Install Theme";
+                let message = format!(
+                    "Install theme \"{}\" and import its colors into your config?",
+                    theme.name
+                );
+                if !termy_native_sdk::confirm(title, &message) {
+                    return;
+                }
+
+                let install_loading_id =
+                    termy_toast::loading(format!("Installing {}...", theme.name));
+                let install_result = cx
+                    .background_executor()
+                    .spawn(async move { theme_store::install_theme_from_store_blocking(theme) })
+                    .await;
+                termy_toast::dismiss_toast(install_loading_id);
+
+                cx.update(|cx| match install_result {
+                    Ok(installed_theme) => {
+                        termy_toast::success(installed_theme.message.clone());
+                        app_actions::update_open_settings_windows(cx, |view, settings_cx| {
+                            view.apply_theme_store_install(
+                                &installed_theme.slug,
+                                &installed_theme.version,
+                                settings_cx,
+                            );
+                        });
+                    }
+                    Err(error) => {
+                        log::error!("Failed to install theme from deeplink: {error}");
+                        termy_toast::error(error);
+                    }
+                });
+            }
+            Err(error) => {
+                log::error!("Failed to fetch theme from deeplink: {error}");
+                termy_toast::error(error);
+            }
+        }
+    })
+    .detach();
+}
+
+fn dispatch_deeplink(
+    cx: &mut App,
+    route: DeepLinkRoute,
+    route_argument: Option<String>,
+) -> Result<(), String> {
+    match route {
+        DeepLinkRoute::Activate => Ok(()),
+        DeepLinkRoute::Settings => app_actions::open_settings_window(cx),
+        DeepLinkRoute::OpenConfig => app_actions::open_config_file(),
+        DeepLinkRoute::ThemeInstall => {
+            let slug = route_argument
+                .filter(|value| !value.trim().is_empty())
+                .ok_or_else(|| "Theme install deeplink requires a slug".to_string())?;
+            start_theme_install_from_deeplink(cx, slug);
+            Ok(())
+        }
+    }
+}
+
+fn handle_open_urls_with_main_window<V: 'static>(
+    cx: &mut App,
+    urls: &[String],
+    mut open_window: impl FnMut(&mut App),
+    mut dispatch: impl FnMut(&mut App, DeepLinkRoute, Option<String>) -> Result<(), String>,
+) {
+    for raw_url in urls {
+        match DeepLinkRoute::parse(raw_url) {
+            Ok((route, route_argument)) => {
+                log::info!("Handling deeplink: {raw_url}");
+                let _ = focus_or_open_main_window::<V>(cx, &mut open_window);
+                if let Err(error) = dispatch(cx, route, route_argument) {
+                    log::error!("Failed to handle deeplink {raw_url}: {error}");
+                    termy_toast::error(error);
+                }
+            }
+            Err(error) => {
+                log::warn!("Rejected deeplink {raw_url}: {error}");
+                termy_toast::error(error);
+            }
+        }
+    }
+}
+
+fn handle_open_urls(cx: &mut App, urls: &[String]) {
+    handle_open_urls_with_main_window::<TerminalView>(
+        cx,
+        urls,
+        reopen_main_window,
+        dispatch_deeplink,
+    );
+}
+
+fn spawn_deeplink_listener(cx: &mut App, deeplink_rx: Receiver<Vec<String>>) {
+    cx.spawn(async move |cx: &mut AsyncApp| {
+        while let Ok(urls) = deeplink_rx.recv_async().await {
+            cx.update(|cx| handle_open_urls(cx, &urls));
+        }
+    })
+    .detach();
+}
+
 fn main() {
     env_logger::init();
 
+    let (deeplink_tx, deeplink_rx) = flume::unbounded::<Vec<String>>();
     let application = Application::new();
     application.on_reopen(|cx| {
         let _ = reopen_if_no_windows(cx, reopen_main_window);
     });
+    application.on_open_urls(move |urls| {
+        if let Err(error) = deeplink_tx.send(urls) {
+            log::error!("Failed to enqueue deeplink event: {error}");
+        }
+    });
 
-    application.run(|cx: &mut App| {
+    application.run(move |cx: &mut App| {
+        spawn_deeplink_listener(cx, deeplink_rx);
+
         cx.on_action(|_: &OpenConfig, _cx| {
             if let Err(error) = app_actions::open_config_file() {
                 log::error!("Failed to open config file: {}", error);
@@ -203,10 +348,15 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
-    use super::reopen_if_no_windows;
+    use super::{
+        DeepLinkRoute, focus_or_open_main_window, handle_open_urls_with_main_window,
+        reopen_if_no_windows,
+    };
+    use crate::app_actions;
     use gpui::{
         App, AppContext, Context, IntoElement, Render, TestAppContext, Window, WindowOptions, div,
     };
+    use std::cell::RefCell;
 
     struct ReopenTestView;
 
@@ -248,5 +398,124 @@ mod tests {
             "expected reopen hook to be skipped when a window already exists"
         );
         assert_eq!(cx.windows().len(), 1);
+    }
+
+    #[gpui::test]
+    fn focus_or_open_main_window_opens_when_missing(cx: &mut TestAppContext) {
+        assert_eq!(cx.windows().len(), 0);
+
+        let opened =
+            cx.update(|app| focus_or_open_main_window::<ReopenTestView>(app, open_test_window));
+
+        assert!(opened, "expected missing window to be opened");
+        assert_eq!(cx.windows().len(), 1);
+    }
+
+    #[gpui::test]
+    fn focus_or_open_main_window_reuses_existing_window(cx: &mut TestAppContext) {
+        cx.update(open_test_window);
+        assert_eq!(cx.windows().len(), 1);
+
+        let opened =
+            cx.update(|app| focus_or_open_main_window::<ReopenTestView>(app, open_test_window));
+
+        assert!(
+            !opened,
+            "expected existing main window to be reused without opening another"
+        );
+        assert_eq!(cx.windows().len(), 1);
+    }
+
+    #[gpui::test]
+    fn handle_open_urls_opens_window_before_dispatch(cx: &mut TestAppContext) {
+        let handled = RefCell::new(Vec::new());
+
+        cx.update(|app| {
+            handle_open_urls_with_main_window::<ReopenTestView>(
+                app,
+                &[String::from("termy://settings")],
+                open_test_window,
+                |_, route, route_argument| {
+                    handled.borrow_mut().push((route, route_argument));
+                    Ok(())
+                },
+            );
+        });
+
+        assert_eq!(cx.windows().len(), 1);
+        assert_eq!(*handled.borrow(), vec![(DeepLinkRoute::Settings, None)]);
+    }
+
+    #[gpui::test]
+    fn bare_deeplink_opens_window_without_error_route(cx: &mut TestAppContext) {
+        let handled = RefCell::new(Vec::new());
+
+        cx.update(|app| {
+            handle_open_urls_with_main_window::<ReopenTestView>(
+                app,
+                &[String::from("termy://")],
+                open_test_window,
+                |_, route, route_argument| {
+                    handled.borrow_mut().push((route, route_argument));
+                    Ok(())
+                },
+            );
+        });
+
+        assert_eq!(cx.windows().len(), 1);
+        assert_eq!(*handled.borrow(), vec![(DeepLinkRoute::Activate, None)]);
+    }
+
+    #[gpui::test]
+    fn theme_install_deeplink_passes_slug_argument(cx: &mut TestAppContext) {
+        let handled = RefCell::new(Vec::new());
+
+        cx.update(|app| {
+            handle_open_urls_with_main_window::<ReopenTestView>(
+                app,
+                &[String::from(
+                    "termy://store/theme-install?slug=catppuccin-mocha",
+                )],
+                open_test_window,
+                |_, route, route_argument| {
+                    handled.borrow_mut().push((route, route_argument));
+                    Ok(())
+                },
+            );
+        });
+
+        assert_eq!(cx.windows().len(), 1);
+        assert_eq!(
+            *handled.borrow(),
+            vec![(
+                DeepLinkRoute::ThemeInstall,
+                Some("catppuccin-mocha".to_string())
+            )]
+        );
+    }
+
+    #[gpui::test]
+    fn settings_deeplink_reuses_existing_settings_window(cx: &mut TestAppContext) {
+        cx.update(|app| {
+            app_actions::open_settings_window(app).expect("settings window should open");
+            handle_open_urls_with_main_window::<ReopenTestView>(
+                app,
+                &[String::from("termy://settings")],
+                open_test_window,
+                super::dispatch_deeplink,
+            );
+        });
+
+        let settings_count = cx
+            .windows()
+            .into_iter()
+            .filter(|handle| {
+                handle
+                    .downcast::<crate::settings_view::SettingsWindow>()
+                    .is_some()
+            })
+            .count();
+
+        assert_eq!(settings_count, 1);
     }
 }

--- a/src/settings_view/mod.rs
+++ b/src/settings_view/mod.rs
@@ -2,6 +2,7 @@ use crate::colors::TerminalColors;
 use crate::config::{self, AiProvider as ConfigAiProvider, AppConfig};
 use crate::plugins::{self, PluginInventoryEntry};
 use crate::text_input::{TextInputAlignment, TextInputElement, TextInputProvider, TextInputState};
+use crate::theme_store::{self, ThemeStoreTheme};
 use crate::ui::scrollbar::{self as ui_scrollbar, ScrollbarPaintStyle, ScrollbarRange};
 use gpui::{
     AnyElement, AsyncApp, Context, FocusHandle, Font, InteractiveElement, IntoElement,
@@ -11,7 +12,6 @@ use gpui::{
     prelude::FluentBuilder, px,
 };
 use std::collections::HashMap;
-use std::io::Write;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::sync::LazyLock;
@@ -60,8 +60,6 @@ const SETTINGS_SLIDER_VALUE_WIDTH: f32 = 60.0;
 const SETTINGS_OPACITY_STEP_RATIO: f32 = 0.05;
 const SETTINGS_CONTROL_INNER_PADDING: f32 = 8.0;
 const SETTINGS_OPACITY_CONTROL_GAP: f32 = 6.0;
-const DEFAULT_THEME_STORE_API_URL: &str = "https://api.termy.run";
-
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum SettingsSection {
     Appearance,
@@ -72,15 +70,6 @@ enum SettingsSection {
     Advanced,
     Colors,
     Keybindings,
-}
-
-#[derive(Clone, Debug)]
-struct ThemeStoreTheme {
-    name: String,
-    slug: String,
-    description: String,
-    latest_version: Option<String>,
-    file_url: Option<String>,
 }
 
 pub struct SettingsWindow {
@@ -179,7 +168,7 @@ impl SettingsWindow {
             theme_store_loaded: false,
             theme_store_loading: false,
             theme_store_error: None,
-            theme_store_installed_versions: Self::load_installed_theme_versions(),
+            theme_store_installed_versions: theme_store::load_installed_theme_versions(),
             plugin_directory,
             plugin_inventory,
             plugin_inventory_error,
@@ -232,7 +221,7 @@ impl SettingsWindow {
     }
 
     fn theme_store_api_base_url() -> String {
-        std::env::var("THEME_STORE_API_URL").unwrap_or_else(|_| DEFAULT_THEME_STORE_API_URL.into())
+        theme_store::theme_store_api_base_url()
     }
 
     fn load_plugin_inventory() -> (Option<PathBuf>, Vec<PluginInventoryEntry>, Option<String>) {
@@ -267,7 +256,8 @@ impl SettingsWindow {
 
         cx.spawn(async move |this: WeakEntity<Self>, cx: &mut AsyncApp| {
             let result =
-                smol::unblock(move || Self::fetch_theme_store_themes_blocking(&api_base)).await;
+                smol::unblock(move || theme_store::fetch_theme_store_themes_blocking(&api_base))
+                    .await;
 
             let _ = cx.update(|cx| {
                 this.update(cx, |view, cx| {
@@ -291,135 +281,6 @@ impl SettingsWindow {
         .detach();
     }
 
-    fn fetch_theme_store_themes_blocking(api_base: &str) -> Result<Vec<ThemeStoreTheme>, String> {
-        let base = api_base.trim_end_matches('/');
-        let url = format!("{base}/themes");
-        let response = ureq::get(&url)
-            .set("Accept", "application/json")
-            .call()
-            .map_err(|error| format!("Failed to fetch store themes: {error}"))?;
-
-        let payload: serde_json::Value = response
-            .into_json()
-            .map_err(|error| format!("Invalid theme store response: {error}"))?;
-
-        let themes = payload
-            .as_array()
-            .ok_or_else(|| "Theme store response must be a JSON array".to_string())?;
-
-        let mut parsed = Vec::with_capacity(themes.len());
-        for theme in themes {
-            let Some(object) = theme.as_object() else {
-                continue;
-            };
-
-            let Some(name) = object
-                .get("name")
-                .and_then(|value| value.as_str())
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-            else {
-                continue;
-            };
-            let Some(slug) = object
-                .get("slug")
-                .and_then(|value| value.as_str())
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-            else {
-                continue;
-            };
-
-            let description = object
-                .get("description")
-                .and_then(|value| value.as_str())
-                .unwrap_or_default()
-                .to_string();
-            let latest_version = object
-                .get("latestVersion")
-                .and_then(|value| value.as_str())
-                .map(ToString::to_string);
-            let file_url = object
-                .get("fileUrl")
-                .and_then(|value| value.as_str())
-                .map(ToString::to_string);
-
-            parsed.push(ThemeStoreTheme {
-                name: name.to_string(),
-                slug: slug.to_string(),
-                description,
-                latest_version,
-                file_url,
-            });
-        }
-
-        parsed.sort_unstable_by(|left, right| {
-            left.name
-                .to_ascii_lowercase()
-                .cmp(&right.name.to_ascii_lowercase())
-        });
-        Ok(parsed)
-    }
-
-    fn installed_theme_state_path() -> Option<PathBuf> {
-        let config_path = config::ensure_config_file().ok()?;
-        let parent = config_path.parent()?;
-        Some(parent.join("theme_store_installed.json"))
-    }
-
-    fn load_installed_theme_versions() -> HashMap<String, String> {
-        let Some(path) = Self::installed_theme_state_path() else {
-            return HashMap::new();
-        };
-        let Ok(contents) = std::fs::read_to_string(&path) else {
-            return HashMap::new();
-        };
-
-        if let Ok(parsed_map) = serde_json::from_str::<HashMap<String, String>>(&contents) {
-            return parsed_map
-                .into_iter()
-                .map(|(slug, version)| {
-                    (slug.trim().to_ascii_lowercase(), version.trim().to_string())
-                })
-                .filter(|(slug, _)| !slug.is_empty())
-                .collect();
-        }
-
-        // Backward compatibility with older JSON array format.
-        if let Ok(parsed_list) = serde_json::from_str::<Vec<String>>(&contents) {
-            return parsed_list
-                .into_iter()
-                .map(|slug| (slug.trim().to_ascii_lowercase(), String::new()))
-                .filter(|(slug, _)| !slug.is_empty())
-                .collect();
-        }
-
-        HashMap::new()
-    }
-
-    fn persist_installed_theme_versions(versions: &HashMap<String, String>) -> Result<(), String> {
-        let Some(path) = Self::installed_theme_state_path() else {
-            return Err("Config path unavailable".to_string());
-        };
-        let Some(parent) = path.parent() else {
-            return Err("Invalid installed-theme metadata path".to_string());
-        };
-        std::fs::create_dir_all(parent)
-            .map_err(|error| format!("Failed to create metadata directory: {error}"))?;
-
-        let mut sorted_entries: Vec<(String, String)> = versions
-            .iter()
-            .map(|(slug, version)| (slug.clone(), version.clone()))
-            .collect();
-        sorted_entries.sort_unstable_by(|left, right| left.0.cmp(&right.0));
-        let normalized: HashMap<String, String> = sorted_entries.into_iter().collect();
-        let contents = serde_json::to_string_pretty(&normalized)
-            .map_err(|error| format!("Failed to serialize installed themes: {error}"))?;
-        std::fs::write(&path, contents)
-            .map_err(|error| format!("Failed to write installed themes metadata: {error}"))?;
-        Ok(())
-    }
-
     fn install_theme_store_theme(&mut self, theme: ThemeStoreTheme, cx: &mut Context<Self>) {
         let installed_slug = theme.slug.trim().to_ascii_lowercase();
         let installed_version = theme.latest_version.clone().unwrap_or_default();
@@ -427,20 +288,20 @@ impl SettingsWindow {
 
         cx.spawn(async move |this: WeakEntity<Self>, cx: &mut AsyncApp| {
             let result =
-                smol::unblock(move || Self::install_theme_from_store_blocking(theme)).await;
+                smol::unblock(move || theme_store::install_theme_from_store_blocking(theme)).await;
 
             termy_toast::dismiss_toast(loading_id);
 
             let _ = cx.update(|cx| {
                 this.update(cx, |view, cx| {
                     match result {
-                        Ok(message) => {
-                            termy_toast::success(message);
+                        Ok(installed_theme) => {
+                            termy_toast::success(installed_theme.message);
                             // Keep a single installed store theme marker at a time.
                             view.theme_store_installed_versions.clear();
                             view.theme_store_installed_versions
                                 .insert(installed_slug.clone(), installed_version.clone());
-                            if let Err(error) = Self::persist_installed_theme_versions(
+                            if let Err(error) = theme_store::persist_installed_theme_versions(
                                 &view.theme_store_installed_versions,
                             ) {
                                 log::error!("Failed to persist installed theme state: {}", error);
@@ -495,7 +356,7 @@ impl SettingsWindow {
                 return;
             }
             if let Err(error) =
-                Self::persist_installed_theme_versions(&self.theme_store_installed_versions)
+                theme_store::persist_installed_theme_versions(&self.theme_store_installed_versions)
             {
                 log::error!("Failed to persist installed theme state: {}", error);
                 termy_toast::error("Failed to persist uninstall state");
@@ -508,27 +369,16 @@ impl SettingsWindow {
         }
     }
 
-    fn install_theme_from_store_blocking(theme: ThemeStoreTheme) -> Result<String, String> {
-        let file_url = theme
-            .file_url
-            .ok_or_else(|| format!("Theme '{}' has no downloadable file URL", theme.slug))?;
-
-        let response = ureq::get(&file_url)
-            .set("Accept", "application/json")
-            .call()
-            .map_err(|error| format!("Failed to download theme '{}': {error}", theme.slug))?;
-        let contents = response
-            .into_string()
-            .map_err(|error| format!("Failed to read theme '{}': {error}", theme.slug))?;
-
-        let mut file =
-            tempfile::NamedTempFile::new().map_err(|error| format!("Temp file error: {error}"))?;
-        file.write_all(contents.as_bytes())
-            .map_err(|error| format!("Failed to write temp theme file: {error}"))?;
-
-        config::import_colors_from_json(file.path())
-            .map(|_| format!("Installed theme '{}'", theme.name))
-            .map_err(|error| format!("Failed to install theme '{}': {error}", theme.name))
+    pub(crate) fn apply_theme_store_install(
+        &mut self,
+        slug: &str,
+        version: &str,
+        cx: &mut Context<Self>,
+    ) {
+        self.theme_store_installed_versions.clear();
+        self.theme_store_installed_versions
+            .insert(slug.trim().to_ascii_lowercase(), version.to_string());
+        cx.notify();
     }
 
     pub(super) fn open_url(url: &str) -> Result<(), String> {

--- a/src/terminal_view/tab_strip/hints.rs
+++ b/src/terminal_view/tab_strip/hints.rs
@@ -38,7 +38,8 @@ impl TabSwitchHintState {
     }
 
     pub(crate) fn reset_hold_state(&mut self) -> bool {
-        let changed = self.modifier_held || self.hold_started_at.is_some() || self.suppressed_for_hold;
+        let changed =
+            self.modifier_held || self.hold_started_at.is_some() || self.suppressed_for_hold;
         self.modifier_held = false;
         self.hold_started_at = None;
         self.suppressed_for_hold = false;
@@ -58,11 +59,7 @@ impl TabSwitchHintState {
         index < TAB_SWITCH_HINTED_TAB_COUNT
     }
 
-    pub(crate) fn handle_modifiers_changed(
-        &mut self,
-        modifiers: Modifiers,
-        now: Instant,
-    ) -> bool {
+    pub(crate) fn handle_modifiers_changed(&mut self, modifiers: Modifiers, now: Instant) -> bool {
         if !self.enabled {
             return self.reset_hold_state();
         }
@@ -207,10 +204,8 @@ impl TabSwitchHintState {
             return 1.0;
         }
 
-        ease_out_cubic(
-            fade_elapsed.as_secs_f32() / TAB_SWITCH_HINT_FADE_DURATION.as_secs_f32(),
-        )
-        .clamp(0.0, 1.0)
+        ease_out_cubic(fade_elapsed.as_secs_f32() / TAB_SWITCH_HINT_FADE_DURATION.as_secs_f32())
+            .clamp(0.0, 1.0)
     }
 }
 
@@ -225,7 +220,9 @@ mod tests {
     #[test]
     fn secondary_modifier_requires_secondary_only() {
         let secondary_only = Modifiers::secondary_key();
-        assert!(TabSwitchHintState::secondary_modifier_held_alone(secondary_only));
+        assert!(TabSwitchHintState::secondary_modifier_held_alone(
+            secondary_only
+        ));
 
         let secondary_with_shift = Modifiers {
             shift: true,
@@ -268,11 +265,19 @@ mod tests {
     fn labels_cover_first_nine_tabs_only() {
         assert_eq!(
             TabSwitchHintState::label_for_index(0).as_deref(),
-            Some(if cfg!(target_os = "macos") { "⌘1" } else { "⌃1" })
+            Some(if cfg!(target_os = "macos") {
+                "⌘1"
+            } else {
+                "⌃1"
+            })
         );
         assert_eq!(
             TabSwitchHintState::label_for_index(8).as_deref(),
-            Some(if cfg!(target_os = "macos") { "⌘9" } else { "⌃9" })
+            Some(if cfg!(target_os = "macos") {
+                "⌘9"
+            } else {
+                "⌃9"
+            })
         );
         assert_eq!(TabSwitchHintState::label_for_index(9), None);
     }
@@ -298,12 +303,7 @@ mod tests {
         let visible_at = now + TAB_SWITCH_HINT_HOLD_DELAY + TAB_SWITCH_HINT_FADE_DURATION;
 
         assert!(state.progress(visible_at, false) > 0.0);
-        assert!(state.suppress_for_key_down(
-            "k",
-            Modifiers::secondary_key(),
-            false,
-            visible_at
-        ));
+        assert!(state.suppress_for_key_down("k", Modifiers::secondary_key(), false, visible_at));
         assert_eq!(state.progress(visible_at, false), 0.0);
     }
 
@@ -314,11 +314,7 @@ mod tests {
         state.handle_modifiers_changed(Modifiers::secondary_key(), now);
         let visible_at = now + TAB_SWITCH_HINT_HOLD_DELAY + TAB_SWITCH_HINT_FADE_DURATION;
 
-        assert!(!state.suppress_for_action(
-            CommandAction::SwitchToTab4,
-            false,
-            visible_at
-        ));
+        assert!(!state.suppress_for_action(CommandAction::SwitchToTab4, false, visible_at));
         assert!(state.progress(visible_at, false) > 0.0);
     }
 

--- a/src/terminal_view/tab_strip/render.rs
+++ b/src/terminal_view/tab_strip/render.rs
@@ -168,7 +168,6 @@ mod tests {
         assert!(!collisions.left);
         assert!(!collisions.right);
     }
-
 }
 
 struct TabStripRenderState {

--- a/src/theme_store.rs
+++ b/src/theme_store.rs
@@ -1,0 +1,222 @@
+use crate::config;
+use std::collections::HashMap;
+use std::io::Write;
+use std::path::PathBuf;
+
+const DEFAULT_THEME_STORE_API_URL: &str = "https://api.termy.run";
+const DEFAULT_THEME_DEEPLINK_API_URL: &str = "https://termy.run/theme-api";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ThemeStoreTheme {
+    pub(crate) name: String,
+    pub(crate) slug: String,
+    pub(crate) description: String,
+    pub(crate) latest_version: Option<String>,
+    pub(crate) file_url: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct InstalledTheme {
+    pub(crate) slug: String,
+    pub(crate) version: String,
+    pub(crate) message: String,
+}
+
+pub(crate) fn theme_store_api_base_url() -> String {
+    std::env::var("THEME_STORE_API_URL").unwrap_or_else(|_| DEFAULT_THEME_STORE_API_URL.into())
+}
+
+pub(crate) fn fetch_theme_store_themes_blocking(
+    api_base: &str,
+) -> Result<Vec<ThemeStoreTheme>, String> {
+    let base = api_base.trim_end_matches('/');
+    let url = format!("{base}/themes");
+    let response = ureq::get(&url)
+        .set("Accept", "application/json")
+        .call()
+        .map_err(|error| format!("Failed to fetch store themes: {error}"))?;
+
+    let payload: serde_json::Value = response
+        .into_json()
+        .map_err(|error| format!("Invalid theme store response: {error}"))?;
+
+    let themes = payload
+        .as_array()
+        .ok_or_else(|| "Theme store response must be a JSON array".to_string())?;
+
+    let mut parsed = Vec::with_capacity(themes.len());
+    for theme in themes {
+        if let Some(parsed_theme) = parse_theme_value(theme) {
+            parsed.push(parsed_theme);
+        }
+    }
+
+    parsed.sort_unstable_by(|left, right| {
+        left.name
+            .to_ascii_lowercase()
+            .cmp(&right.name.to_ascii_lowercase())
+    });
+    Ok(parsed)
+}
+
+pub(crate) fn fetch_theme_for_deeplink_blocking(slug: &str) -> Result<ThemeStoreTheme, String> {
+    let slug = normalize_slug(slug)?;
+    let base = std::env::var("THEME_STORE_DEEPLINK_API_URL")
+        .unwrap_or_else(|_| DEFAULT_THEME_DEEPLINK_API_URL.into());
+    let url = format!("{}/themes/{}", base.trim_end_matches('/'), slug);
+    let response = ureq::get(&url)
+        .set("Accept", "application/json")
+        .call()
+        .map_err(|error| format!("Failed to fetch theme '{slug}': {error}"))?;
+
+    let payload: serde_json::Value = response
+        .into_json()
+        .map_err(|error| format!("Invalid theme response for '{slug}': {error}"))?;
+
+    parse_theme_value(&payload)
+        .ok_or_else(|| format!("Theme response for '{slug}' is missing required fields"))
+}
+
+pub(crate) fn load_installed_theme_versions() -> HashMap<String, String> {
+    let Some(path) = installed_theme_state_path() else {
+        return HashMap::new();
+    };
+    let Ok(contents) = std::fs::read_to_string(&path) else {
+        return HashMap::new();
+    };
+
+    if let Ok(parsed_map) = serde_json::from_str::<HashMap<String, String>>(&contents) {
+        return parsed_map
+            .into_iter()
+            .map(|(slug, version)| (slug.trim().to_ascii_lowercase(), version.trim().to_string()))
+            .filter(|(slug, _)| !slug.is_empty())
+            .collect();
+    }
+
+    if let Ok(parsed_list) = serde_json::from_str::<Vec<String>>(&contents) {
+        return parsed_list
+            .into_iter()
+            .map(|slug| (slug.trim().to_ascii_lowercase(), String::new()))
+            .filter(|(slug, _)| !slug.is_empty())
+            .collect();
+    }
+
+    HashMap::new()
+}
+
+pub(crate) fn persist_installed_theme_versions(
+    versions: &HashMap<String, String>,
+) -> Result<(), String> {
+    let Some(path) = installed_theme_state_path() else {
+        return Err("Config path unavailable".to_string());
+    };
+    let Some(parent) = path.parent() else {
+        return Err("Invalid installed-theme metadata path".to_string());
+    };
+    std::fs::create_dir_all(parent)
+        .map_err(|error| format!("Failed to create metadata directory: {error}"))?;
+
+    let mut sorted_entries: Vec<(String, String)> = versions
+        .iter()
+        .map(|(slug, version)| (slug.clone(), version.clone()))
+        .collect();
+    sorted_entries.sort_unstable_by(|left, right| left.0.cmp(&right.0));
+    let normalized: HashMap<String, String> = sorted_entries.into_iter().collect();
+    let contents = serde_json::to_string_pretty(&normalized)
+        .map_err(|error| format!("Failed to serialize installed themes: {error}"))?;
+    std::fs::write(&path, contents)
+        .map_err(|error| format!("Failed to write installed themes metadata: {error}"))?;
+    Ok(())
+}
+
+pub(crate) fn install_theme_from_store_blocking(
+    theme: ThemeStoreTheme,
+) -> Result<InstalledTheme, String> {
+    let file_url = theme
+        .file_url
+        .clone()
+        .ok_or_else(|| format!("Theme '{}' has no downloadable file URL", theme.slug))?;
+
+    let response = ureq::get(&file_url)
+        .set("Accept", "application/json")
+        .call()
+        .map_err(|error| format!("Failed to download theme '{}': {error}", theme.slug))?;
+    let contents = response
+        .into_string()
+        .map_err(|error| format!("Failed to read theme '{}': {error}", theme.slug))?;
+
+    let mut file =
+        tempfile::NamedTempFile::new().map_err(|error| format!("Temp file error: {error}"))?;
+    file.write_all(contents.as_bytes())
+        .map_err(|error| format!("Failed to write temp theme file: {error}"))?;
+
+    config::import_colors_from_json(file.path())
+        .map_err(|error| format!("Failed to install theme '{}': {error}", theme.name))?;
+
+    let mut installed_versions = HashMap::new();
+    let normalized_slug = theme.slug.trim().to_ascii_lowercase();
+    let installed_version = theme.latest_version.clone().unwrap_or_default();
+    installed_versions.insert(normalized_slug.clone(), installed_version.clone());
+    persist_installed_theme_versions(&installed_versions)?;
+
+    Ok(InstalledTheme {
+        slug: normalized_slug,
+        version: installed_version,
+        message: format!("Installed theme '{}'", theme.name),
+    })
+}
+
+fn installed_theme_state_path() -> Option<PathBuf> {
+    let config_path = config::ensure_config_file().ok()?;
+    let parent = config_path.parent()?;
+    Some(parent.join("theme_store_installed.json"))
+}
+
+fn normalize_slug(slug: &str) -> Result<String, String> {
+    let slug = slug.trim().to_ascii_lowercase();
+    if slug.is_empty() {
+        return Err("Theme install deeplink is missing a slug".to_string());
+    }
+    if !slug.chars().all(|character| {
+        character.is_ascii_lowercase() || character.is_ascii_digit() || character == '-'
+    }) {
+        return Err(format!("Invalid theme slug '{slug}'"));
+    }
+    Ok(slug)
+}
+
+fn parse_theme_value(theme: &serde_json::Value) -> Option<ThemeStoreTheme> {
+    let object = theme.as_object()?;
+    let name = object
+        .get("name")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+    let slug = object
+        .get("slug")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+
+    let description = object
+        .get("description")
+        .and_then(|value| value.as_str())
+        .unwrap_or_default()
+        .to_string();
+    let latest_version = object
+        .get("latestVersion")
+        .and_then(|value| value.as_str())
+        .map(ToString::to_string);
+    let file_url = object
+        .get("fileUrl")
+        .and_then(|value| value.as_str())
+        .map(ToString::to_string);
+
+    Some(ThemeStoreTheme {
+        name: name.to_string(),
+        slug: slug.to_string(),
+        description,
+        latest_version,
+        file_url,
+    })
+}


### PR DESCRIPTION
Summary
- register the termy:// URL scheme on Windows, macOS, and Linux installers/bundles
- add parsing and dispatch logic for settings/open config deeplinks and ensure existing windows are reused when handling them
- provide deeplink helpers in tests
Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom "termy://" URL scheme across Windows, macOS, and Linux platforms
  * Theme store website now includes "Install in Termy" buttons that launch the app and install themes with a single click

<!-- end of auto-generated comment: release notes by coderabbit.ai -->