### PR TITLE
fix(terminal): handle wide char spacer cells in selection and copy

### DIFF
--- a/src/terminal_view/interaction/selection.rs
+++ b/src/terminal_view/interaction/selection.rs
@@ -483,7 +483,13 @@ impl TerminalView {
         let mut start_col = effective_col;
         while start_col > 0 {
             match line[start_col - 1] {
-                None => start_col -= 1,
+                // Spacer: only cross it if the real char beyond it is the same class.
+                None if start_col >= 2
+                    && line[start_col - 2]
+                        .is_some_and(|c| Self::terminal_selection_char_class(c) == class) =>
+                {
+                    start_col -= 1
+                }
                 Some(c) if Self::terminal_selection_char_class(c) == class => start_col -= 1,
                 _ => break,
             }
@@ -492,10 +498,22 @@ impl TerminalView {
         let mut end_col = effective_col;
         while end_col + 1 < line.len() {
             match line[end_col + 1] {
-                None => end_col += 1,
+                // Spacer: only cross it if the real char beyond it is the same class.
+                None if end_col + 2 < line.len()
+                    && line[end_col + 2]
+                        .is_some_and(|c| Self::terminal_selection_char_class(c) == class) =>
+                {
+                    end_col += 1
+                }
                 Some(c) if Self::terminal_selection_char_class(c) == class => end_col += 1,
                 _ => break,
             }
+        }
+
+        // Include the trailing spacer of the last wide char so the
+        // selection highlight covers both cells of the glyph.
+        if end_col + 1 < line.len() && line[end_col + 1].is_none() {
+            end_col += 1;
         }
 
         self.selection_anchor = Some(SelectionPos {


### PR DESCRIPTION
# Pull Request

## Description

CJK wide characters (中文、日本語 etc.) occupy 2 terminal cells. The right-half "spacer" cell was incorrectly handled in selection and copy, causing:

- Extra spaces in copied text when selecting CJK content
- Missed characters when the selection start lands on the right half of a wide character
- Broken double-click word selection on the right half of a wide character

This PR introduces `Option<char>` to distinguish the two alacritty spacer types:
- `WIDE_CHAR_SPACER` (trailing, same line) → `None`, triggers col-1 fallback
- `LEADING_WIDE_CHAR_SPACER` (line-wrap placeholder) → `Some(' ')`, no fallback

Also adds 6 regression tests covering `grid_line_text`, `row_text_from_terminal`, and `selected_text_from_terminal` with CJK content.

## Screenshots/Videos

N/A — text selection behavior, see reproduction steps below.

**How to reproduce:**

1. Run a command that produces CJK output: `echo "cd 桌面"` or `echo "git 提交记录"`
2. Select the text by dragging, Cmd+C and paste — before this fix, copied text had extra spaces
3. Double-click the right half of a CJK character — before this fix, word selection failed
4. In a narrow terminal (5 cols), `echo "src/文"` — the wrapped wide char should copy correctly

## Related Issues

N/A

## Checklist

- [x] I confirmed there is no existing open PR for the same or overlapping changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of wide characters (CJK) during selection, copy, and rendering.
  * Fixed incorrect text extraction when selections cross wide-character boundaries, preventing stray spaces or missing halves of glyphs.
  * Selection expansion now correctly includes or skips wide-character spacer positions so copied and highlighted text match what’s displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->