### PR TITLE
Remove built-in themes and migrate to user-installed theme library

### DIFF
--- a/crates/cli/src/commands/providers.rs
+++ b/crates/cli/src/commands/providers.rs
@@ -31,14 +31,13 @@ pub fn list_color_lines() -> Vec<String> {
     let theme_id = active_theme_id();
     let mut lines = vec![format!("Theme: {}", theme_id), String::new()];
 
-    let theme_colors = termy_themes::resolve_theme(&theme_id);
-    let colors = match theme_colors {
+    let colors = match termy_themes::resolve_theme(&theme_id) {
         Some(colors) => colors,
         None => {
             lines.push(format!("Unknown theme: {}", theme_id));
-            lines.push("Using built-in fallback: termy".to_string());
+            lines.push("Using terminal default fallback colors".to_string());
             lines.push(String::new());
-            termy_themes::termy()
+            terminal_default_theme_colors()
         }
     };
 
@@ -123,6 +122,34 @@ fn action_lines_for_capabilities(tmux_enabled: bool, install_cli_available: bool
             )
         })
         .collect()
+}
+
+fn terminal_default_theme_colors() -> termy_themes::ThemeColors {
+    use termy_themes::Rgb8;
+
+    termy_themes::ThemeColors {
+        ansi: [
+            Rgb8::new(0x00, 0x00, 0x00),
+            Rgb8::new(0xCD, 0x00, 0x00),
+            Rgb8::new(0x00, 0xCD, 0x00),
+            Rgb8::new(0xCD, 0xCD, 0x00),
+            Rgb8::new(0x00, 0x00, 0xEE),
+            Rgb8::new(0xCD, 0x00, 0xCD),
+            Rgb8::new(0x00, 0xCD, 0xCD),
+            Rgb8::new(0xE5, 0xE5, 0xE5),
+            Rgb8::new(0x7F, 0x7F, 0x7F),
+            Rgb8::new(0xFF, 0x00, 0x00),
+            Rgb8::new(0x00, 0xFF, 0x00),
+            Rgb8::new(0xFF, 0xFF, 0x00),
+            Rgb8::new(0x5C, 0x5C, 0xFF),
+            Rgb8::new(0xFF, 0x00, 0xFF),
+            Rgb8::new(0x00, 0xFF, 0xFF),
+            Rgb8::new(0xFF, 0xFF, 0xFF),
+        ],
+        foreground: Rgb8::new(0xE5, 0xE5, 0xE5),
+        background: Rgb8::new(0x1E, 0x1E, 0x1E),
+        cursor: Rgb8::new(0xFF, 0xFF, 0xFF),
+    }
 }
 
 fn keybind_lines_for_tmux_enabled(
@@ -419,6 +446,6 @@ mod tests {
     #[test]
     fn themes_are_sourced_from_theme_registry() {
         let themes = list_theme_lines();
-        assert!(themes.iter().any(|theme| theme == "termy"));
+        assert!(themes.is_empty());
     }
 }

--- a/crates/config_core/src/default_config.txt
+++ b/crates/config_core/src/default_config.txt
@@ -1,6 +1,6 @@
 # Main settings
 # Current color scheme name
-theme = termy
+theme = shell-decide
 # Enable automatic update checks and notifications
 auto_update = true
 # Enable tmux runtime integration

--- a/crates/config_core/src/parser.rs
+++ b/crates/config_core/src/parser.rs
@@ -601,10 +601,6 @@ pub fn parse_theme_id(value: &str) -> Option<ThemeId> {
         return None;
     }
 
-    if let Some(canonical) = termy_theme_core::canonical_builtin_theme_id(value) {
-        return Some(canonical.to_string());
-    }
-
     let normalized = termy_theme_core::normalize_theme_id(value);
     if matches!(
         normalized.as_str(),

--- a/crates/config_core/src/parser_tests.rs
+++ b/crates/config_core/src/parser_tests.rs
@@ -595,10 +595,10 @@ fn shell_decide_theme_aliases_canonicalize() {
 }
 
 #[test]
-fn builtin_theme_aliases_canonicalize() {
+fn theme_ids_are_normalized_without_builtin_aliases() {
     let config = parse("theme = gruvbox\n");
-    assert_eq!(config.theme, "gruvbox-dark");
+    assert_eq!(config.theme, "gruvbox");
 
     let config = parse("theme = tokyonight\n");
-    assert_eq!(config.theme, "tokyo-night");
+    assert_eq!(config.theme, "tokyonight");
 }

--- a/crates/config_core/src/types.rs
+++ b/crates/config_core/src/types.rs
@@ -5,6 +5,7 @@ use crate::constants::{
     DEFAULT_TAB_TITLE_EXPLICIT_PREFIX, DEFAULT_TAB_TITLE_FALLBACK, DEFAULT_TAB_TITLE_PROMPT_FORMAT,
     DEFAULT_TERM, DEFAULT_TMUX_BINARY, DEFAULT_TMUX_ENABLED, DEFAULT_TMUX_PERSISTENCE,
     DEFAULT_TMUX_SHOW_ACTIVE_PANE_BORDER, DEFAULT_WARN_ON_QUIT_WITH_RUNNING_PROCESS,
+    SHELL_DECIDE_THEME_ID,
 };
 
 pub type ThemeId = String;
@@ -319,7 +320,7 @@ pub struct KeybindConfigLine {
 impl Default for AppConfig {
     fn default() -> Self {
         Self {
-            theme: "termy".to_string(),
+            theme: SHELL_DECIDE_THEME_ID.to_string(),
             auto_update: true,
             tmux_enabled: DEFAULT_TMUX_ENABLED,
             tmux_persistence: DEFAULT_TMUX_PERSISTENCE,

--- a/crates/theme_core/src/lib.rs
+++ b/crates/theme_core/src/lib.rs
@@ -19,21 +19,7 @@ pub struct ThemeColors {
     pub cursor: Rgb8,
 }
 
-pub const BUILTIN_THEME_IDS: &[&str] = &[
-    "termy",
-    "tokyo-night",
-    "catppuccin-mocha",
-    "dracula",
-    "gruvbox-dark",
-    "nord",
-    "solarized-dark",
-    "one-dark",
-    "monokai",
-    "material-dark",
-    "palenight",
-    "tomorrow-night",
-    "oceanic-next",
-];
+pub const BUILTIN_THEME_IDS: &[&str] = &[];
 
 pub const ANSI_COLOR_NAMES: [&str; 16] = [
     "black",
@@ -83,29 +69,8 @@ pub fn normalize_theme_id(theme_id: &str) -> String {
 }
 
 pub fn canonical_builtin_theme_id(theme_id: &str) -> Option<&'static str> {
-    let normalized = normalize_theme_lookup(theme_id);
-    match normalized.as_str() {
-        "termy" | "default" => Some("termy"),
-        "tokyonight" => Some("tokyo-night"),
-        "catppuccin" | "catppuccinmocha" => Some("catppuccin-mocha"),
-        "dracula" => Some("dracula"),
-        "gruvbox" | "gruvboxdark" => Some("gruvbox-dark"),
-        "nord" => Some("nord"),
-        "solarized" | "solarizeddark" => Some("solarized-dark"),
-        "one" | "onedark" => Some("one-dark"),
-        "monokai" => Some("monokai"),
-        "material" | "materialdark" => Some("material-dark"),
-        "palenight" => Some("palenight"),
-        "tomorrow" | "tomorrownight" => Some("tomorrow-night"),
-        "oceanic" | "oceanicnext" => Some("oceanic-next"),
-        _ => None,
-    }
-}
-
-fn normalize_theme_lookup(theme_id: &str) -> String {
-    let mut normalized = normalize_theme_id(theme_id);
-    normalized.retain(|character| character != '-');
-    normalized
+    let _ = theme_id;
+    None
 }
 
 pub fn format_hex(color: Rgb8) -> String {
@@ -128,12 +93,9 @@ mod tests {
     }
 
     #[test]
-    fn builtin_aliases_canonicalize() {
-        assert_eq!(canonical_builtin_theme_id("gruvbox"), Some("gruvbox-dark"));
-        assert_eq!(
-            canonical_builtin_theme_id("tokyonight"),
-            Some("tokyo-night")
-        );
-        assert_eq!(canonical_builtin_theme_id("default"), Some("termy"));
+    fn builtin_aliases_are_disabled() {
+        assert_eq!(canonical_builtin_theme_id("gruvbox"), None);
+        assert_eq!(canonical_builtin_theme_id("tokyonight"), None);
+        assert_eq!(canonical_builtin_theme_id("default"), None);
     }
 }

--- a/crates/themes/src/lib.rs
+++ b/crates/themes/src/lib.rs
@@ -12,11 +12,8 @@ mod termy;
 mod tokyo_night;
 mod tomorrow_night;
 
-use std::collections::HashSet;
 use std::sync::{OnceLock, RwLock};
-pub use termy_theme_core::{
-    BUILTIN_THEME_IDS, Rgb8, ThemeColors, canonical_builtin_theme_id, normalize_theme_id,
-};
+pub use termy_theme_core::{Rgb8, ThemeColors, normalize_theme_id};
 
 pub trait ThemeProvider: Send + Sync {
     fn theme(&self, theme_id: &str) -> Option<ThemeColors>;
@@ -36,12 +33,6 @@ impl ThemeRegistry {
         Self::default()
     }
 
-    pub fn with_builtins() -> Self {
-        let mut registry = Self::new();
-        registry.register_provider(BuiltinThemeProvider);
-        registry
-    }
-
     pub fn register_provider<P>(&mut self, provider: P)
     where
         P: ThemeProvider + 'static,
@@ -59,11 +50,10 @@ impl ThemeRegistry {
     }
 
     pub fn theme_ids(&self) -> Vec<&'static str> {
-        let mut seen = HashSet::new();
         let mut ids = Vec::new();
         for provider in &self.providers {
             for id in provider.theme_ids() {
-                if seen.insert(*id) {
+                if !ids.contains(id) {
                     ids.push(*id);
                 }
             }
@@ -72,22 +62,10 @@ impl ThemeRegistry {
     }
 }
 
-pub struct BuiltinThemeProvider;
-
-impl ThemeProvider for BuiltinThemeProvider {
-    fn theme(&self, theme_id: &str) -> Option<ThemeColors> {
-        builtin_theme(theme_id)
-    }
-
-    fn theme_ids(&self) -> &'static [&'static str] {
-        BUILTIN_THEME_IDS
-    }
-}
-
 static GLOBAL_THEME_REGISTRY: OnceLock<RwLock<ThemeRegistry>> = OnceLock::new();
 
 fn global_theme_registry() -> &'static RwLock<ThemeRegistry> {
-    GLOBAL_THEME_REGISTRY.get_or_init(|| RwLock::new(ThemeRegistry::with_builtins()))
+    GLOBAL_THEME_REGISTRY.get_or_init(|| RwLock::new(ThemeRegistry::new()))
 }
 
 pub fn register_theme_provider<P>(provider: P)
@@ -115,22 +93,8 @@ pub fn available_theme_ids() -> Vec<&'static str> {
 }
 
 pub fn builtin_theme(theme_id: &str) -> Option<ThemeColors> {
-    match canonical_builtin_theme_id(theme_id)? {
-        "termy" => Some(termy()),
-        "tokyo-night" => Some(tokyo_night()),
-        "catppuccin-mocha" => Some(catppuccin_mocha()),
-        "dracula" => Some(dracula()),
-        "gruvbox-dark" => Some(gruvbox_dark()),
-        "nord" => Some(nord()),
-        "solarized-dark" => Some(solarized_dark()),
-        "one-dark" => Some(one_dark()),
-        "monokai" => Some(monokai()),
-        "material-dark" => Some(material_dark()),
-        "palenight" => Some(palenight()),
-        "tomorrow-night" => Some(tomorrow_night()),
-        "oceanic-next" => Some(oceanic_next()),
-        _ => None,
-    }
+    let _ = theme_id;
+    None
 }
 
 pub fn tokyo_night() -> ThemeColors {

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -1,4 +1,5 @@
 use crate::config::{CustomColors, SHELL_DECIDE_THEME_ID};
+use crate::theme_store;
 use alacritty_terminal::vte::ansi::{Color as AnsiColor, NamedColor, Rgb as AnsiRgb};
 use gpui::Rgba;
 use termy_themes as themes;
@@ -45,8 +46,12 @@ impl TerminalColors {
         let mut colors = if theme.eq_ignore_ascii_case(SHELL_DECIDE_THEME_ID) {
             Self::default()
         } else {
-            let theme_colors = themes::resolve_theme(theme).unwrap_or_else(themes::termy);
-            Self::from_theme_colors(theme_colors)
+            match theme_store::load_installed_theme_colors(theme)
+                .or_else(|| themes::resolve_theme(theme))
+            {
+                Some(theme_colors) => Self::from_theme_colors(theme_colors),
+                None => Self::default(),
+            }
         };
         colors.apply_custom(custom);
         colors

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2,8 +2,10 @@ mod error;
 mod io;
 mod mutate;
 
+use crate::theme_store;
 use std::time::Duration;
 use std::{
+    collections::HashSet,
     fs,
     hash::{DefaultHasher, Hash, Hasher},
     path::{Path, PathBuf},
@@ -12,8 +14,8 @@ use std::{
 pub use error::ConfigIoError;
 pub use io::{ensure_config_file, open_config_file, subscribe_config_changes};
 pub use mutate::{
-    clear_all_color_overrides, import_colors_from_json, remove_root_setting, set_color_setting,
-    set_keybind_lines, set_root_setting, set_theme_in_config,
+    import_colors_from_json, remove_root_setting, set_color_setting, set_keybind_lines,
+    set_root_setting, set_theme_in_config,
 };
 pub use termy_config_core::{
     AiProvider, AppConfig, ConfigDiagnostic, ConfigDiagnosticKind, CursorStyle, CustomColors,
@@ -38,10 +40,16 @@ pub struct RuntimeConfigLoad {
 pub(crate) const DEFAULT_CONFIG: &str = termy_config_core::DEFAULT_CONFIG_TEMPLATE;
 
 fn load_from_path(path: PathBuf) -> Result<LoadedConfig, ConfigIoError> {
-    let contents = fs::read_to_string(&path).map_err(|source| ConfigIoError::ReadConfig {
-        path: path.clone(),
-        source,
-    })?;
+    let original_contents =
+        fs::read_to_string(&path).map_err(|source| ConfigIoError::ReadConfig {
+            path: path.clone(),
+            source,
+        })?;
+    let contents = migrate_legacy_builtin_theme_in_contents(&original_contents);
+    if contents != original_contents {
+        io::write_atomic(&path, &contents)?;
+        io::notify_config_changed();
+    }
     let fingerprint = config_fingerprint_from_bytes(contents.as_bytes());
     let report = AppConfig::from_contents_with_report(&contents);
 
@@ -171,6 +179,61 @@ fn diagnostic_kind_label(kind: ConfigDiagnosticKind) -> &'static str {
     }
 }
 
+fn migrate_legacy_builtin_theme_in_contents(contents: &str) -> String {
+    let installed_theme_ids: HashSet<String> = theme_store::load_installed_theme_ids()
+        .into_iter()
+        .collect();
+    migrate_legacy_builtin_theme_in_contents_with_installed_ids(contents, &installed_theme_ids)
+}
+
+fn migrate_legacy_builtin_theme_in_contents_with_installed_ids(
+    contents: &str,
+    installed_theme_ids: &HashSet<String>,
+) -> String {
+    let report = AppConfig::from_contents(contents);
+    let Some(canonical_legacy_theme) = canonical_legacy_builtin_theme_id(&report.theme) else {
+        return contents.to_string();
+    };
+
+    let next_theme = if installed_theme_ids.contains(canonical_legacy_theme) {
+        canonical_legacy_theme.to_string()
+    } else {
+        SHELL_DECIDE_THEME_ID.to_string()
+    };
+
+    if report.theme == next_theme {
+        return contents.to_string();
+    }
+
+    termy_config_core::upsert_root_setting(
+        contents,
+        termy_config_core::RootSettingId::Theme,
+        &next_theme,
+    )
+}
+
+fn canonical_legacy_builtin_theme_id(theme_id: &str) -> Option<&'static str> {
+    let normalized = termy_themes::normalize_theme_id(theme_id);
+    let lookup = normalized.replace('-', "");
+
+    match lookup.as_str() {
+        "termy" | "default" => Some("termy"),
+        "tokyonight" => Some("tokyo-night"),
+        "catppuccin" | "catppuccinmocha" => Some("catppuccin-mocha"),
+        "dracula" => Some("dracula"),
+        "gruvbox" | "gruvboxdark" => Some("gruvbox-dark"),
+        "nord" => Some("nord"),
+        "solarized" | "solarizeddark" => Some("solarized-dark"),
+        "one" | "onedark" => Some("one-dark"),
+        "monokai" => Some("monokai"),
+        "material" | "materialdark" => Some("material-dark"),
+        "palenight" => Some("palenight"),
+        "tomorrow" | "tomorrownight" => Some("tomorrow-night"),
+        "oceanic" | "oceanicnext" => Some("oceanic-next"),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -238,5 +301,23 @@ mod tests {
                 section_name
             );
         }
+    }
+
+    #[test]
+    fn migrates_removed_builtin_theme_to_shell_decide_when_not_installed() {
+        let output = migrate_legacy_builtin_theme_in_contents_with_installed_ids(
+            "theme = termy\nfont_size = 14\n",
+            &HashSet::new(),
+        );
+        assert_eq!(output, "theme = shell-decide\nfont_size = 14\n");
+    }
+
+    #[test]
+    fn migrates_legacy_builtin_alias_to_installed_slug() {
+        let output = migrate_legacy_builtin_theme_in_contents_with_installed_ids(
+            "theme = tokyonight\nfont_size = 14\n",
+            &HashSet::from([String::from("tokyo-night")]),
+        );
+        assert_eq!(output, "theme = tokyo-night\nfont_size = 14\n");
     }
 }

--- a/src/config/mutate.rs
+++ b/src/config/mutate.rs
@@ -9,7 +9,7 @@ use std::{
 use fs4::fs_std::FileExt;
 use termy_config_core::{
     ColorSettingId, ColorSettingUpdate, Rgb8, RootSettingId, apply_color_updates,
-    color_setting_from_key, color_setting_spec, color_setting_specs, parse_theme_id,
+    color_setting_from_key, color_setting_spec, parse_theme_id,
     remove_root_setting as remove_root_setting_entry, replace_keybind_lines, upsert_root_setting,
 };
 
@@ -182,17 +182,6 @@ pub fn import_colors_from_json(json_path: &Path) -> Result<String, String> {
         .collect::<Vec<_>>();
     update_config_contents(|existing| Ok((apply_color_updates(existing, &updates), ())))?;
     Ok(format!("Imported {} colors", color_count))
-}
-
-pub fn clear_all_color_overrides() -> Result<(), String> {
-    let updates = color_setting_specs()
-        .iter()
-        .map(|spec| ColorSettingUpdate {
-            id: spec.id,
-            value: None,
-        })
-        .collect::<Vec<_>>();
-    update_config_contents(|existing| Ok((apply_color_updates(existing, &updates), ())))
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,7 +189,7 @@ fn start_theme_install_from_deeplink(cx: &mut App, slug: String) {
             Ok(theme) => {
                 let title = "Install Theme";
                 let message = format!(
-                    "Install theme \"{}\" and import its colors into your config?",
+                    "Install theme \"{}\" into your local theme library?",
                     theme.name
                 );
                 if !termy_native_sdk::confirm(title, &message) {

--- a/src/settings_view/mod.rs
+++ b/src/settings_view/mod.rs
@@ -297,8 +297,6 @@ impl SettingsWindow {
                     match result {
                         Ok(installed_theme) => {
                             termy_toast::success(installed_theme.message);
-                            // Keep a single installed store theme marker at a time.
-                            view.theme_store_installed_versions.clear();
                             view.theme_store_installed_versions
                                 .insert(installed_slug.clone(), installed_version.clone());
                             if let Err(error) = theme_store::persist_installed_theme_versions(
@@ -324,7 +322,7 @@ impl SettingsWindow {
     ) {
         let title = "Install Theme";
         let message = format!(
-            "Install theme \"{}\" and import its colors into your config?",
+            "Install theme \"{}\" into your local theme library?",
             theme.name
         );
 
@@ -349,23 +347,29 @@ impl SettingsWindow {
             return;
         }
 
-        if self.theme_store_installed_versions.remove(&key).is_some() {
-            if let Err(error) = config::clear_all_color_overrides() {
-                log::error!("Failed to clear colors during uninstall: {}", error);
-                termy_toast::error("Failed to remove installed theme colors");
+        match theme_store::uninstall_installed_theme(&key) {
+            Ok(true) => {
+                self.theme_store_installed_versions.remove(&key);
+                if self.config.theme.eq_ignore_ascii_case(&key) {
+                    if let Err(error) = config::set_theme_in_config(config::SHELL_DECIDE_THEME_ID) {
+                        log::error!("Failed to reset theme during uninstall: {}", error);
+                        termy_toast::error("Failed to reset selected theme");
+                        return;
+                    }
+                    self.config.theme = config::SHELL_DECIDE_THEME_ID.to_string();
+                }
+                let _ = self.reload_config_if_changed(cx);
+                termy_toast::success("Theme uninstalled");
+            }
+            Ok(false) => {
+                termy_toast::info("Theme is not installed");
                 return;
             }
-            if let Err(error) =
-                theme_store::persist_installed_theme_versions(&self.theme_store_installed_versions)
-            {
-                log::error!("Failed to persist installed theme state: {}", error);
-                termy_toast::error("Failed to persist uninstall state");
+            Err(error) => {
+                log::error!("Failed to uninstall theme: {}", error);
+                termy_toast::error(error);
                 return;
             }
-            let _ = self.reload_config_if_changed(cx);
-            termy_toast::success("Theme uninstalled and colors reverted");
-        } else {
-            termy_toast::info("Theme is not installed");
         }
     }
 
@@ -375,7 +379,6 @@ impl SettingsWindow {
         version: &str,
         cx: &mut Context<Self>,
     ) {
-        self.theme_store_installed_versions.clear();
         self.theme_store_installed_versions
             .insert(slug.trim().to_ascii_lowercase(), version.to_string());
         cx.notify();

--- a/src/settings_view/state.rs
+++ b/src/settings_view/state.rs
@@ -1151,9 +1151,10 @@ impl SettingsWindow {
     }
 
     pub(super) fn ordered_theme_ids_for_settings(&self) -> Vec<String> {
-        let mut theme_ids: Vec<String> = termy_themes::available_theme_ids()
-            .into_iter()
-            .map(ToOwned::to_owned)
+        let mut theme_ids: Vec<String> = self
+            .theme_store_installed_versions
+            .keys()
+            .cloned()
             .collect();
         theme_ids.push("shell-decide".to_string());
 

--- a/src/terminal_view/command_palette/mod.rs
+++ b/src/terminal_view/command_palette/mod.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::theme_store;
 use gpui::point;
 use state::{
     CommandPaletteItem, CommandPaletteItemKind, command_palette_next_scroll_y,
@@ -225,10 +226,7 @@ impl TerminalView {
     }
 
     fn command_palette_theme_items(&self) -> Vec<CommandPaletteItem> {
-        let theme_ids: Vec<String> = termy_themes::available_theme_ids()
-            .into_iter()
-            .map(ToOwned::to_owned)
-            .collect();
+        let theme_ids = theme_store::load_installed_theme_ids();
 
         ordered_theme_ids_for_palette(theme_ids, &self.theme_id)
             .into_iter()

--- a/src/theme_store.rs
+++ b/src/theme_store.rs
@@ -1,7 +1,7 @@
 use crate::config;
 use std::collections::HashMap;
-use std::io::Write;
 use std::path::PathBuf;
+use termy_themes::{Rgb8, ThemeColors, normalize_theme_id};
 
 const DEFAULT_THEME_STORE_API_URL: &str = "https://api.termy.run";
 const DEFAULT_THEME_DEEPLINK_API_URL: &str = "https://termy.run/theme-api";
@@ -104,6 +104,45 @@ pub(crate) fn load_installed_theme_versions() -> HashMap<String, String> {
     HashMap::new()
 }
 
+pub(crate) fn load_installed_theme_ids() -> Vec<String> {
+    let mut ids = Vec::new();
+    let Some(dir) = installed_themes_dir_path() else {
+        return ids;
+    };
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return ids;
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|value| value.to_str()) != Some("json") {
+            continue;
+        }
+        let Some(stem) = path.file_stem().and_then(|value| value.to_str()) else {
+            continue;
+        };
+        let normalized = normalize_theme_id(stem);
+        if !normalized.is_empty() {
+            ids.push(normalized);
+        }
+    }
+
+    ids.sort_unstable();
+    ids.dedup();
+    ids
+}
+
+pub(crate) fn load_installed_theme_colors(theme_id: &str) -> Option<ThemeColors> {
+    let normalized = normalize_theme_id(theme_id);
+    if normalized.is_empty() {
+        return None;
+    }
+
+    let path = installed_theme_file_path(&normalized)?;
+    let contents = std::fs::read_to_string(path).ok()?;
+    parse_theme_colors_json(&contents).ok()
+}
+
 pub(crate) fn persist_installed_theme_versions(
     versions: &HashMap<String, String>,
 ) -> Result<(), String> {
@@ -145,17 +184,23 @@ pub(crate) fn install_theme_from_store_blocking(
         .into_string()
         .map_err(|error| format!("Failed to read theme '{}': {error}", theme.slug))?;
 
-    let mut file =
-        tempfile::NamedTempFile::new().map_err(|error| format!("Temp file error: {error}"))?;
-    file.write_all(contents.as_bytes())
-        .map_err(|error| format!("Failed to write temp theme file: {error}"))?;
+    parse_theme_colors_json(&contents)
+        .map_err(|error| format!("Failed to validate theme '{}': {error}", theme.name))?;
 
-    config::import_colors_from_json(file.path())
-        .map_err(|error| format!("Failed to install theme '{}': {error}", theme.name))?;
-
-    let mut installed_versions = HashMap::new();
     let normalized_slug = theme.slug.trim().to_ascii_lowercase();
     let installed_version = theme.latest_version.clone().unwrap_or_default();
+
+    let path = installed_theme_file_path(&normalized_slug)
+        .ok_or_else(|| "Config path unavailable".to_string())?;
+    let Some(parent) = path.parent() else {
+        return Err("Invalid installed theme path".to_string());
+    };
+    std::fs::create_dir_all(parent)
+        .map_err(|error| format!("Failed to create installed theme directory: {error}"))?;
+    std::fs::write(&path, contents)
+        .map_err(|error| format!("Failed to write installed theme file: {error}"))?;
+
+    let mut installed_versions = load_installed_theme_versions();
     installed_versions.insert(normalized_slug.clone(), installed_version.clone());
     persist_installed_theme_versions(&installed_versions)?;
 
@@ -170,6 +215,33 @@ fn installed_theme_state_path() -> Option<PathBuf> {
     let config_path = config::ensure_config_file().ok()?;
     let parent = config_path.parent()?;
     Some(parent.join("theme_store_installed.json"))
+}
+
+fn installed_themes_dir_path() -> Option<PathBuf> {
+    let config_path = config::ensure_config_file().ok()?;
+    let parent = config_path.parent()?;
+    Some(parent.join("themes"))
+}
+
+fn installed_theme_file_path(slug: &str) -> Option<PathBuf> {
+    let normalized = normalize_slug(slug).ok()?;
+    Some(installed_themes_dir_path()?.join(format!("{normalized}.json")))
+}
+
+pub(crate) fn uninstall_installed_theme(slug: &str) -> Result<bool, String> {
+    let key = normalize_slug(slug)?;
+    let mut installed_versions = load_installed_theme_versions();
+    let removed = installed_versions.remove(&key).is_some();
+
+    if let Some(path) = installed_theme_file_path(&key)
+        && path.exists()
+    {
+        std::fs::remove_file(&path)
+            .map_err(|error| format!("Failed to remove installed theme file: {error}"))?;
+    }
+
+    persist_installed_theme_versions(&installed_versions)?;
+    Ok(removed)
 }
 
 fn normalize_slug(slug: &str) -> Result<String, String> {
@@ -218,5 +290,64 @@ fn parse_theme_value(theme: &serde_json::Value) -> Option<ThemeStoreTheme> {
         description,
         latest_version,
         file_url,
+    })
+}
+
+fn parse_theme_colors_json(contents: &str) -> Result<ThemeColors, String> {
+    let json: serde_json::Value =
+        serde_json::from_str(contents).map_err(|error| format!("Invalid JSON: {error}"))?;
+    let object = json
+        .as_object()
+        .ok_or_else(|| "Theme JSON must be an object".to_string())?;
+
+    let ansi = [
+        parse_required_color(object, "black")?,
+        parse_required_color(object, "red")?,
+        parse_required_color(object, "green")?,
+        parse_required_color(object, "yellow")?,
+        parse_required_color(object, "blue")?,
+        parse_required_color(object, "magenta")?,
+        parse_required_color(object, "cyan")?,
+        parse_required_color(object, "white")?,
+        parse_required_color(object, "bright_black")?,
+        parse_required_color(object, "bright_red")?,
+        parse_required_color(object, "bright_green")?,
+        parse_required_color(object, "bright_yellow")?,
+        parse_required_color(object, "bright_blue")?,
+        parse_required_color(object, "bright_magenta")?,
+        parse_required_color(object, "bright_cyan")?,
+        parse_required_color(object, "bright_white")?,
+    ];
+
+    Ok(ThemeColors {
+        ansi,
+        foreground: parse_required_color(object, "foreground")?,
+        background: parse_required_color(object, "background")?,
+        cursor: parse_required_color(object, "cursor")?,
+    })
+}
+
+fn parse_required_color(
+    object: &serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> Result<Rgb8, String> {
+    let value = object
+        .get(key)
+        .and_then(|value| value.as_str())
+        .ok_or_else(|| format!("Theme JSON is missing '{key}'"))?;
+
+    parse_hex_color(value).ok_or_else(|| format!("Theme color '{key}' must be a #RRGGBB hex"))
+}
+
+fn parse_hex_color(value: &str) -> Option<Rgb8> {
+    let hex = value.strip_prefix('#')?;
+    if hex.len() != 6 {
+        return None;
+    }
+
+    Some(Rgb8 {
+        r: u8::from_str_radix(&hex[0..2], 16).ok()?,
+        g: u8::from_str_radix(&hex[2..4], 16).ok()?,
+        b: u8::from_str_radix(&hex[4..6], 16).ok()?,
     })
 }


### PR DESCRIPTION
This pull request removes all built-in themes from the codebase and migrates theme handling to rely on user-installed themes or a terminal-default fallback. It updates the default theme to `shell-decide`, introduces migration logic for legacy theme settings, and simplifies theme resolution throughout the application.

Theme system overhaul:

* Removed all built-in themes and their aliases from the codebase, including disabling their registration and lookup logic in `termy_theme_core` and `termy_themes`. Now, `BUILTIN_THEME_IDS` is empty and `canonical_builtin_theme_id` always returns `None`. [[1]](diffhunk://#diff-6e02c1e9cc6245564341caedfb27cc2fa6dfae7b4017ee0c425f1180337efb8dL22-R22) [[2]](diffhunk://#diff-6e02c1e9cc6245564341caedfb27cc2fa6dfae7b4017ee0c425f1180337efb8dL86-R73) [[3]](diffhunk://#diff-6e02c1e9cc6245564341caedfb27cc2fa6dfae7b4017ee0c425f1180337efb8dL131-R99) [[4]](diffhunk://#diff-e31e58c0859fc514223bd16d769bd309a41557c7460b0a1ab6c901054da045a0L15-R16) [[5]](diffhunk://#diff-e31e58c0859fc514223bd16d769bd309a41557c7460b0a1ab6c901054da045a0L39-L44) [[6]](diffhunk://#diff-e31e58c0859fc514223bd16d769bd309a41557c7460b0a1ab6c901054da045a0L62-R56) [[7]](diffhunk://#diff-e31e58c0859fc514223bd16d769bd309a41557c7460b0a1ab6c901054da045a0L75-R68) [[8]](diffhunk://#diff-e31e58c0859fc514223bd16d769bd309a41557c7460b0a1ab6c901054da045a0L118-R97)
* Updated theme resolution logic to use terminal default colors when a theme is unknown or missing, introducing the `terminal_default_theme_colors` function and updating relevant fallback messages. [[1]](diffhunk://#diff-deda2f5c76ece87367c9ea66ea67349dabf989dfec7f13b6e10a56b6ad5eb517L34-R40) [[2]](diffhunk://#diff-deda2f5c76ece87367c9ea66ea67349dabf989dfec7f13b6e10a56b6ad5eb517R127-R154)

Configuration migration and defaults:

* Changed the default theme in configuration files and code from `termy` to `shell-decide`, and updated normalization logic and tests to remove legacy alias handling. [[1]](diffhunk://#diff-bef00ecd4110c89ae0250f1e38b920ca3c38ae6eb18e426f0063df6722cc53bdL3-R3) [[2]](diffhunk://#diff-689d9d0554e70c785d8b5e785be56a43a316dec6416e4ea53381195b87a774a3R8) [[3]](diffhunk://#diff-689d9d0554e70c785d8b5e785be56a43a316dec6416e4ea53381195b87a774a3L322-R323) [[4]](diffhunk://#diff-4cdcc88d9d69a2913bc512e810f669d843fd03a3035f51848338481daca7521bL604-L607) [[5]](diffhunk://#diff-f1bb1bd3718a1f2f0304bcec8d6e6fa566bbd3b994f827a0dc194da64f1144afL598-R603)
* Added migration logic to automatically update legacy built-in theme settings in user configs to either the installed theme slug or `shell-decide` if not installed, with corresponding tests for migration scenarios. [[1]](diffhunk://#diff-b0ba3e54b6f5ef1fa6aed8075e352a68fda66067fbafa8421042a2347801338aL41-R52) [[2]](diffhunk://#diff-b0ba3e54b6f5ef1fa6aed8075e352a68fda66067fbafa8421042a2347801338aR182-R236) [[3]](diffhunk://#diff-b0ba3e54b6f5ef1fa6aed8075e352a68fda66067fbafa8421042a2347801338aR305-R322)

Application integration and cleanup:

* Updated theme loading logic in `src/colors.rs` and `src/main.rs` to prioritize user-installed themes, and clarified theme install messaging. [[1]](diffhunk://#diff-983f8a7bf409653c9e8399dacd5e2758b2433f9d46da6b8136e6c4c96e6ec224R2) [[2]](diffhunk://#diff-983f8a7bf409653c9e8399dacd5e2758b2433f9d46da6b8136e6c4c96e6ec224L48-R54) [[3]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL192-R192)
* Removed unused or obsolete code related to built-in theme management and color override clearing. [[1]](diffhunk://#diff-b0ba3e54b6f5ef1fa6aed8075e352a68fda66067fbafa8421042a2347801338aL15-R18) [[2]](diffhunk://#diff-fece1f65b6b4ade713e58450363a73d97130b788aa7ee78ac639a7287eab4f0bL12-R12) [[3]](diffhunk://#diff-fece1f65b6b4ade713e58450363a73d97130b788aa7ee78ac639a7287eab4f0bL187-L197) [[4]](diffhunk://#diff-f51f6c57d2c7954dbefd937aff06c4eafbdf96878e6be1346cbb09e9b0555c0fL300-L301)

These changes collectively ensure that theme selection and migration are robust, relying solely on user-installed themes and providing a seamless fallback to terminal defaults where necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Theme installation and uninstallation functionality for managing local theme library.
  * Automatic migration of legacy built-in themes to shell-decide or installed alternatives.

* **Configuration**
  * Default theme changed to shell-decide.
  * Built-in theme support replaced with installable theme system.
  * Themes now loaded from local installation directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->