### PR TITLE
Add device authentication flow for theme store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1512,6 +1512,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1723,6 +1729,16 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "command-fds"
@@ -4052,6 +4068,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4585,6 +4623,12 @@ checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
  "getrandom 0.2.17",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "new_debug_unreachable"
@@ -7308,6 +7352,7 @@ dependencies = [
  "termy_toast",
  "ureq",
  "url",
+ "webbrowser",
  "winresource",
 ]
 
@@ -8591,6 +8636,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "webbrowser"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f00bb839c1cf1e3036066614cbdcd035ecf215206691ea646aa3c60a24f68f2"
+dependencies = [
+ "core-foundation 0.10.0",
+ "jni",
+ "log",
+ "ndk-context",
+ "objc2",
+ "objc2-foundation",
+ "url",
+ "web-sys",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8854,6 +8915,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -8895,6 +8965,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -8956,6 +9041,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -8974,6 +9065,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -8989,6 +9086,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -9022,6 +9125,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -9037,6 +9146,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -9058,6 +9173,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -9073,6 +9194,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ url = "2.5"
 tempfile = "3"
 fs4 = { version = "0.13.1", features = ["sync"] }
 ureq = { version = "2", features = ["json"] }
+webbrowser = "1.0"
 
 # Termy Workspace Crates
 termy_auto_update = { path = "crates/auto_update" }

--- a/crates/command_core/src/catalog.rs
+++ b/crates/command_core/src/catalog.rs
@@ -40,6 +40,7 @@ macro_rules! termy_command_catalog {
             (RestartApp, "restart_app"),
             (OpenConfig, "open_config"),
             (OpenSettings, "open_settings"),
+            (ImportThemeStoreAuth, "import_theme_store_auth"),
             (ImportColors, "import_colors"),
             (SwitchTheme, "switch_theme"),
             (ZoomIn, "zoom_in"),

--- a/crates/termy_api/src/main.rs
+++ b/crates/termy_api/src/main.rs
@@ -156,6 +156,10 @@ fn build_router(state: AppState) -> Router {
         .route("/auth/github/login", get(auth_github_login))
         .route("/auth/github/callback", get(auth_github_callback))
         .route("/auth/me", get(auth_me))
+        .route(
+            "/auth/device-session",
+            axum::routing::post(auth_device_session),
+        )
         .route("/auth/logout", axum::routing::post(auth_logout))
         .route("/themes/me", get(list_my_themes))
         .route("/themes", get(list_themes).post(create_theme))
@@ -248,6 +252,13 @@ struct AuthUser {
     github_login: String,
     avatar_url: Option<String>,
     name: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AuthDeviceSessionResponse {
+    session_token: String,
+    user: AuthUser,
 }
 
 #[derive(Debug, Deserialize)]
@@ -491,6 +502,28 @@ async fn auth_me(
 ) -> Result<Json<AuthUser>, ApiError> {
     let user = require_auth_user(&state, &headers).await?;
     Ok(Json(user))
+}
+
+async fn auth_device_session(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Result<Json<AuthDeviceSessionResponse>, ApiError> {
+    let user = require_auth_user(&state, &headers).await?;
+    let token = format!("{}{}", Uuid::new_v4().simple(), Uuid::new_v4().simple());
+    let token_hash = hash_token(&token);
+    let expires_at = Utc::now() + Duration::hours(state.auth.session_ttl_hours);
+
+    sqlx::query("INSERT INTO user_session (user_id, token_hash, expires_at) VALUES ($1, $2, $3)")
+        .bind(user.id)
+        .bind(token_hash)
+        .bind(expires_at)
+        .execute(&state.db)
+        .await?;
+
+    Ok(Json(AuthDeviceSessionResponse {
+        session_token: token,
+        user,
+    }))
 }
 
 async fn auth_logout(

--- a/site/src/lib/theme-store.ts
+++ b/site/src/lib/theme-store.ts
@@ -34,6 +34,11 @@ export interface AuthUser {
   name: string | null;
 }
 
+export interface DeviceSessionResponse {
+  sessionToken: string;
+  user: AuthUser;
+}
+
 export interface ThemeWithVersionsResponse {
   theme: Theme;
   versions: ThemeVersion[];
@@ -104,6 +109,12 @@ export async function fetchCurrentUser(): Promise<AuthUser | null> {
 
 export async function logout(): Promise<void> {
   await requestJson<void>("/auth/logout", { method: "POST" });
+}
+
+export async function createDeviceSession(): Promise<DeviceSessionResponse> {
+  return requestJson<DeviceSessionResponse>("/auth/device-session", {
+    method: "POST",
+  });
 }
 
 export async function fetchThemes(): Promise<Theme[]> {
@@ -254,4 +265,23 @@ export function getThemeLoginUrl(redirectToPath: string): string {
 
   const redirectTo = `${window.location.origin}${redirectToPath}`;
   return `${API_BASE}/auth/github/login?redirect_to=${encodeURIComponent(redirectTo)}`;
+}
+
+export function buildNativeAuthCallbackUrl(
+  session: DeviceSessionResponse,
+): string {
+  const url = new URL("termy://auth/callback");
+  url.searchParams.set("session_token", session.sessionToken);
+  url.searchParams.set("id", session.user.id);
+  url.searchParams.set("github_user_id", String(session.user.githubUserId));
+  url.searchParams.set("github_login", session.user.githubLogin);
+
+  if (session.user.avatarUrl) {
+    url.searchParams.set("avatar_url", session.user.avatarUrl);
+  }
+  if (session.user.name) {
+    url.searchParams.set("name", session.user.name);
+  }
+
+  return url.toString();
 }

--- a/site/src/routeTree.gen.ts
+++ b/site/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from "./routes/__root"
+import { Route as DeviceRouteImport } from "./routes/device"
 import { Route as AddRouteImport } from "./routes/add"
 import { Route as IndexRouteImport } from "./routes/index"
 import { Route as ThemesIndexRouteImport } from "./routes/themes/index"
@@ -22,6 +23,11 @@ import { Route as ReleasesTagRouteImport } from "./routes/releases/$tag"
 import { Route as DocsSplatRouteImport } from "./routes/docs/$"
 import { Route as ThemesSlugUpdateRouteImport } from "./routes/themes/$slug/update"
 
+const DeviceRoute = DeviceRouteImport.update({
+  id: "/device",
+  path: "/device",
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AddRoute = AddRouteImport.update({
   id: "/add",
   path: "/add",
@@ -86,6 +92,7 @@ const ThemesSlugUpdateRoute = ThemesSlugUpdateRouteImport.update({
 export interface FileRoutesByFullPath {
   "/": typeof IndexRoute
   "/add": typeof AddRoute
+  "/device": typeof DeviceRoute
   "/docs/$": typeof DocsSplatRoute
   "/releases/$tag": typeof ReleasesTagRoute
   "/themes/$slug": typeof ThemesSlugRouteWithChildren
@@ -100,6 +107,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   "/": typeof IndexRoute
   "/add": typeof AddRoute
+  "/device": typeof DeviceRoute
   "/docs/$": typeof DocsSplatRoute
   "/releases/$tag": typeof ReleasesTagRoute
   "/themes/$slug": typeof ThemesSlugRouteWithChildren
@@ -115,6 +123,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   "/": typeof IndexRoute
   "/add": typeof AddRoute
+  "/device": typeof DeviceRoute
   "/docs/$": typeof DocsSplatRoute
   "/releases/$tag": typeof ReleasesTagRoute
   "/themes/$slug": typeof ThemesSlugRouteWithChildren
@@ -131,6 +140,7 @@ export interface FileRouteTypes {
   fullPaths:
     | "/"
     | "/add"
+    | "/device"
     | "/docs/$"
     | "/releases/$tag"
     | "/themes/$slug"
@@ -145,6 +155,7 @@ export interface FileRouteTypes {
   to:
     | "/"
     | "/add"
+    | "/device"
     | "/docs/$"
     | "/releases/$tag"
     | "/themes/$slug"
@@ -159,6 +170,7 @@ export interface FileRouteTypes {
     | "__root__"
     | "/"
     | "/add"
+    | "/device"
     | "/docs/$"
     | "/releases/$tag"
     | "/themes/$slug"
@@ -174,6 +186,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AddRoute: typeof AddRoute
+  DeviceRoute: typeof DeviceRoute
   DocsSplatRoute: typeof DocsSplatRoute
   ReleasesTagRoute: typeof ReleasesTagRoute
   ThemesSlugRoute: typeof ThemesSlugRouteWithChildren
@@ -187,6 +200,13 @@ export interface RootRouteChildren {
 
 declare module "@tanstack/react-router" {
   interface FileRoutesByPath {
+    "/device": {
+      id: "/device"
+      path: "/device"
+      fullPath: "/device"
+      preLoaderRoute: typeof DeviceRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     "/add": {
       id: "/add"
       path: "/add"
@@ -289,6 +309,7 @@ const ThemesSlugRouteWithChildren = ThemesSlugRoute._addFileChildren(
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AddRoute: AddRoute,
+  DeviceRoute: DeviceRoute,
   DocsSplatRoute: DocsSplatRoute,
   ReleasesTagRoute: ReleasesTagRoute,
   ThemesSlugRoute: ThemesSlugRouteWithChildren,

--- a/site/src/routes/device.tsx
+++ b/site/src/routes/device.tsx
@@ -1,0 +1,177 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { ExternalLink, LoaderCircle, LogIn } from "lucide-react";
+import type { JSX } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  buildNativeAuthCallbackUrl,
+  createDeviceSession,
+  fetchCurrentUser,
+  getThemeLoginUrl,
+  type AuthUser,
+} from "@/lib/theme-store";
+
+export const Route = createFileRoute("/device")({
+  component: DeviceAuthPage,
+});
+
+type DeviceState = "checking" | "signed_out" | "creating" | "ready" | "error";
+
+function DeviceAuthPage(): JSX.Element {
+  const [state, setState] = useState<DeviceState>("checking");
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [callbackUrl, setCallbackUrl] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const loginUrl = useMemo(() => getThemeLoginUrl("/device"), []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function run(): Promise<void> {
+      try {
+        setState("checking");
+        setError(null);
+        const currentUser = await fetchCurrentUser();
+        if (cancelled) {
+          return;
+        }
+
+        if (!currentUser) {
+          setUser(null);
+          setState("signed_out");
+          return;
+        }
+
+        setUser(currentUser);
+        setState("creating");
+        const deviceSession = await createDeviceSession();
+        if (cancelled) {
+          return;
+        }
+
+        const nextCallbackUrl = buildNativeAuthCallbackUrl(deviceSession);
+        setCallbackUrl(nextCallbackUrl);
+        setState("ready");
+        window.location.replace(nextCallbackUrl);
+      } catch (err) {
+        if (cancelled) {
+          return;
+        }
+        setError(getErrorMessage(err));
+        setState("error");
+      }
+    }
+
+    void run();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <section className="relative overflow-hidden py-24 sm:py-32">
+      <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,#93c5fd22,transparent_45%),linear-gradient(180deg,transparent,rgba(12,18,28,0.08))]" />
+
+      <div className="mx-auto flex max-w-3xl flex-col items-center px-6 text-center">
+        <div className="animate-blur-in rounded-full border border-border/50 bg-background/80 px-3 py-1 text-xs uppercase tracking-[0.28em] text-muted-foreground">
+          Termy Device Login
+        </div>
+
+        <h1
+          className="mt-6 text-4xl font-bold tracking-tight text-foreground md:text-6xl animate-blur-in"
+          style={{ animationDelay: "80ms" }}
+        >
+          Connect your browser to <span className="gradient-text">Termy</span>.
+        </h1>
+
+        <p
+          className="mt-4 max-w-2xl text-base leading-7 text-muted-foreground md:text-lg animate-blur-in"
+          style={{ animationDelay: "140ms" }}
+        >
+          Sign in with GitHub here, then this page will hand the session back to the app with a
+          secure `termy://auth/callback` deeplink.
+        </p>
+
+        <div
+          className="mt-10 w-full animate-blur-in rounded-2xl border border-border/50 bg-card/40 p-6 shadow-[0_20px_80px_rgba(0,0,0,0.08)] backdrop-blur"
+          style={{ animationDelay: "220ms" }}
+        >
+          {state === "checking" && <StatusPanel title="Checking browser session" />}
+          {state === "creating" && (
+            <StatusPanel
+              title={user ? `Creating device session for @${user.githubLogin}` : "Creating device session"}
+            />
+          )}
+
+          {state === "signed_out" && (
+            <div className="space-y-4">
+              <p className="text-sm text-muted-foreground">
+                You are not signed in yet. Continue with GitHub in the browser, then this page
+                will return to Termy automatically.
+              </p>
+              <Button asChild size="lg" className="w-full sm:w-auto">
+                <a href={loginUrl}>
+                  <LogIn className="mr-2 size-4" />
+                  Login with GitHub
+                </a>
+              </Button>
+            </div>
+          )}
+
+          {state === "ready" && callbackUrl && (
+            <div className="space-y-4">
+              <p className="text-sm text-muted-foreground">
+                If Termy did not open automatically, open it manually with the button below.
+              </p>
+              <Button asChild size="lg" className="w-full sm:w-auto">
+                <a href={callbackUrl}>
+                  <ExternalLink className="mr-2 size-4" />
+                  Open Termy
+                </a>
+              </Button>
+              <div className="rounded-xl border border-border/50 bg-background/60 p-3 text-left">
+                <p className="mb-2 text-xs uppercase tracking-[0.2em] text-muted-foreground">
+                  Callback
+                </p>
+                <code className="break-all text-xs text-foreground/80">{callbackUrl}</code>
+              </div>
+            </div>
+          )}
+
+          {state === "error" && (
+            <div className="space-y-4">
+              <p className="text-sm text-destructive">{error ?? "Could not create device session."}</p>
+              <div className="flex flex-wrap justify-center gap-3">
+                <Button asChild>
+                  <a href={loginUrl}>Retry GitHub Login</a>
+                </Button>
+                <Button variant="outline" onClick={() => window.location.reload()}>
+                  Reload
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function StatusPanel({ title }: { title: string }): JSX.Element {
+  return (
+    <div className="flex flex-col items-center gap-4 py-6">
+      <div className="rounded-full border border-border/50 bg-background/80 p-3">
+        <LoaderCircle className="size-5 animate-spin text-primary" />
+      </div>
+      <p className="text-sm text-muted-foreground">{title}</p>
+    </div>
+  );
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return "Unexpected error";
+}

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -718,6 +718,16 @@ define_commands!(
         ))
     ),
     (
+        ImportThemeStoreAuth,
+        GLOBAL_CONTEXT,
+        Some(palette(
+            "Import Theme Store Auth",
+            "github login auth token session clipboard paste",
+            CommandPaletteVisibility::Always
+        )),
+        None
+    ),
+    (
         ImportColors,
         TERMINAL_CONTEXT,
         Some(palette(

--- a/src/settings_view/mod.rs
+++ b/src/settings_view/mod.rs
@@ -537,6 +537,10 @@ impl SettingsWindow {
     }
 
     pub(super) fn open_url(url: &str) -> Result<(), String> {
+        if webbrowser::open(url).is_ok() {
+            return Ok(());
+        }
+
         #[cfg(target_os = "macos")]
         {
             Command::new("open")

--- a/src/terminal_view/command_palette/mod.rs
+++ b/src/terminal_view/command_palette/mod.rs
@@ -923,7 +923,7 @@ impl TerminalView {
             CommandAction::ZoomIn => termy_toast::info("Zoomed in"),
             CommandAction::ZoomOut => termy_toast::info("Zoomed out"),
             CommandAction::ZoomReset => termy_toast::info("Zoom reset"),
-            CommandAction::ImportColors => {}
+            CommandAction::ImportThemeStoreAuth | CommandAction::ImportColors => {}
             CommandAction::Quit
             | CommandAction::SwitchTheme
             | CommandAction::ManageTmuxSessions

--- a/src/terminal_view/interaction/actions.rs
+++ b/src/terminal_view/interaction/actions.rs
@@ -104,6 +104,7 @@ impl TerminalView {
             }
             _ if shortcuts_suspended => {}
             CommandAction::OpenConfig
+            | CommandAction::ImportThemeStoreAuth
             | CommandAction::ImportColors
             | CommandAction::AppInfo
             | CommandAction::OpenSettings

--- a/src/terminal_view/interaction/app.rs
+++ b/src/terminal_view/interaction/app.rs
@@ -11,6 +11,10 @@ impl TerminalView {
                 self.open_config_action(cx);
                 true
             }
+            CommandAction::ImportThemeStoreAuth => {
+                self.import_theme_store_auth_action(cx);
+                true
+            }
             CommandAction::ImportColors => {
                 self.import_colors_action(cx);
                 true
@@ -66,6 +70,49 @@ impl TerminalView {
                         view.notify_overlay(cx);
                     }
                 })
+            });
+        })
+        .detach();
+    }
+
+    fn import_theme_store_auth_action(&mut self, cx: &mut Context<Self>) {
+        let Some(input) = cx.read_from_clipboard().and_then(|item| item.text()) else {
+            termy_toast::info("Copy a theme store auth deeplink or session token first");
+            self.notify_overlay(cx);
+            return;
+        };
+
+        let api_base = crate::theme_store::theme_store_api_base_url();
+        let loading_id = termy_toast::loading("Importing theme store auth...");
+
+        cx.spawn(async move |this, cx: &mut AsyncApp| {
+            let result = smol::unblock(move || {
+                crate::theme_store::resolve_auth_session_from_input_blocking(&api_base, &input)
+                    .and_then(|session| {
+                        crate::theme_store::persist_auth_session(&session)?;
+                        Ok(session)
+                    })
+            })
+            .await;
+
+            termy_toast::dismiss_toast(loading_id);
+
+            let _ = cx.update(|cx| match result {
+                Ok(session) => {
+                    crate::app_actions::update_open_settings_windows(cx, |view, settings_cx| {
+                        view.apply_theme_store_auth_session(session.clone(), settings_cx);
+                    });
+                    let _ = this.update(cx, |view, cx| view.notify_overlay(cx));
+                    termy_toast::success(format!("Signed in as @{}", session.user.github_login));
+                }
+                Err(error) => {
+                    log::error!(
+                        "Failed to import theme store auth from clipboard: {}",
+                        error
+                    );
+                    let _ = this.update(cx, |view, cx| view.notify_overlay(cx));
+                    termy_toast::error(error);
+                }
             });
         })
         .detach();

--- a/src/theme_store.rs
+++ b/src/theme_store.rs
@@ -1,11 +1,12 @@
 use crate::config;
+use crate::deeplink::{DeepLinkArgument, DeepLinkRoute};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use termy_themes::{Rgb8, ThemeColors, normalize_theme_id};
-use url::Url;
 
 const DEFAULT_THEME_STORE_API_URL: &str = "https://api.termy.run";
 const DEFAULT_THEME_DEEPLINK_API_URL: &str = "https://termy.run/theme-api";
+const DEFAULT_THEME_STORE_DEVICE_URL: &str = "https://termy.run/device";
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct ThemeStoreTheme {
@@ -43,12 +44,9 @@ pub(crate) fn theme_store_api_base_url() -> String {
 }
 
 pub(crate) fn theme_store_native_login_url(api_base: &str) -> String {
-    let base = api_base.trim_end_matches('/');
-    let mut url = Url::parse(&format!("{base}/auth/github/login"))
-        .expect("theme store API base must be valid");
-    url.query_pairs_mut()
-        .append_pair("redirect_to", "termy://auth/callback");
-    url.into()
+    let _ = api_base;
+    std::env::var("THEME_STORE_DEVICE_URL")
+        .unwrap_or_else(|_| DEFAULT_THEME_STORE_DEVICE_URL.to_string())
 }
 
 pub(crate) fn fetch_theme_store_themes_blocking(
@@ -117,6 +115,18 @@ pub(crate) fn fetch_auth_user_blocking(
     response
         .into_json::<ThemeStoreAuthUser>()
         .map_err(|error| format!("Invalid authenticated user response: {error}"))
+}
+
+pub(crate) fn resolve_auth_session_from_input_blocking(
+    api_base: &str,
+    input: &str,
+) -> Result<ThemeStoreAuthSession, String> {
+    let session_token = extract_auth_session_token_from_input(input)?;
+    let user = fetch_auth_user_blocking(api_base, &session_token)?;
+    Ok(ThemeStoreAuthSession {
+        session_token,
+        user,
+    })
 }
 
 pub(crate) fn logout_auth_session_blocking(
@@ -315,6 +325,26 @@ fn auth_session_path() -> Option<PathBuf> {
     Some(parent.join("theme_store_auth.json"))
 }
 
+fn extract_auth_session_token_from_input(input: &str) -> Result<String, String> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Err("Clipboard does not contain a theme store auth token".to_string());
+    }
+
+    if trimmed.starts_with("termy://") {
+        let (route, argument) = DeepLinkRoute::parse(trimmed)?;
+        if route != DeepLinkRoute::AuthCallback {
+            return Err("Clipboard deeplink is not a theme store auth callback".to_string());
+        }
+        let Some(DeepLinkArgument::AuthCallback(payload)) = argument else {
+            return Err("Auth callback deeplink is missing a session token".to_string());
+        };
+        return Ok(payload.session_token);
+    }
+
+    Ok(trimmed.to_string())
+}
+
 fn installed_themes_dir_path() -> Option<PathBuf> {
     let config_path = config::ensure_config_file().ok()?;
     let parent = config_path.parent()?;
@@ -353,6 +383,36 @@ fn normalize_slug(slug: &str) -> Result<String, String> {
         return Err(format!("Invalid theme slug '{slug}'"));
     }
     Ok(slug)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_auth_session_token_from_input;
+
+    #[test]
+    fn extracts_plain_session_token() {
+        assert_eq!(
+            extract_auth_session_token_from_input("  abc123  ").unwrap(),
+            "abc123"
+        );
+    }
+
+    #[test]
+    fn extracts_session_token_from_auth_callback_deeplink() {
+        assert_eq!(
+            extract_auth_session_token_from_input(
+                "termy://auth/callback?session_token=abc123&id=user-1&github_user_id=42&github_login=lasse"
+            )
+            .unwrap(),
+            "abc123"
+        );
+    }
+
+    #[test]
+    fn rejects_non_auth_deeplink() {
+        let error = extract_auth_session_token_from_input("termy://settings").unwrap_err();
+        assert!(error.contains("not a theme store auth callback"));
+    }
 }
 
 fn parse_theme_value(theme: &serde_json::Value) -> Option<ThemeStoreTheme> {


### PR DESCRIPTION
This commit introduces a complete device authentication flow allowing users to sign in to the theme store via browser and securely transfer the session to the native app. Changes include:

- New `/device` page on the site for browser-based authentication with deeplink callback
- New `/auth/device-session` API endpoint for creating short-lived session tokens
- New `ImportThemeStoreAuth` command to paste auth tokens from clipboard
- Support for `termy://auth/callback` deeplinks with session parameters
- Adds `webbrowser` crate for cross-platform URL opening
- Updates Cargo.lock with new dependencies (jni, combine, cesu8)

# Pull Request

<!-- A clear and concise description of what this PR does and why it's needed. -->

## Description

<!-- Describe the changes made in the PR. -->

- 
-
-
-

## Screenshots/Videos

<!-- If applicable, add screenshots or screen recordings to help explain your changes. -->


## Related Issues

<!-- If this PR closes any issues, use the keyword 'closes' followed by the issue number -->

Closes #

## Checklist

- [ ] I confirmed there is no existing open PR for the same or overlapping changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Device authentication flow for Theme Store login accessible via `/device` route
  * Import Theme Store Auth command in command palette
  * Support for authentication via clipboard tokens and deeplinks
  * Device session API endpoint for authentication

* **Improvements**
  * Enhanced cross-platform URL opening capability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->