### PR TITLE
Add native context menu for terminal with copy, paste, ask AI, and

### DIFF
--- a/crates/native_sdk/Cargo.toml
+++ b/crates/native_sdk/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 dispatch2 = "0.3.0"
 objc2 = "0.6.3"
 objc2-foundation = { version = "0.3.2", default-features = false, features = ["NSString"] }
-objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSAlert", "NSApplication", "NSButton", "NSControl", "NSResponder", "NSView"] }
+objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSAlert", "NSApplication", "NSButton", "NSControl", "NSEvent", "NSMenu", "NSMenuItem", "NSResponder", "NSView"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.61", features = ["Win32_UI_WindowsAndMessaging"] }

--- a/crates/native_sdk/src/lib.rs
+++ b/crates/native_sdk/src/lib.rs
@@ -1,21 +1,96 @@
 #[cfg(target_os = "macos")]
 use dispatch2::run_on_main;
 #[cfg(target_os = "macos")]
-use objc2_app_kit::{NSAlert, NSAlertSecondButtonReturn};
+use objc2::{
+    DeclaredClass, MainThreadOnly, define_class, msg_send, rc::Retained, runtime::AnyObject, sel,
+};
 #[cfg(target_os = "macos")]
-use objc2_foundation::NSString;
+use objc2_app_kit::{
+    NSAlert, NSAlertSecondButtonReturn, NSApplication, NSEvent, NSMenu, NSMenuItem,
+};
+#[cfg(target_os = "macos")]
+use objc2_foundation::{MainThreadMarker, NSPoint, NSString};
+#[cfg(target_os = "macos")]
+use std::cell::Cell;
+#[cfg(target_os = "macos")]
+use std::sync::atomic::{AtomicI32, Ordering};
 
 #[cfg(target_os = "linux")]
 use std::process::Command;
 
 #[cfg(target_os = "windows")]
