### PR TITLE
Add support for pasting theme JSON directly

### DIFF
--- a/crates/termy_api/README.md
+++ b/crates/termy_api/README.md
@@ -53,6 +53,9 @@ curl -X POST http://127.0.0.1:8080/themes \
   -F 'themeFile=@./tokyo-night.json;type=application/json'
 ```
 
+You can also paste JSON instead of uploading a file by sending a `themeJson`
+multipart field.
+
 Publish version:
 
 ```bash

--- a/crates/termy_api/src/main.rs
+++ b/crates/termy_api/src/main.rs
@@ -996,6 +996,9 @@ async fn parse_create_theme_upload(
             "githubUsernameClaim" => {
                 github_username_claim = Some(field.text().await.map_err(multipart_error)?);
             }
+            "themeJson" => {
+                theme_json = Some(field.text().await.map_err(multipart_error)?.into_bytes());
+            }
             "themeFile" | "file" => {
                 theme_json = Some(field.bytes().await.map_err(multipart_error)?.to_vec());
             }
@@ -1047,6 +1050,9 @@ async fn parse_publish_theme_version_upload(
             }
             "createdBy" => {
                 created_by = Some(field.text().await.map_err(multipart_error)?);
+            }
+            "themeJson" => {
+                theme_json = Some(field.text().await.map_err(multipart_error)?.into_bytes());
             }
             "themeFile" | "file" => {
                 theme_json = Some(field.bytes().await.map_err(multipart_error)?.to_vec());

--- a/site/src/lib/theme-store.ts
+++ b/site/src/lib/theme-store.ts
@@ -125,14 +125,15 @@ export async function createTheme(input: {
   description: string;
   isPublic: boolean;
   version: string;
-  themeFile: File;
+  themeFile?: File | null;
+  themeJson?: string;
 }): Promise<Theme> {
   const formData = new FormData();
   formData.append("name", input.name);
   formData.append("description", input.description);
   formData.append("isPublic", String(input.isPublic));
   formData.append("version", input.version);
-  formData.append("themeFile", input.themeFile);
+  appendThemePayload(formData, input.themeFile ?? null, input.themeJson);
 
   return requestJson<Theme>("/themes", {
     method: "POST",
@@ -164,14 +165,15 @@ export async function publishThemeVersion(
     version: string;
     changelog: string;
     checksumSha256: string;
-    themeFile: File;
+    themeFile?: File | null;
+    themeJson?: string;
   },
 ): Promise<{ theme: Theme; version: ThemeVersion }> {
   const formData = new FormData();
   formData.append("version", input.version);
   formData.append("changelog", input.changelog);
   formData.append("checksumSha256", input.checksumSha256);
-  formData.append("themeFile", input.themeFile);
+  appendThemePayload(formData, input.themeFile ?? null, input.themeJson);
 
   return requestJson<{ theme: Theme; version: ThemeVersion }>(
     `/themes/${slug}/versions`,
@@ -180,6 +182,23 @@ export async function publishThemeVersion(
       body: formData,
     },
   );
+}
+
+function appendThemePayload(
+  formData: FormData,
+  themeFile: File | null,
+  themeJson?: string,
+): void {
+  const trimmedThemeJson = themeJson?.trim();
+
+  if (trimmedThemeJson) {
+    formData.append("themeJson", trimmedThemeJson);
+    return;
+  }
+
+  if (themeFile) {
+    formData.append("themeFile", themeFile);
+  }
 }
 
 export interface ThemePalette {

--- a/site/src/routes/themes/$slug/update.tsx
+++ b/site/src/routes/themes/$slug/update.tsx
@@ -39,6 +39,7 @@ function ThemeUpdatePage(): JSX.Element {
   const [publishChangelog, setPublishChangelog] = useState("");
   const [publishChecksum, setPublishChecksum] = useState("");
   const [publishThemeFile, setPublishThemeFile] = useState<File | null>(null);
+  const [publishThemeJson, setPublishThemeJson] = useState("");
 
   const [loading, setLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -116,8 +117,8 @@ function ThemeUpdatePage(): JSX.Element {
     if (!theme || !isOwner) {
       return;
     }
-    if (!publishThemeFile) {
-      setError("Theme JSON file is required.");
+    if (!hasThemePayload(publishThemeFile, publishThemeJson)) {
+      setError("Theme JSON file or pasted JSON is required.");
       return;
     }
 
@@ -130,6 +131,7 @@ function ThemeUpdatePage(): JSX.Element {
         changelog: publishChangelog,
         checksumSha256: publishChecksum,
         themeFile: publishThemeFile,
+        themeJson: publishThemeJson,
       });
       setTheme(response.theme);
       setVersions((previous) => [response.version, ...previous]);
@@ -137,6 +139,7 @@ function ThemeUpdatePage(): JSX.Element {
       setPublishChangelog("");
       setPublishChecksum("");
       setPublishThemeFile(null);
+      setPublishThemeJson("");
       setNotice("Version published.");
     } catch (err) {
       setError(getErrorMessage(err));
@@ -213,10 +216,7 @@ function ThemeUpdatePage(): JSX.Element {
         )}
 
         {!user && (
-          <div
-            className="animate-blur-in"
-            style={{ animationDelay: "200ms" }}
-          >
+          <div className="animate-blur-in" style={{ animationDelay: "200ms" }}>
             <Card className="border-border/60">
               <CardHeader>
                 <CardTitle>Authentication Required</CardTitle>
@@ -323,6 +323,19 @@ function ThemeUpdatePage(): JSX.Element {
                     disabled={isSubmitting}
                   />
                   <textarea
+                    className="min-h-48 w-full rounded-lg border border-border bg-background px-3 py-2 font-mono text-sm"
+                    placeholder='Or paste the next theme JSON here, for example: { "background": "#141a24" }'
+                    value={publishThemeJson}
+                    onChange={(event) =>
+                      setPublishThemeJson(event.target.value)
+                    }
+                    disabled={isSubmitting}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Paste JSON or upload a file. Pasted JSON is used when both
+                    are provided.
+                  </p>
+                  <textarea
                     className="min-h-20 w-full rounded-lg border border-border bg-background px-3 py-2 text-sm"
                     placeholder="Changelog"
                     value={publishChangelog}
@@ -335,9 +348,7 @@ function ThemeUpdatePage(): JSX.Element {
                     className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm"
                     placeholder="Checksum SHA256 (optional)"
                     value={publishChecksum}
-                    onChange={(event) =>
-                      setPublishChecksum(event.target.value)
-                    }
+                    onChange={(event) => setPublishChecksum(event.target.value)}
                     disabled={isSubmitting}
                   />
                   <Button type="submit" disabled={isSubmitting}>
@@ -349,10 +360,7 @@ function ThemeUpdatePage(): JSX.Element {
           </div>
         )}
 
-        <div
-          className="animate-blur-in"
-          style={{ animationDelay: "300ms" }}
-        >
+        <div className="animate-blur-in" style={{ animationDelay: "300ms" }}>
           <Card className="border-border/60">
             <CardHeader>
               <CardTitle>Version history</CardTitle>
@@ -393,4 +401,8 @@ function getErrorMessage(error: unknown): string {
   }
 
   return "Unexpected error";
+}
+
+function hasThemePayload(themeFile: File | null, themeJson: string): boolean {
+  return themeFile !== null || themeJson.trim().length > 0;
 }

--- a/site/src/routes/themes/add.tsx
+++ b/site/src/routes/themes/add.tsx
@@ -38,6 +38,7 @@ export function ThemeAddPage(): JSX.Element {
   const [createIsPublic, setCreateIsPublic] = useState(true);
   const [createVersion, setCreateVersion] = useState("1.0.0");
   const [createThemeFile, setCreateThemeFile] = useState<File | null>(null);
+  const [createThemeJson, setCreateThemeJson] = useState("");
 
   const [updateName, setUpdateName] = useState("");
   const [updateDescription, setUpdateDescription] = useState("");
@@ -47,6 +48,7 @@ export function ThemeAddPage(): JSX.Element {
   const [publishChangelog, setPublishChangelog] = useState("");
   const [publishChecksum, setPublishChecksum] = useState("");
   const [publishThemeFile, setPublishThemeFile] = useState<File | null>(null);
+  const [publishThemeJson, setPublishThemeJson] = useState("");
 
   const [isBootstrapping, setIsBootstrapping] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -132,8 +134,8 @@ export function ThemeAddPage(): JSX.Element {
     event: FormEvent<HTMLFormElement>,
   ): Promise<void> {
     event.preventDefault();
-    if (!createThemeFile) {
-      setError("Theme JSON file is required.");
+    if (!hasThemePayload(createThemeFile, createThemeJson)) {
+      setError("Theme JSON file or pasted JSON is required.");
       return;
     }
 
@@ -148,6 +150,7 @@ export function ThemeAddPage(): JSX.Element {
         isPublic: createIsPublic,
         version: createVersion,
         themeFile: createThemeFile,
+        themeJson: createThemeJson,
       });
 
       setThemes((prev) => [
@@ -160,6 +163,7 @@ export function ThemeAddPage(): JSX.Element {
       setCreateDescription("");
       setCreateVersion("1.0.0");
       setCreateThemeFile(null);
+      setCreateThemeJson("");
       setNotice(`Theme '${created.slug}' created.`);
     } catch (err) {
       setError(getErrorMessage(err));
@@ -205,8 +209,8 @@ export function ThemeAddPage(): JSX.Element {
     if (!selectedTheme) {
       return;
     }
-    if (!publishThemeFile) {
-      setError("Theme JSON file is required.");
+    if (!hasThemePayload(publishThemeFile, publishThemeJson)) {
+      setError("Theme JSON file or pasted JSON is required.");
       return;
     }
 
@@ -220,6 +224,7 @@ export function ThemeAddPage(): JSX.Element {
         changelog: publishChangelog,
         checksumSha256: publishChecksum,
         themeFile: publishThemeFile,
+        themeJson: publishThemeJson,
       });
 
       const loadedThemes = await fetchMyThemes();
@@ -229,6 +234,7 @@ export function ThemeAddPage(): JSX.Element {
       setPublishChangelog("");
       setPublishChecksum("");
       setPublishThemeFile(null);
+      setPublishThemeJson("");
       setNotice("Version published.");
     } catch (err) {
       setError(getErrorMessage(err));
@@ -259,7 +265,8 @@ export function ThemeAddPage(): JSX.Element {
             className="mt-4 text-lg text-muted-foreground animate-blur-in"
             style={{ animationDelay: "100ms" }}
           >
-            Upload theme JSON files, publish versions, and maintain your catalog.
+            Upload theme JSON files, publish versions, and maintain your
+            catalog.
           </p>
           <div
             className="mt-6 flex flex-wrap items-center justify-center gap-3 animate-blur-in"
@@ -299,10 +306,7 @@ export function ThemeAddPage(): JSX.Element {
         )}
 
         {!isBootstrapping && !user && (
-          <div
-            className="animate-blur-in"
-            style={{ animationDelay: "300ms" }}
-          >
+          <div className="animate-blur-in" style={{ animationDelay: "300ms" }}>
             <Card className="border-border/60">
               <CardHeader>
                 <CardTitle>Authentication Required</CardTitle>
@@ -418,6 +422,19 @@ export function ThemeAddPage(): JSX.Element {
                       }
                       disabled={!user || isSubmitting}
                     />
+                    <textarea
+                      className="min-h-48 w-full rounded-lg border border-border bg-background px-3 py-2 font-mono text-sm"
+                      placeholder='Or paste theme JSON here, for example: { "foreground": "#d1d5db" }'
+                      value={createThemeJson}
+                      onChange={(event) =>
+                        setCreateThemeJson(event.target.value)
+                      }
+                      disabled={!user || isSubmitting}
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      Paste JSON or upload a file. Pasted JSON is used when both
+                      are provided.
+                    </p>
                     <Button type="submit" disabled={!user || isSubmitting}>
                       Create theme
                     </Button>
@@ -505,6 +522,19 @@ export function ThemeAddPage(): JSX.Element {
                           disabled={!canEditSelectedTheme || isSubmitting}
                         />
                         <textarea
+                          className="min-h-48 w-full rounded-lg border border-border bg-background px-3 py-2 font-mono text-sm"
+                          placeholder='Or paste the next theme JSON here, for example: { "background": "#141a24" }'
+                          value={publishThemeJson}
+                          onChange={(event) =>
+                            setPublishThemeJson(event.target.value)
+                          }
+                          disabled={!canEditSelectedTheme || isSubmitting}
+                        />
+                        <p className="text-xs text-muted-foreground">
+                          Paste JSON or upload a file. Pasted JSON is used when
+                          both are provided.
+                        </p>
+                        <textarea
                           className="min-h-20 w-full rounded-lg border border-border bg-background px-3 py-2 text-sm"
                           placeholder="Changelog"
                           value={publishChangelog}
@@ -585,4 +615,8 @@ function getErrorMessage(error: unknown): string {
   }
 
   return "Unexpected error";
+}
+
+function hasThemePayload(themeFile: File | null, themeJson: string): boolean {
+  return themeFile !== null || themeJson.trim().length > 0;
 }

--- a/site/src/routes/themes/index.tsx
+++ b/site/src/routes/themes/index.tsx
@@ -20,7 +20,11 @@ function buildThemeInstallHref(slug: string): string {
   return `termy://store/theme-install?slug=${encodeURIComponent(slug)}`;
 }
 
-function ThemeColorSwatch({ fileUrl }: { fileUrl: string | null }): JSX.Element {
+function ThemeColorSwatch({
+  fileUrl,
+}: {
+  fileUrl: string | null;
+}): JSX.Element {
   const [palette, setPalette] = useState<ThemePalette | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -91,8 +95,23 @@ function ThemeStorePage(): JSX.Element {
   const [user, setUser] = useState<AuthUser | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
 
   const loginUrl = useMemo(() => getThemeLoginUrl("/themes"), []);
+  const filteredThemes = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase();
+
+    if (!query) {
+      return themes;
+    }
+
+    return themes.filter((theme) =>
+      [theme.name, theme.slug, theme.description, theme.githubUsernameClaim]
+        .join(" ")
+        .toLowerCase()
+        .includes(query),
+    );
+  }, [searchQuery, themes]);
 
   useEffect(() => {
     void load();
@@ -162,9 +181,22 @@ function ThemeStorePage(): JSX.Element {
           </div>
         )}
 
+        <div className="mx-auto w-full max-w-2xl px-6">
+          <div className="rounded-2xl border border-border/60 bg-card/40 p-2 backdrop-blur-sm">
+            <input
+              type="search"
+              value={searchQuery}
+              onChange={(event) => setSearchQuery(event.target.value)}
+              placeholder="Search themes by name, slug, description, or author..."
+              className="w-full rounded-xl border border-transparent bg-background/70 px-4 py-3 text-sm text-foreground outline-none transition-colors placeholder:text-muted-foreground/70 focus:border-primary/40"
+              aria-label="Search themes"
+            />
+          </div>
+        </div>
+
         {/* Theme cards */}
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {themes.map((theme, i) => (
+          {filteredThemes.map((theme, i) => (
             <div
               key={theme.id}
               className="animate-blur-in group flex flex-col rounded-xl border border-border/40 bg-card/30 transition-all duration-300 hover:border-primary/20 hover:bg-card/60 overflow-hidden"
@@ -211,6 +243,12 @@ function ThemeStorePage(): JSX.Element {
         {!loading && themes.length === 0 && (
           <div className="rounded-xl border border-border/60 bg-card/50 px-4 py-6 text-center text-sm text-muted-foreground">
             No themes published yet.
+          </div>
+        )}
+
+        {!loading && themes.length > 0 && filteredThemes.length === 0 && (
+          <div className="rounded-xl border border-border/60 bg-card/50 px-4 py-6 text-center text-sm text-muted-foreground">
+            No themes match "{searchQuery.trim()}".
           </div>
         )}
 


### PR DESCRIPTION
- Add `themeJson` multipart field to API endpoints for create and publish
- Update frontend to allow JSON input as alternative to file upload
- Add search functionality to theme store page
- Prioritize pasted JSON over file when both provided

# Pull Request

<!-- A clear and concise description of what this PR does and why it's needed. -->

## Description

<!-- Describe the changes made in the PR. -->

- 
-
-
-

## Screenshots/Videos

<!-- If applicable, add screenshots or screen recordings to help explain your changes. -->


## Related Issues

<!-- If this PR closes any issues, use the keyword 'closes' followed by the issue number -->

Closes #

## Checklist

- [ ] I confirmed there is no existing open PR for the same or overlapping changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now paste theme JSON directly as text input, in addition to uploading JSON files, for both theme creation and publishing workflows.
  * Added search functionality to filter themes by name, slug, description, or author in real-time.

* **Documentation**
  * Updated documentation to reflect the new JSON text input option for theme uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->