+use windows::Win32::Foundation::{HWND, POINT};
+#[cfg(target_os = "windows")]
 use windows::Win32::UI::WindowsAndMessaging::{
-    IDYES, MB_ICONINFORMATION, MB_OK, MB_YESNO, MessageBoxW,
+    AppendMenuW, CreatePopupMenu, DestroyMenu, GetCursorPos, GetForegroundWindow, IDYES,
+    MB_ICONINFORMATION, MB_OK, MB_YESNO, MF_GRAYED, MF_STRING, MessageBoxW, TPM_NONOTIFY,
+    TPM_RETURNCMD, TPM_RIGHTBUTTON, TrackPopupMenu,
 };
 
 #[cfg(target_os = "windows")]
 fn wide_string(s: &str) -> Vec<u16> {
     s.encode_utf16().chain(std::iter::once(0)).collect()
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ContextMenuAction {
+    Copy,
+    Paste,
+    OpenSearch,
+    AskAi,
+    SearchGoogle,
+}
+
+const CONTEXT_MENU_COPY_ID: i32 = 1;
+const CONTEXT_MENU_PASTE_ID: i32 = 2;
+const CONTEXT_MENU_OPEN_SEARCH_ID: i32 = 3;
+const CONTEXT_MENU_ASK_AI_ID: i32 = 4;
+const CONTEXT_MENU_SEARCH_GOOGLE_ID: i32 = 5;
+
+#[cfg(target_os = "macos")]
+static CONTEXT_MENU_SELECTION: AtomicI32 = AtomicI32::new(0);
+
+#[cfg(target_os = "macos")]
+define_class!(
+    #[unsafe(super(NSMenuItem))]
+    #[name = "TermyContextMenuItem"]
+    #[thread_kind = MainThreadOnly]
+    #[ivars = Cell<i32>]
+    struct TermyContextMenuItem;
+
+    impl TermyContextMenuItem {
+        #[unsafe(method(fireContextMenuAction:))]
+        fn fire_context_menu_action(&self, _sender: Option<&AnyObject>) {
+            CONTEXT_MENU_SELECTION.store(self.ivars().get(), Ordering::Relaxed);
+        }
+    }
+);
+
+#[cfg(target_os = "macos")]
+impl TermyContextMenuItem {
+    fn new_with_action_id(
+        mtm: MainThreadMarker,
+        title: &str,
+        action_id: i32,
+        enabled: bool,
+    ) -> Retained<Self> {
+        let this = mtm.alloc().set_ivars(Cell::new(action_id));
+        let title = NSString::from_str(title);
+        let key_equivalent = NSString::from_str("");
+        let item: Retained<Self> = unsafe {
+            msg_send![
+                super(this),
+                initWithTitle: &*title,
+                action: Some(sel!(fireContextMenuAction:)),
+                keyEquivalent: &*key_equivalent
+            ]
+        };
+        unsafe {
+            item.setTarget(Some(&item));
+        }
+        item.setEnabled(enabled);
+        item
+    }
 }
 
 #[cfg(target_os = "linux")]
@@ -76,6 +151,213 @@ pub fn show_alert(title: &str, message: &str) {
     #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
     {
         eprintln!("[native_sdk] show_alert: {title}: {message}");
+    }
+}
+
+pub fn show_copy_paste_context_menu(
+    can_copy: bool,
+    can_paste: bool,
+    can_ask_ai: bool,
+    can_search_google: bool,
+) -> Option<ContextMenuAction> {
+    #[cfg(target_os = "macos")]
+    {
+        fn show_copy_paste_context_menu_on_main(
+            mtm: MainThreadMarker,
+            can_copy: bool,
+            can_paste: bool,
+            can_ask_ai: bool,
+            can_search_google: bool,
+        ) -> Option<ContextMenuAction> {
+            let app = NSApplication::sharedApplication(mtm);
+            let Some(_current_event) = app.currentEvent() else {
+                return None;
+            };
+
+            let menu = NSMenu::new(mtm);
+            menu.setAutoenablesItems(false);
+
+            let copy_item = TermyContextMenuItem::new_with_action_id(
+                mtm,
+                "Copy",
+                CONTEXT_MENU_COPY_ID,
+                can_copy,
+            );
+            let paste_item = TermyContextMenuItem::new_with_action_id(
+                mtm,
+                "Paste",
+                CONTEXT_MENU_PASTE_ID,
+                can_paste,
+            );
+            let ask_ai_item = TermyContextMenuItem::new_with_action_id(
+                mtm,
+                "Ask AI",
+                CONTEXT_MENU_ASK_AI_ID,
+                can_ask_ai,
+            );
+            let open_search_item = TermyContextMenuItem::new_with_action_id(
+                mtm,
+                "Open Search",
+                CONTEXT_MENU_OPEN_SEARCH_ID,
+                true,
+            );
+            let search_google_item = TermyContextMenuItem::new_with_action_id(
+                mtm,
+                "Search Google",
+                CONTEXT_MENU_SEARCH_GOOGLE_ID,
+                can_search_google,
+            );
+
+            menu.addItem(&copy_item);
+            menu.addItem(&paste_item);
+            menu.addItem(&open_search_item);
+            menu.addItem(&ask_ai_item);
+            menu.addItem(&search_google_item);
+
+            CONTEXT_MENU_SELECTION.store(0, Ordering::Relaxed);
+            let location: NSPoint = NSEvent::mouseLocation();
+            let _ = menu.popUpMenuPositioningItem_atLocation_inView(None, location, None);
+
+            match CONTEXT_MENU_SELECTION.swap(0, Ordering::Relaxed) {
+                CONTEXT_MENU_COPY_ID => Some(ContextMenuAction::Copy),
+                CONTEXT_MENU_PASTE_ID => Some(ContextMenuAction::Paste),
+                CONTEXT_MENU_OPEN_SEARCH_ID => Some(ContextMenuAction::OpenSearch),
+                CONTEXT_MENU_ASK_AI_ID => Some(ContextMenuAction::AskAi),
+                CONTEXT_MENU_SEARCH_GOOGLE_ID => Some(ContextMenuAction::SearchGoogle),
+                _ => None,
+            }
+        }
+
+        if let Some(mtm) = MainThreadMarker::new() {
+            return show_copy_paste_context_menu_on_main(
+                mtm,
+                can_copy,
+                can_paste,
+                can_ask_ai,
+                can_search_google,
+            );
+        }
+        return run_on_main(|mtm| {
+            show_copy_paste_context_menu_on_main(
+                mtm,
+                can_copy,
+                can_paste,
+                can_ask_ai,
+                can_search_google,
+            )
+        });
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        let menu = unsafe { CreatePopupMenu().ok()? };
+        struct MenuGuard(windows::Win32::UI::WindowsAndMessaging::HMENU);
+        impl Drop for MenuGuard {
+            fn drop(&mut self) {
+                let _ = unsafe { DestroyMenu(self.0) };
+            }
+        }
+        let _menu_guard = MenuGuard(menu);
+
+        let copy_title = wide_string("Copy");
+        let paste_title = wide_string("Paste");
+        let open_search_title = wide_string("Open Search");
+        let ask_ai_title = wide_string("Ask AI");
+        let search_google_title = wide_string("Search Google");
+        let copy_flags = if can_copy {
+            MF_STRING
+        } else {
+            MF_STRING | MF_GRAYED
+        };
+        let paste_flags = if can_paste {
+            MF_STRING
+        } else {
+            MF_STRING | MF_GRAYED
+        };
+        let ask_ai_flags = if can_ask_ai {
+            MF_STRING
+        } else {
+            MF_STRING | MF_GRAYED
+        };
+        let search_google_flags = if can_search_google {
+            MF_STRING
+        } else {
+            MF_STRING | MF_GRAYED
+        };
+
+        unsafe {
+            AppendMenuW(
+                menu,
+                copy_flags,
+                CONTEXT_MENU_COPY_ID as usize,
+                windows::core::PCWSTR(copy_title.as_ptr()),
+            )
+            .ok()?;
+            AppendMenuW(
+                menu,
+                paste_flags,
+                CONTEXT_MENU_PASTE_ID as usize,
+                windows::core::PCWSTR(paste_title.as_ptr()),
+            )
+            .ok()?;
+            AppendMenuW(
+                menu,
+                MF_STRING,
+                CONTEXT_MENU_OPEN_SEARCH_ID as usize,
+                windows::core::PCWSTR(open_search_title.as_ptr()),
+            )
+            .ok()?;
+            AppendMenuW(
+                menu,
+                ask_ai_flags,
+                CONTEXT_MENU_ASK_AI_ID as usize,
+                windows::core::PCWSTR(ask_ai_title.as_ptr()),
+            )
+            .ok()?;
+            AppendMenuW(
+                menu,
+                search_google_flags,
+                CONTEXT_MENU_SEARCH_GOOGLE_ID as usize,
+                windows::core::PCWSTR(search_google_title.as_ptr()),
+            )
+            .ok()?;
+        }
+
+        let mut cursor = POINT::default();
+        unsafe {
+            GetCursorPos(&mut cursor).ok()?;
+        }
+        let owner: HWND = unsafe { GetForegroundWindow() };
+        let result = unsafe {
+            TrackPopupMenu(
+                menu,
+                TPM_RETURNCMD | TPM_RIGHTBUTTON | TPM_NONOTIFY,
+                cursor.x,
+                cursor.y,
+                Some(0),
+                owner,
+                None,
+            )
+            .0
+        };
+
+        return match result {
+            CONTEXT_MENU_COPY_ID => Some(ContextMenuAction::Copy),
+            CONTEXT_MENU_PASTE_ID => Some(ContextMenuAction::Paste),
+            CONTEXT_MENU_OPEN_SEARCH_ID => Some(ContextMenuAction::OpenSearch),
+            CONTEXT_MENU_ASK_AI_ID => Some(ContextMenuAction::AskAi),
+            CONTEXT_MENU_SEARCH_GOOGLE_ID => Some(ContextMenuAction::SearchGoogle),
+            _ => None,
+        };
+    }
+
+    #[cfg(any(
+        target_os = "linux",
+        not(any(target_os = "macos", target_os = "windows"))
+    ))]
+    {
+        let _ = (can_copy, can_paste, can_ask_ai, can_search_google);
+        None
     }
 }
 

--- a/site/index.html
+++ b/site/index.html
@@ -8,7 +8,13 @@
       href="https://raw.githubusercontent.com/lassejlv/termy/refs/heads/main/assets/termy_icon.png"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="preload" href="/fonts/outfit-latin.woff2" as="font" type="font/woff2" crossorigin />
+    <link
+      rel="preload"
+      href="/fonts/outfit-latin.woff2"
+      as="font"
+      type="font/woff2"
+      crossorigin
+    />
     <title>Termy</title>
   </head>
   <body>
@@ -18,6 +24,13 @@
       defer
       src="https://analytics.beer/script.js"
       data-website-id="e7d3ed1c-80ec-4d81-91f4-79da987aea91"
+    ></script>
+    <script
+      defer
+      data-site-id="f9290160-3f4f-49b7-9fea-682d804bc0d9"
+      data-endpoint="https://cdn.usedatix.com/api/event"
+      data-site-domain="termy.run"
+      src="https://cdn.usedatix.com/script.js"
     ></script>
   </body>
 </html>

--- a/src/terminal_view/ai_input.rs
+++ b/src/terminal_view/ai_input.rs
@@ -27,6 +27,8 @@ impl TerminalView {
             return;
         }
 
+        let _ = self.close_terminal_context_menu(cx);
+
         // Close other overlays
         if self.is_command_palette_open() {
             self.close_command_palette(cx);

--- a/src/terminal_view/command_palette/mod.rs
+++ b/src/terminal_view/command_palette/mod.rs
@@ -296,6 +296,7 @@ impl TerminalView {
         mode: CommandPaletteMode,
         cx: &mut Context<Self>,
     ) {
+        let _ = self.close_terminal_context_menu(cx);
         let was_open = self.command_palette.is_open();
         self.command_palette.open(mode);
         let notify_event = if was_open {

--- a/src/terminal_view/interaction/context_menu.rs
+++ b/src/terminal_view/interaction/context_menu.rs
@@ -1,0 +1,218 @@
+use super::*;
+
+impl TerminalView {
+    fn terminal_context_menu_capabilities(
+        &self,
+        cx: &mut Context<Self>,
+    ) -> (bool, bool, bool, bool) {
+        let has_selection = self.selected_text().is_some();
+        let can_copy = has_selection;
+        let can_paste = cx
+            .read_from_clipboard()
+            .and_then(|item| item.text())
+            .is_some();
+        let can_ask_ai = has_selection;
+        let can_search_google = has_selection;
+        (can_copy, can_paste, can_ask_ai, can_search_google)
+    }
+
+    fn command_action_for_context_menu_action(
+        action: termy_native_sdk::ContextMenuAction,
+    ) -> Option<CommandAction> {
+        match action {
+            termy_native_sdk::ContextMenuAction::Copy => Some(CommandAction::Copy),
+            termy_native_sdk::ContextMenuAction::Paste => Some(CommandAction::Paste),
+            termy_native_sdk::ContextMenuAction::OpenSearch => Some(CommandAction::OpenSearch),
+            termy_native_sdk::ContextMenuAction::AskAi
+            | termy_native_sdk::ContextMenuAction::SearchGoogle => None,
+        }
+    }
+
+    pub(in super::super) fn close_terminal_context_menu(&mut self, cx: &mut Context<Self>) -> bool {
+        if self.terminal_context_menu.take().is_some() {
+            self.notify_overlay(cx);
+            true
+        } else {
+            false
+        }
+    }
+
+    pub(in super::super) fn execute_terminal_context_menu_command(
+        &mut self,
+        action: CommandAction,
+        cx: &mut Context<Self>,
+    ) {
+        if !matches!(action, CommandAction::Copy | CommandAction::Paste) {
+            return;
+        }
+        let _ = self.close_terminal_context_menu(cx);
+        let _ = self.execute_input_command_action(action, cx);
+    }
+
+    fn execute_terminal_context_menu_action(
+        &mut self,
+        action: termy_native_sdk::ContextMenuAction,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(command_action) = Self::command_action_for_context_menu_action(action) {
+            if command_action == CommandAction::OpenSearch {
+                let _ = self.close_terminal_context_menu(cx);
+                self.open_search(cx);
+            } else {
+                self.execute_terminal_context_menu_command(command_action, cx);
+            }
+            return;
+        }
+
+        if action == termy_native_sdk::ContextMenuAction::AskAi {
+            self.execute_terminal_context_menu_ask_ai(cx);
+            return;
+        }
+
+        if action == termy_native_sdk::ContextMenuAction::SearchGoogle {
+            self.execute_terminal_context_menu_search_google(cx);
+        }
+    }
+
+    pub(in super::super) fn execute_terminal_context_menu_ask_ai(
+        &mut self,
+        cx: &mut Context<Self>,
+    ) {
+        let selected = self.selected_text();
+        let _ = self.close_terminal_context_menu(cx);
+        self.open_ai_input(cx);
+        if let Some(selected) = selected {
+            self.ai_input_mut().set_text(selected);
+            self.reset_cursor_blink_phase();
+            cx.notify();
+        }
+    }
+
+    pub(in super::super) fn execute_terminal_context_menu_search_google(
+        &mut self,
+        cx: &mut Context<Self>,
+    ) {
+        let selected = self.selected_text();
+        let _ = self.close_terminal_context_menu(cx);
+        let Some(selected) = selected else {
+            return;
+        };
+        if selected.trim().is_empty() {
+            return;
+        }
+
+        let query: String = url::form_urlencoded::byte_serialize(selected.as_bytes()).collect();
+        let url = format!("https://www.google.com/search?q={query}");
+        if let Err(error) = webbrowser::open(&url) {
+            termy_toast::error(format!("Failed to open browser: {error}"));
+            self.notify_overlay(cx);
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn schedule_native_terminal_context_menu(
+        &mut self,
+        can_copy: bool,
+        can_paste: bool,
+        can_ask_ai: bool,
+        can_search_google: bool,
+        cx: &mut Context<Self>,
+    ) {
+        cx.spawn(async move |this: WeakEntity<Self>, cx: &mut AsyncApp| {
+            let action = smol::unblock(move || {
+                termy_native_sdk::show_copy_paste_context_menu(
+                    can_copy,
+                    can_paste,
+                    can_ask_ai,
+                    can_search_google,
+                )
+            })
+            .await;
+            let Some(action) = action else {
+                return;
+            };
+
+            let _ = cx.update(|cx| {
+                this.update(cx, |view, cx| {
+                    view.execute_terminal_context_menu_action(action, cx);
+                })
+            });
+        })
+        .detach();
+    }
+
+    pub(in super::super) fn open_terminal_context_menu(
+        &mut self,
+        position: gpui::Point<Pixels>,
+        cx: &mut Context<Self>,
+    ) {
+        let (can_copy, can_paste, can_ask_ai, can_search_google) =
+            self.terminal_context_menu_capabilities(cx);
+
+        #[cfg(target_os = "linux")]
+        {
+            let state = TerminalContextMenuState {
+                anchor_position: position,
+                can_copy,
+                can_paste,
+                can_ask_ai,
+                can_search_google,
+            };
+            if self.terminal_context_menu != Some(state) {
+                self.terminal_context_menu = Some(state);
+                self.notify_overlay(cx);
+            }
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = position;
+            self.schedule_native_terminal_context_menu(
+                can_copy,
+                can_paste,
+                can_ask_ai,
+                can_search_google,
+                cx,
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn context_menu_action_maps_to_command_action() {
+        assert_eq!(
+            TerminalView::command_action_for_context_menu_action(
+                termy_native_sdk::ContextMenuAction::Copy
+            ),
+            Some(CommandAction::Copy)
+        );
+        assert_eq!(
+            TerminalView::command_action_for_context_menu_action(
+                termy_native_sdk::ContextMenuAction::Paste
+            ),
+            Some(CommandAction::Paste)
+        );
+        assert_eq!(
+            TerminalView::command_action_for_context_menu_action(
+                termy_native_sdk::ContextMenuAction::OpenSearch
+            ),
+            Some(CommandAction::OpenSearch)
+        );
+        assert_eq!(
+            TerminalView::command_action_for_context_menu_action(
+                termy_native_sdk::ContextMenuAction::AskAi
+            ),
+            None
+        );
+        assert_eq!(
+            TerminalView::command_action_for_context_menu_action(
+                termy_native_sdk::ContextMenuAction::SearchGoogle
+            ),
+            None
+        );
+    }
+}

--- a/src/terminal_view/interaction/input.rs
+++ b/src/terminal_view/interaction/input.rs
@@ -197,6 +197,7 @@ impl TerminalView {
         cx: &mut Context<Self>,
     ) {
         self.reset_cursor_blink_phase();
+        let _ = self.close_terminal_context_menu(cx);
         let key = event.keystroke.key.as_str();
         self.maybe_suppress_tab_switch_hint_for_key_down(key, event.keystroke.modifiers, cx);
 
@@ -251,6 +252,7 @@ impl TerminalView {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        let _ = self.close_terminal_context_menu(cx);
         let paths_list = paths.paths();
         if paths_list.is_empty() {
             return;

--- a/src/terminal_view/interaction/mod.rs
+++ b/src/terminal_view/interaction/mod.rs
@@ -2,6 +2,7 @@ use super::*;
 
 mod actions;
 mod app;
+mod context_menu;
 mod input;
 mod install_cli;
 mod layout;

--- a/src/terminal_view/interaction/mouse.rs
+++ b/src/terminal_view/interaction/mouse.rs
@@ -550,6 +550,10 @@ impl TerminalView {
         button == MouseButton::Left && selection_dragging
     }
 
+    fn is_terminal_context_menu_passthrough(modifiers: gpui::Modifiers) -> bool {
+        modifiers.shift
+    }
+
     pub(in super::super) fn handle_global_mouse_move_event(
         &mut self,
         event: &MouseMoveEvent,
@@ -578,6 +582,12 @@ impl TerminalView {
         event: &MouseUpEvent,
         cx: &mut Context<Self>,
     ) -> bool {
+        if event.button == MouseButton::Right
+            && Self::is_terminal_context_menu_passthrough(event.modifiers)
+        {
+            return self.force_forward_right_mouse_up(event, cx);
+        }
+
         if event.button == MouseButton::Left && self.agent_sidebar_resize_drag.take().is_some() {
             if let Err(error) = self.persist_agent_sidebar_width() {
                 termy_toast::error(error);
@@ -606,6 +616,9 @@ impl TerminalView {
         // Focus the terminal on click
         self.focus_handle.focus(window, cx);
         self.reset_cursor_blink_phase();
+        if event.button != MouseButton::Right {
+            let _ = self.close_terminal_context_menu(cx);
+        }
         let mut changed = false;
         if event.button == MouseButton::Left && self.tab_strip.drag.is_some() {
             self.commit_tab_drag(cx);
@@ -617,6 +630,23 @@ impl TerminalView {
         }
         if changed {
             cx.notify();
+        }
+
+        if event.button == MouseButton::Right {
+            if Self::is_terminal_context_menu_passthrough(event.modifiers) {
+                let _ = self.close_terminal_context_menu(cx);
+                let _ = self.force_forward_right_mouse_down(event, cx);
+                return;
+            }
+
+            if let Some((pane_id, _)) = self.position_to_pane_cell(event.position, false)
+                && !self.is_active_pane_id(pane_id.as_str())
+            {
+                let _ = self.focus_pane_target(pane_id.as_str(), cx);
+            }
+            self.open_terminal_context_menu(event.position, cx);
+            cx.stop_propagation();
+            return;
         }
 
         if self.try_forward_mouse_down(event, cx) {
@@ -789,6 +819,13 @@ impl TerminalView {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if event.button == MouseButton::Right
+            && Self::is_terminal_context_menu_passthrough(event.modifiers)
+        {
+            let _ = self.force_forward_right_mouse_up(event, cx);
+            return;
+        }
+
         if event.button == MouseButton::Left && self.stop_terminal_scrollbar_track_hold() {
             cx.stop_propagation();
             cx.notify();
@@ -875,5 +912,17 @@ mod tests {
             MouseButton::Right,
             true
         ));
+    }
+
+    #[test]
+    fn terminal_context_menu_passthrough_requires_shift_modifier() {
+        let shifted = gpui::Modifiers {
+            shift: true,
+            ..gpui::Modifiers::default()
+        };
+        let plain = gpui::Modifiers::default();
+
+        assert!(TerminalView::is_terminal_context_menu_passthrough(shifted));
+        assert!(!TerminalView::is_terminal_context_menu_passthrough(plain));
     }
 }

--- a/src/terminal_view/interaction/mouse_reporting.rs
+++ b/src/terminal_view/interaction/mouse_reporting.rs
@@ -358,6 +358,46 @@ impl TerminalView {
         true
     }
 
+    pub(in super::super) fn force_forward_right_mouse_down(
+        &mut self,
+        event: &MouseDownEvent,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        if event.button != MouseButton::Right {
+            return false;
+        }
+
+        let Some((pane_id, cell)) = self.position_to_pane_cell(event.position, false) else {
+            return false;
+        };
+
+        let outcome = self.try_send_mouse_event_to_pane(
+            pane_id.as_str(),
+            TerminalMouseEventKind::Press(TerminalMouseButton::Right),
+            cell,
+            event.modifiers,
+        );
+        if !outcome.is_handled() {
+            return false;
+        }
+
+        self.set_pressed_mouse_target(
+            MouseTrackedButton::Right,
+            MouseReportTargetCell {
+                pane_id: pane_id.clone(),
+                col: cell.col,
+                row: cell.row,
+            },
+        );
+        self.mouse_reporting.hover_target = None;
+        if should_focus_target_after_mouse_press(outcome, self.is_active_pane_id(pane_id.as_str()))
+        {
+            let _ = self.focus_pane_target(pane_id.as_str(), cx);
+        }
+        cx.stop_propagation();
+        true
+    }
+
     pub(in super::super) fn try_forward_mouse_move(
         &mut self,
         event: &MouseMoveEvent,
@@ -491,6 +531,42 @@ impl TerminalView {
         let outcome = self.try_send_mouse_event_to_pane(
             tracked.pane_id.as_str(),
             TerminalMouseEventKind::Release(button.terminal_button()),
+            cell,
+            event.modifiers,
+        );
+        if outcome.is_handled() {
+            cx.stop_propagation();
+            return true;
+        }
+        false
+    }
+
+    pub(in super::super) fn force_forward_right_mouse_up(
+        &mut self,
+        event: &MouseUpEvent,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        if event.button != MouseButton::Right {
+            return false;
+        }
+
+        let Some(tracked) = self.take_pressed_mouse_target(MouseTrackedButton::Right) else {
+            return false;
+        };
+        self.mouse_reporting.hover_target = None;
+        if self.pane_terminal_by_id(tracked.pane_id.as_str()).is_none() {
+            return false;
+        }
+        let cell = self
+            .position_to_cell_in_pane(tracked.pane_id.as_str(), event.position, true)
+            .unwrap_or(CellPos {
+                col: tracked.col,
+                row: tracked.row,
+            });
+
+        let outcome = self.try_send_mouse_event_to_pane(
+            tracked.pane_id.as_str(),
+            TerminalMouseEventKind::Release(TerminalMouseButton::Right),
             cell,
             event.modifiers,
         );

--- a/src/terminal_view/interaction/scroll.rs
+++ b/src/terminal_view/interaction/scroll.rs
@@ -404,6 +404,8 @@ impl TerminalView {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        let _ = self.close_terminal_context_menu(cx);
+
         if self.consume_suppressed_scroll_event(event.touch_phase, cx) {
             return;
         }

--- a/src/terminal_view/mod.rs
+++ b/src/terminal_view/mod.rs
@@ -219,6 +219,15 @@ struct TerminalScrollbarHit {
     thumb_top: f32,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct TerminalContextMenuState {
+    anchor_position: gpui::Point<Pixels>,
+    can_copy: bool,
+    can_paste: bool,
+    can_ask_ai: bool,
+    can_search_google: bool,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct TerminalScrollbarMarkerCacheKey {
     results_revision: u64,
@@ -1094,6 +1103,7 @@ pub struct TerminalView {
     selection_head: Option<SelectionPos>,
     selection_dragging: bool,
     selection_moved: bool,
+    terminal_context_menu: Option<TerminalContextMenuState>,
     hovered_link: Option<HoveredLink>,
     hovered_toast: Option<u64>,
     copied_toast_feedback: Option<(u64, Instant)>,
@@ -2237,6 +2247,7 @@ impl TerminalView {
             selection_head: None,
             selection_dragging: false,
             selection_moved: false,
+            terminal_context_menu: None,
             hovered_link: None,
             hovered_toast: None,
             copied_toast_feedback: None,
@@ -2333,7 +2344,8 @@ impl TerminalView {
         cx.on_blur(&blur_focus_handle, window, |view, _window, cx| {
             let released_mouse_presses = view.release_all_forwarded_mouse_presses();
             let cleared_tab_switch_hint_state = view.tab_strip.switch_hints.reset_hold_state();
-            if released_mouse_presses || cleared_tab_switch_hint_state {
+            let dismissed_context_menu = view.close_terminal_context_menu(cx);
+            if released_mouse_presses || cleared_tab_switch_hint_state || dismissed_context_menu {
                 cx.notify();
             }
         })

--- a/src/terminal_view/render.rs
+++ b/src/terminal_view/render.rs
@@ -1476,6 +1476,229 @@ impl TerminalView {
         )
     }
 
+    #[cfg(target_os = "linux")]
+    fn clamped_terminal_context_menu_origin(
+        &self,
+        anchor: gpui::Point<Pixels>,
+        menu_width: f32,
+        menu_height: f32,
+    ) -> (f32, f32) {
+        let mut x: f32 = anchor.x.into();
+        let mut y: f32 = anchor.y.into();
+
+        if let Some((viewport_width, viewport_height)) = self.last_viewport_size_px {
+            let max_x = (viewport_width as f32 - menu_width).max(0.0);
+            let max_y = (viewport_height as f32 - menu_height).max(0.0);
+            x = x.clamp(0.0, max_x);
+            y = y.clamp(0.0, max_y);
+        }
+
+        (x, y)
+    }
+
+    fn render_terminal_context_menu_overlay(
+        &mut self,
+        cx: &mut Context<Self>,
+    ) -> Option<AnyElement> {
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = cx;
+            return None;
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            let state = self.terminal_context_menu?;
+            let overlay_style = self.overlay_style();
+            let menu_width = 170.0;
+            let row_height = 30.0;
+            let menu_height = row_height * 5.0 + 8.0;
+            let (menu_x, menu_y) = self.clamped_terminal_context_menu_origin(
+                state.anchor_position,
+                menu_width,
+                menu_height,
+            );
+            let panel_bg = overlay_style.panel_background(0.98);
+            let panel_border = overlay_style.panel_foreground(0.22);
+            let text_active = overlay_style.panel_foreground(0.95);
+            let text_disabled = overlay_style.panel_foreground(0.42);
+            let hover_bg = overlay_style.panel_cursor(0.22);
+
+            let command_item =
+                |id: &'static str, label: &'static str, enabled: bool, action: CommandAction| {
+                    let text_color = if enabled { text_active } else { text_disabled };
+                    div()
+                        .id(id)
+                        .h(px(row_height))
+                        .px(px(10.0))
+                        .flex()
+                        .items_center()
+                        .text_size(px(13.0))
+                        .text_color(text_color)
+                        .when(enabled, |s| s.cursor_pointer())
+                        .when(enabled, |s| s.hover(|style| style.bg(hover_bg)))
+                        .when(enabled, |s| {
+                            s.on_mouse_down(
+                                MouseButton::Left,
+                                cx.listener(move |view, _event: &MouseDownEvent, _window, cx| {
+                                    view.execute_terminal_context_menu_command(action, cx);
+                                    cx.stop_propagation();
+                                }),
+                            )
+                        })
+                        .child(label)
+                        .into_any_element()
+                };
+            let ask_ai_item = |enabled: bool| {
+                let text_color = if enabled { text_active } else { text_disabled };
+                div()
+                    .id("terminal-context-menu-ask-ai")
+                    .h(px(row_height))
+                    .px(px(10.0))
+                    .flex()
+                    .items_center()
+                    .text_size(px(13.0))
+                    .text_color(text_color)
+                    .when(enabled, |s| s.cursor_pointer())
+                    .when(enabled, |s| s.hover(|style| style.bg(hover_bg)))
+                    .when(enabled, |s| {
+                        s.on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(move |view, _event: &MouseDownEvent, _window, cx| {
+                                view.execute_terminal_context_menu_ask_ai(cx);
+                                cx.stop_propagation();
+                            }),
+                        )
+                    })
+                    .child("Ask AI")
+                    .into_any_element()
+            };
+            let open_search_item = || {
+                div()
+                    .id("terminal-context-menu-open-search")
+                    .h(px(row_height))
+                    .px(px(10.0))
+                    .flex()
+                    .items_center()
+                    .text_size(px(13.0))
+                    .text_color(text_active)
+                    .cursor_pointer()
+                    .hover(|style| style.bg(hover_bg))
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(move |view, _event: &MouseDownEvent, _window, cx| {
+                            let _ = view.close_terminal_context_menu(cx);
+                            view.open_search(cx);
+                            cx.stop_propagation();
+                        }),
+                    )
+                    .child("Open Search")
+                    .into_any_element()
+            };
+            let search_google_item = |enabled: bool| {
+                let text_color = if enabled { text_active } else { text_disabled };
+                div()
+                    .id("terminal-context-menu-search-google")
+                    .h(px(row_height))
+                    .px(px(10.0))
+                    .flex()
+                    .items_center()
+                    .text_size(px(13.0))
+                    .text_color(text_color)
+                    .when(enabled, |s| s.cursor_pointer())
+                    .when(enabled, |s| s.hover(|style| style.bg(hover_bg)))
+                    .when(enabled, |s| {
+                        s.on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(move |view, _event: &MouseDownEvent, _window, cx| {
+                                view.execute_terminal_context_menu_search_google(cx);
+                                cx.stop_propagation();
+                            }),
+                        )
+                    })
+                    .child("Search Google")
+                    .into_any_element()
+            };
+
+            Some(
+                div()
+                    .id("terminal-context-menu-overlay")
+                    .absolute()
+                    .top_0()
+                    .left_0()
+                    .right_0()
+                    .bottom_0()
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(|view, _event: &MouseDownEvent, _window, cx| {
+                            let _ = view.close_terminal_context_menu(cx);
+                            cx.stop_propagation();
+                        }),
+                    )
+                    .on_mouse_down(
+                        MouseButton::Middle,
+                        cx.listener(|view, _event: &MouseDownEvent, _window, cx| {
+                            let _ = view.close_terminal_context_menu(cx);
+                            cx.stop_propagation();
+                        }),
+                    )
+                    .on_mouse_down(
+                        MouseButton::Right,
+                        cx.listener(|view, event: &MouseDownEvent, _window, cx| {
+                            view.open_terminal_context_menu(event.position, cx);
+                            cx.stop_propagation();
+                        }),
+                    )
+                    .child(
+                        div()
+                            .id("terminal-context-menu-panel")
+                            .absolute()
+                            .left(px(menu_x))
+                            .top(px(menu_y))
+                            .w(px(menu_width))
+                            .py(px(4.0))
+                            .bg(panel_bg)
+                            .border_1()
+                            .border_color(panel_border)
+                            .on_mouse_down(
+                                MouseButton::Left,
+                                cx.listener(|_view, _event: &MouseDownEvent, _window, cx| {
+                                    cx.stop_propagation();
+                                }),
+                            )
+                            .on_mouse_down(
+                                MouseButton::Middle,
+                                cx.listener(|_view, _event: &MouseDownEvent, _window, cx| {
+                                    cx.stop_propagation();
+                                }),
+                            )
+                            .on_mouse_down(
+                                MouseButton::Right,
+                                cx.listener(|_view, _event: &MouseDownEvent, _window, cx| {
+                                    cx.stop_propagation();
+                                }),
+                            )
+                            .child(command_item(
+                                "terminal-context-menu-copy",
+                                "Copy",
+                                state.can_copy,
+                                CommandAction::Copy,
+                            ))
+                            .child(command_item(
+                                "terminal-context-menu-paste",
+                                "Paste",
+                                state.can_paste,
+                                CommandAction::Paste,
+                            ))
+                            .child(open_search_item())
+                            .child(ask_ai_item(state.can_ask_ai))
+                            .child(search_google_item(state.can_search_google)),
+                    )
+                    .into_any_element(),
+            )
+        }
+    }
+
     pub(super) fn render_overlay_layer(
         &mut self,
         _window: &mut Window,
@@ -1558,6 +1781,7 @@ impl TerminalView {
                 .children(ai_input_overlay)
                 .into_any_element()
         });
+        let context_menu_overlay = self.render_terminal_context_menu_overlay(cx);
         let toast_overlay = self.render_toast_overlay(&colors, cx);
         let resize_overlay = self
             .resize_indicator_visible_until
@@ -1653,6 +1877,7 @@ impl TerminalView {
             .size_full()
             .children(banner_overlay)
             .children(terminal_overlay)
+            .children(context_menu_overlay)
             .children(resize_overlay)
             .children(debug_overlay)
             .children(toast_overlay)

--- a/src/terminal_view/search.rs
+++ b/src/terminal_view/search.rs
@@ -45,6 +45,8 @@ impl TerminalView {
             return;
         }
 
+        let _ = self.close_terminal_context_menu(cx);
+
         // Close other overlays
         if self.is_command_palette_open() {
             self.close_command_palette(cx);


### PR DESCRIPTION
search

Implement platform-native context menus for macOS and Windows using objc2-app-kit and Win32 APIs, with a custom GPUI-based menu for Linux. Menu includes Copy, Paste, Open Search, Ask AI, and Search Google options
with proper state management and overlay dismissal handling.

# Pull Request

<!-- A clear and concise description of what this PR does and why it's needed. -->

## Description

<!-- Describe the changes made in the PR. -->

- 
-
-
-

## Screenshots/Videos

<!-- If applicable, add screenshots or screen recordings to help explain your changes. -->


## Related Issues

<!-- If this PR closes any issues, use the keyword 'closes' followed by the issue number -->

Closes #

## Checklist

- [ ] I confirmed there is no existing open PR for the same or overlapping changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a cross-platform context menu for terminal interactions with Copy, Paste, Open Search, Ask AI, and Search Google options.
  * Implemented right-click context menu support on macOS, Windows, and Linux with shift-modifier passthrough for native menus.
  * Added analytics integration.

* **Bug Fixes**
  * Context menu now properly closes when opening other overlays like command palette, search, and AI input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->