### PR TITLE
Add CONTRIBUTING.md, warn_on_quit setting, and prettify config command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,147 @@
+# Contributing to Termy
+
+Thanks for contributing.
+
+This guide focuses on the current Termy workflow so you can get a change from clone to PR without guessing.
+
+## Before you start
+
+- Check open issues and PRs for overlap before starting a larger change.
+- Keep changes scoped. Small, reviewable PRs move faster here.
+- If you touch generated docs, regenerate them instead of editing generated files by hand.
+
+## Project layout
+
+- `src/`: main desktop app built with Rust + GPUI
+- `crates/`: shared workspace crates such as config, command catalog, plugin host, search, terminal UI, and CLI helpers
+- `docs/`: repository docs used by contributors
+- `site/`: website and public docs
+- `.github/`: issue templates, PR template, and CI workflows
+
+## Local setup
+
+Requirements:
+
+- Rust stable toolchain
+- Platform build dependencies for GPUI and native packaging where relevant
+
+Optional tools:
+
+- `just` for the repo command shortcuts
+- `cargo-watch` if you want the `just dev` loop
+- `tmux >= 3.3` if you want to run tmux integration tests
+
+Clone and verify the workspace:
+
+```sh
+cargo check --workspace
+```
+
+## Common commands
+
+Run the app:
+
+```sh
+cargo run -p termy
+```
+
+Useful `just` commands:
+
+```sh
+just
+just check
+just dev
+just test-tmux-integration
+just check-boundaries
+```
+
+## Docs and generated files
+
+These files are generated. Do not edit them manually:
+
+- `docs/keybindings.md`
+- `docs/configuration.md`
+
+Regenerate them with:
+
+```sh
+just generate-keybindings-doc
+just generate-config-doc
+```
+
+Or verify they are up to date with:
+
+```sh
+just check-keybindings-doc
+just check-config-doc
+```
+
+## Testing and validation
+
+Use the smallest validation pass that proves your change.
+
+Common options:
+
+```sh
+cargo check -p termy
+cargo test -p termy_config_core
+just check-boundaries
+```
+
+If your change touches tmux behavior, also run:
+
+```sh
+just test-tmux-integration
+```
+
+## Config and command changes
+
+If you change config keys:
+
+- update the config schema in `crates/config_core`
+- keep parsing, defaults, and rendering in sync
+- regenerate config docs
+
+If you change commands or keybind-facing actions:
+
+- update the command catalog in `crates/command_core`
+- wire the action through the app in `src/`
+- regenerate keybinding docs if defaults or public command names changed
+
+## Documentation changes
+
+Pick the right place:
+
+- contributor-facing repo docs: `docs/`
+- public user docs: `site/src/content/`
+- quick project entry points: `README.md`
+
+When behavior changes, update docs in the same PR.
+
+## Pull requests
+
+Before opening a PR:
+
+- make sure the branch is up to date enough to review cleanly
+- run the relevant checks for your change
+- fill out `.github/PULL_REQUEST_TEMPLATE.md`
+- link the issue with `Closes #<number>` when appropriate
+
+Good PRs usually include:
+
+- what changed
+- why it changed
+- any user-visible behavior changes
+- screenshots or video for UI work
+- notes about tests or intentionally skipped validation
+
+## Style expectations
+
+- Prefer small, explicit code paths over clever abstractions.
+- Preserve existing project structure and naming where possible.
+- Keep docs and behavior aligned.
+- Avoid unrelated drive-by changes in the same PR.
+
+## Questions
+
+If the right direction is unclear, open an issue first or start with a smaller draft PR that frames the change.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
   <p>A minimal terminal emulator built with <a href="https://gpui.rs">GPUI</a> and <a href="https://alacritty.org">alacritty_terminal</a>.</p>
   <p>
     <a href="https://termy.run/docs">Documentation</a> •
+    <a href="CONTRIBUTING.md">Contributing</a> •
     <a href="https://github.com/lassejlv/termy/releases/latest">Download</a> •
     <a href="https://github.com/lassejlv/termy">GitHub</a> •
     <a href="https://github.com/sponsors/lassejlv">Sponsor</a>
@@ -16,6 +17,10 @@
 ## Download
 
 [Download Termy](https://termy.run/#download) for your platform at termy.run
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, validation commands, and PR expectations.
 
 ## License
 

--- a/crates/command_core/src/catalog.rs
+++ b/crates/command_core/src/catalog.rs
@@ -39,6 +39,7 @@ macro_rules! termy_command_catalog {
             (AppInfo, "app_info"),
             (RestartApp, "restart_app"),
             (OpenConfig, "open_config"),
+            (PrettifyConfig, "prettify_config"),
             (OpenSettings, "open_settings"),
             (ImportThemeStoreAuth, "import_theme_store_auth"),
             (ImportColors, "import_colors"),

--- a/crates/config_core/src/constants.rs
+++ b/crates/config_core/src/constants.rs
@@ -20,6 +20,7 @@ pub(crate) const MAX_PANE_FOCUS_STRENGTH: f32 = 2.0;
 pub(crate) const MIN_MOUSE_SCROLL_MULTIPLIER: f32 = 0.1;
 pub(crate) const MAX_MOUSE_SCROLL_MULTIPLIER: f32 = 1_000.0;
 pub(crate) const DEFAULT_CURSOR_BLINK: bool = true;
+pub(crate) const DEFAULT_WARN_ON_QUIT: bool = false;
 pub(crate) const DEFAULT_WARN_ON_QUIT_WITH_RUNNING_PROCESS: bool = true;
 
 pub const VALID_ROOT_KEYS: &[&str] = ROOT_SETTING_ALL_KEYS;

--- a/crates/config_core/src/default_config.txt
+++ b/crates/config_core/src/default_config.txt
@@ -25,6 +25,8 @@ tmux_show_active_pane_border = false
 # working_dir = none
 # Directory used when working_dir is unset
 # working_dir_fallback = home
+# Warn every time you try to quit the app
+warn_on_quit = false
 # Warn before quitting when a tab has an active process
 warn_on_quit_with_running_process = true
 # Exact source priority for tab titles

--- a/crates/config_core/src/parser.rs
+++ b/crates/config_core/src/parser.rs
@@ -245,6 +245,13 @@ impl AppConfig {
                         );
                     }
                 }
+                RootSettingId::WarnOnQuit => {
+                    if let Some(parsed) =
+                        parse_bool_field(&mut diagnostics, line_number, key, value)
+                    {
+                        config.warn_on_quit = parsed;
+                    }
+                }
                 RootSettingId::WarnOnQuitWithRunningProcess => {
                     if let Some(parsed) =
                         parse_bool_field(&mut diagnostics, line_number, key, value)

--- a/crates/config_core/src/parser_tests.rs
+++ b/crates/config_core/src/parser_tests.rs
@@ -278,6 +278,7 @@ fn bool_root_setting_value(config: &AppConfig, setting: RootSettingId) -> Option
         RootSettingId::ShowPluginsTab => Some(config.show_plugins_tab),
         RootSettingId::ShowDebugOverlay => Some(config.show_debug_overlay),
         RootSettingId::TmuxShowActivePaneBorder => Some(config.tmux_show_active_pane_border),
+        RootSettingId::WarnOnQuit => Some(config.warn_on_quit),
         RootSettingId::WarnOnQuitWithRunningProcess => {
             Some(config.warn_on_quit_with_running_process)
         }
@@ -548,8 +549,10 @@ fn keybind_lines_are_collected_in_order_with_line_numbers() {
 fn removed_hide_titlebar_buttons_key_is_ignored_as_unknown() {
     let configured = parse(
         "hide_titlebar_buttons = true\n\
+         warn_on_quit = true\n\
          warn_on_quit_with_running_process = false\n",
     );
+    assert!(configured.warn_on_quit);
     assert!(!configured.warn_on_quit_with_running_process);
 }
 

--- a/crates/config_core/src/schema.rs
+++ b/crates/config_core/src/schema.rs
@@ -322,7 +322,8 @@ define_root_settings! {
     (TmuxShowActivePaneBorder, "tmux_show_active_pane_border", [], Terminal, "TMUX", "Show Active Pane Border", "Show active tmux pane border highlight in managed sessions", ["tmux", "pane", "border", "highlight"], RootSettingValueKind::Boolean, false),
     (WorkingDir, "working_dir", [], Advanced, "STARTUP", "Working Directory", "Initial directory for new sessions", ["working directory", "cwd", "startup", "path"], RootSettingValueKind::Text, false),
     (WorkingDirFallback, "working_dir_fallback", ["default_working_dir"], Advanced, "STARTUP", "Working Directory Fallback", "Directory used when working_dir is unset", ["working directory", "fallback", "cwd", "startup"], RootSettingValueKind::Enum, false),
-    (WarnOnQuitWithRunningProcess, "warn_on_quit_with_running_process", [], Advanced, "SAFETY", "Warn On Quit", "Warn before quitting when a tab has an active process", ["quit", "warning", "safety", "process"], RootSettingValueKind::Boolean, false),
+    (WarnOnQuit, "warn_on_quit", [], Advanced, "SAFETY", "Always Warn On Quit", "Warn every time you try to quit the app", ["quit", "warning", "safety", "always"], RootSettingValueKind::Boolean, false),
+    (WarnOnQuitWithRunningProcess, "warn_on_quit_with_running_process", [], Advanced, "SAFETY", "Warn On Quit With Running Process", "Warn before quitting when a tab has an active process", ["quit", "warning", "safety", "process"], RootSettingValueKind::Boolean, false),
     (TabTitlePriority, "tab_title_priority", [], Tabs, "TAB TITLES", "Title Priority", "Exact source priority for tab titles", ["tab", "title", "priority", "source"], RootSettingValueKind::Special, false),
     (TabTitleMode, "tab_title_mode", [], Tabs, "TAB TITLES", "Title Mode", "How tab titles are determined", ["tab", "title", "mode", "smart", "shell", "explicit", "static"], RootSettingValueKind::Enum, false),
     (TabTitleFallback, "tab_title_fallback", [], Tabs, "TAB TITLES", "Fallback Title", "Default tab title when no source is available", ["tab", "title", "fallback"], RootSettingValueKind::Text, false),
@@ -440,6 +441,7 @@ pub fn root_setting_default_value(config: &AppConfig, id: RootSettingId) -> Opti
             WorkingDirFallback::Home => "home".to_string(),
             WorkingDirFallback::Process => "process".to_string(),
         }),
+        RootSettingId::WarnOnQuit => Some(config.warn_on_quit.to_string()),
         RootSettingId::WarnOnQuitWithRunningProcess => {
             Some(config.warn_on_quit_with_running_process.to_string())
         }

--- a/crates/config_core/src/types.rs
+++ b/crates/config_core/src/types.rs
@@ -4,8 +4,8 @@ use crate::constants::{
     DEFAULT_TAB_SWITCH_MODIFIER_HINTS, DEFAULT_TAB_TITLE_COMMAND_FORMAT,
     DEFAULT_TAB_TITLE_EXPLICIT_PREFIX, DEFAULT_TAB_TITLE_FALLBACK, DEFAULT_TAB_TITLE_PROMPT_FORMAT,
     DEFAULT_TERM, DEFAULT_TMUX_BINARY, DEFAULT_TMUX_ENABLED, DEFAULT_TMUX_PERSISTENCE,
-    DEFAULT_TMUX_SHOW_ACTIVE_PANE_BORDER, DEFAULT_WARN_ON_QUIT_WITH_RUNNING_PROCESS,
-    SHELL_DECIDE_THEME_ID,
+    DEFAULT_TMUX_SHOW_ACTIVE_PANE_BORDER, DEFAULT_WARN_ON_QUIT,
+    DEFAULT_WARN_ON_QUIT_WITH_RUNNING_PROCESS, SHELL_DECIDE_THEME_ID,
 };
 
 pub type ThemeId = String;
@@ -280,6 +280,7 @@ pub struct AppConfig {
     pub tmux_show_active_pane_border: bool,
     pub working_dir: Option<String>,
     pub working_dir_fallback: WorkingDirFallback,
+    pub warn_on_quit: bool,
     pub warn_on_quit_with_running_process: bool,
     pub tab_title: TabTitleConfig,
     pub tab_close_visibility: TabCloseVisibility,
@@ -344,6 +345,7 @@ impl Default for AppConfig {
             tmux_show_active_pane_border: DEFAULT_TMUX_SHOW_ACTIVE_PANE_BORDER,
             working_dir: None,
             working_dir_fallback: WorkingDirFallback::default(),
+            warn_on_quit: DEFAULT_WARN_ON_QUIT,
             warn_on_quit_with_running_process: DEFAULT_WARN_ON_QUIT_WITH_RUNNING_PROCESS,
             tab_title: TabTitleConfig::default(),
             tab_close_visibility: TabCloseVisibility::default(),

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -221,6 +221,11 @@ Tmux integration is an add-on. Set `tmux_enabled = true` to start in tmux mode b
 - Directory used when working_dir is unset
 - Group: `STARTUP`
 
+`warn_on_quit`
+- Default: `false`
+- Warn every time you try to quit the app
+- Group: `SAFETY`
+
 `warn_on_quit_with_running_process`
 - Default: `true`
 - Warn before quitting when a tab has an active process

--- a/site/src/content/configuration.md
+++ b/site/src/content/configuration.md
@@ -169,6 +169,11 @@ Termy reads configuration from `~/.config/termy/config.txt`.
 - Directory used when working_dir is unset
 - Group: `STARTUP`
 
+`warn_on_quit`
+- Default: `false`
+- Warn every time you try to quit the app
+- Group: `SAFETY`
+
 `warn_on_quit_with_running_process`
 - Default: `true`
 - Warn before quitting when a tab has an active process

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -717,6 +717,16 @@ define_commands!(
             MenuActionRole::Normal
         ))
     ),
+    (
+        PrettifyConfig,
+        GLOBAL_CONTEXT,
+        Some(palette(
+            "Prettify Settings File",
+            "prettify format config settings file tidy sort",
+            CommandPaletteVisibility::Always
+        )),
+        None
+    ),
     (ImportThemeStoreAuth, GLOBAL_CONTEXT, None, None),
     (
         ImportColors,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -15,8 +15,8 @@ use std::{
 pub use error::ConfigIoError;
 pub use io::{ensure_config_file, open_config_file, subscribe_config_changes};
 pub use mutate::{
-    import_colors_from_json, remove_root_setting, set_color_setting, set_keybind_lines,
-    set_root_setting, set_theme_in_config,
+    import_colors_from_json, prettify_config_file, remove_root_setting, set_color_setting,
+    set_keybind_lines, set_root_setting, set_theme_in_config,
 };
 pub use preview::{
     BackgroundOpacityPreview, current_background_opacity_preview, effective_background_opacity,

--- a/src/config/mutate.rs
+++ b/src/config/mutate.rs
@@ -9,7 +9,7 @@ use std::{
 use fs4::fs_std::FileExt;
 use termy_config_core::{
     ColorSettingId, ColorSettingUpdate, Rgb8, RootSettingId, apply_color_updates,
-    color_setting_from_key, color_setting_spec, parse_theme_id,
+    color_setting_from_key, color_setting_spec, parse_theme_id, prettify_config_contents,
     remove_root_setting as remove_root_setting_entry, replace_keybind_lines, upsert_root_setting,
 };
 
@@ -127,6 +127,13 @@ pub fn set_color_setting(color: ColorSettingId, value: Option<&str>) -> Result<(
 
 pub fn set_keybind_lines(lines: &[String]) -> Result<(), String> {
     update_config_contents(|existing| Ok((replace_keybind_lines(existing, lines), ())))
+}
+
+pub fn prettify_config_file() -> Result<String, String> {
+    update_config_contents(|existing| {
+        let prettified = prettify_config_contents(existing);
+        Ok((prettified.clone(), prettified))
+    })
 }
 
 pub fn import_colors_from_json(json_path: &Path) -> Result<String, String> {

--- a/src/settings_view/sections.rs
+++ b/src/settings_view/sections.rs
@@ -1908,7 +1908,8 @@ impl SettingsWindow {
             .clone()
             .unwrap_or_else(|| "Not set".to_string());
         let working_dir_fallback = self.editable_field_value(EditableField::WorkingDirFallback);
-        let warn_on_quit = self.config.warn_on_quit_with_running_process;
+        let always_warn_on_quit = self.config.warn_on_quit;
+        let warn_on_quit_with_running_process = self.config.warn_on_quit_with_running_process;
         let native_tab_persistence = self.config.native_tab_persistence;
         let native_layout_autosave = self.config.native_layout_autosave;
         let native_buffer_persistence = self.config.native_buffer_persistence;
@@ -1982,14 +1983,24 @@ impl SettingsWindow {
         ];
         let startup_group = self.render_settings_group("STARTUP", startup_rows);
 
-        let safety_rows = vec![self.render_root_bool_setting_row(
-            "warn_on_quit_with_running_process",
-            "warn_on_quit-toggle",
-            RootSettingId::WarnOnQuitWithRunningProcess,
-            warn_on_quit,
-            "Saved",
-            cx,
-        )];
+        let safety_rows = vec![
+            self.render_root_bool_setting_row(
+                "warn_on_quit",
+                "warn_on_quit-toggle",
+                RootSettingId::WarnOnQuit,
+                always_warn_on_quit,
+                "Saved",
+                cx,
+            ),
+            self.render_root_bool_setting_row(
+                "warn_on_quit_with_running_process",
+                "warn_on_quit_with_running_process-toggle",
+                RootSettingId::WarnOnQuitWithRunningProcess,
+                warn_on_quit_with_running_process,
+                "Saved",
+                cx,
+            ),
+        ];
         let safety_group = self.render_settings_group("SAFETY", safety_rows);
 
         let window_rows = vec![

--- a/src/terminal_view/command_palette/mod.rs
+++ b/src/terminal_view/command_palette/mod.rs
@@ -920,6 +920,10 @@ impl TerminalView {
                 termy_toast::info("Opened settings file");
                 self.notify_overlay(cx);
             }
+            CommandAction::PrettifyConfig => {
+                termy_toast::success("Prettified settings file");
+                self.notify_overlay(cx);
+            }
             CommandAction::NewTab => termy_toast::success("Opened new tab"),
             CommandAction::CloseTab => termy_toast::info("Closed active tab"),
             CommandAction::ClosePaneOrTab => termy_toast::info("Closed active pane or tab"),

--- a/src/terminal_view/interaction/actions.rs
+++ b/src/terminal_view/interaction/actions.rs
@@ -136,6 +136,7 @@ impl TerminalView {
             }
             _ if shortcuts_suspended => {}
             CommandAction::OpenConfig
+            | CommandAction::PrettifyConfig
             | CommandAction::ImportThemeStoreAuth
             | CommandAction::ImportColors
             | CommandAction::AppInfo
@@ -225,6 +226,15 @@ impl TerminalView {
         cx: &mut Context<Self>,
     ) {
         self.execute_command_action(CommandAction::ImportColors, true, window, cx);
+    }
+
+    pub(in super::super) fn handle_prettify_config_action(
+        &mut self,
+        _: &commands::PrettifyConfig,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.execute_command_action(CommandAction::PrettifyConfig, true, window, cx);
     }
 
     pub(in super::super) fn handle_switch_theme_action(
@@ -763,6 +773,10 @@ mod tests {
         );
         assert_eq!(
             TerminalView::command_palette_mode_for_action(CommandAction::OpenConfig),
+            None
+        );
+        assert_eq!(
+            TerminalView::command_palette_mode_for_action(CommandAction::PrettifyConfig),
             None
         );
     }

--- a/src/terminal_view/interaction/app.rs
+++ b/src/terminal_view/interaction/app.rs
@@ -11,6 +11,10 @@ impl TerminalView {
                 self.open_config_action(cx);
                 true
             }
+            CommandAction::PrettifyConfig => {
+                self.prettify_config_action(cx);
+                true
+            }
             CommandAction::ImportThemeStoreAuth => {
                 self.import_theme_store_auth_action_from_clipboard(cx);
                 true
@@ -40,6 +44,23 @@ impl TerminalView {
             log::error!("Failed to open config file from command action: {}", error);
             termy_toast::error(error);
             self.notify_overlay(cx);
+        }
+    }
+
+    fn prettify_config_action(&mut self, cx: &mut Context<Self>) {
+        match config::prettify_config_file() {
+            Ok(_) => {
+                self.reload_config(cx);
+                cx.notify();
+            }
+            Err(error) => {
+                log::error!(
+                    "Failed to prettify config file from command action: {}",
+                    error
+                );
+                termy_toast::error(error);
+                self.notify_overlay(cx);
+            }
         }
     }
 

--- a/src/terminal_view/interaction/quit.rs
+++ b/src/terminal_view/interaction/quit.rs
@@ -9,6 +9,22 @@ enum CloseRequestTarget {
 }
 
 impl TerminalView {
+    fn should_prompt_for_close_target(
+        target: CloseRequestTarget,
+        warn_on_quit: bool,
+        warn_on_quit_with_running_process: bool,
+        busy_tab_count: usize,
+    ) -> bool {
+        if busy_tab_count > 0 {
+            return warn_on_quit_with_running_process;
+        }
+
+        matches!(
+            target,
+            CloseRequestTarget::Application | CloseRequestTarget::WindowClose
+        ) && warn_on_quit
+    }
+
     fn should_force_quit_when_prompt_in_flight(target: CloseRequestTarget) -> bool {
         matches!(target, CloseRequestTarget::Application)
     }
@@ -145,7 +161,16 @@ impl TerminalView {
         }
     }
 
-    fn close_warning_detail(&self, target: CloseRequestTarget, busy_titles: &[String]) -> String {
+    fn close_warning_detail(target: CloseRequestTarget, busy_titles: &[String]) -> Option<String> {
+        if busy_titles.is_empty() {
+            return match target {
+                CloseRequestTarget::Application | CloseRequestTarget::WindowClose => {
+                    Some("This will close all your current Termy sessions.".to_string())
+                }
+                CloseRequestTarget::TabClose { .. } => None,
+            };
+        }
+
         if matches!(target, CloseRequestTarget::TabClose { .. }) {
             let mut detail =
                 "This tab is running a command or fullscreen terminal app:\n".to_string();
@@ -157,7 +182,7 @@ impl TerminalView {
             }
 
             detail.push_str("\nClose this tab anyway?");
-            return detail;
+            return Some(detail);
         }
 
         let count = busy_titles.len();
@@ -176,7 +201,7 @@ impl TerminalView {
 
         detail.push('\n');
         detail.push_str(Self::close_warning_final_prompt(target));
-        detail
+        Some(detail)
     }
 
     fn close_tab_by_id(&mut self, tab_id: TabId, cx: &mut Context<Self>) {
@@ -225,16 +250,21 @@ impl TerminalView {
         }
 
         let busy_titles = self.busy_tab_titles_for_close_target(target);
-        if !self.warn_on_quit_with_running_process || busy_titles.is_empty() {
+        if !Self::should_prompt_for_close_target(
+            target,
+            self.warn_on_quit,
+            self.warn_on_quit_with_running_process,
+            busy_titles.len(),
+        ) {
             return self.follow_through_close_request(target, cx);
         }
 
         self.quit_prompt_in_flight = true;
-        let detail = self.close_warning_detail(target, &busy_titles);
+        let detail = Self::close_warning_detail(target, &busy_titles);
         let prompt = window.prompt(
             PromptLevel::Warning,
             Self::close_warning_title(target),
-            Some(&detail),
+            detail.as_deref(),
             Self::close_warning_buttons(target),
             cx,
         );
@@ -342,5 +372,51 @@ mod tests {
         assert!(!TerminalView::should_force_quit_when_prompt_in_flight(
             CloseRequestTarget::TabClose { tab_id: 1 }
         ));
+    }
+
+    #[test]
+    fn always_warn_on_quit_only_prompts_for_app_or_window_close_when_not_busy() {
+        assert!(TerminalView::should_prompt_for_close_target(
+            CloseRequestTarget::Application,
+            true,
+            false,
+            0,
+        ));
+        assert!(TerminalView::should_prompt_for_close_target(
+            CloseRequestTarget::WindowClose,
+            true,
+            false,
+            0,
+        ));
+        assert!(!TerminalView::should_prompt_for_close_target(
+            CloseRequestTarget::TabClose { tab_id: 1 },
+            true,
+            false,
+            0,
+        ));
+    }
+
+    #[test]
+    fn running_process_warning_only_prompts_when_busy() {
+        assert!(TerminalView::should_prompt_for_close_target(
+            CloseRequestTarget::Application,
+            false,
+            true,
+            1,
+        ));
+        assert!(!TerminalView::should_prompt_for_close_target(
+            CloseRequestTarget::Application,
+            false,
+            true,
+            0,
+        ));
+    }
+
+    #[test]
+    fn close_warning_detail_is_absent_for_always_warn_without_busy_tabs() {
+        assert_eq!(
+            TerminalView::close_warning_detail(CloseRequestTarget::Application, &[]),
+            None
+        );
     }
 }

--- a/src/terminal_view/mod.rs
+++ b/src/terminal_view/mod.rs
@@ -1079,6 +1079,7 @@ pub struct TerminalView {
     theme_id: String,
     colors: TerminalColors,
     inactive_tab_scrollback: Option<usize>,
+    warn_on_quit: bool,
     warn_on_quit_with_running_process: bool,
     tab_title: TabTitleConfig,
     tab_close_visibility: TabCloseVisibility,
@@ -2240,6 +2241,7 @@ impl TerminalView {
             theme_id,
             colors,
             inactive_tab_scrollback: config.inactive_tab_scrollback,
+            warn_on_quit: config.warn_on_quit,
             warn_on_quit_with_running_process: config.warn_on_quit_with_running_process,
             tab_title,
             tab_close_visibility: config.tab_close_visibility,
@@ -2476,6 +2478,7 @@ impl TerminalView {
         self.theme_id = config.theme.clone();
         self.colors = TerminalColors::from_theme(&config.theme, &config.colors);
         self.inactive_tab_scrollback = config.inactive_tab_scrollback;
+        self.warn_on_quit = config.warn_on_quit;
         self.warn_on_quit_with_running_process = config.warn_on_quit_with_running_process;
         self.tab_title = config.tab_title.clone();
         let tab_close_visibility_changed = self.tab_close_visibility != config.tab_close_visibility;

--- a/src/terminal_view/render.rs
+++ b/src/terminal_view/render.rs
@@ -2566,6 +2566,7 @@ impl Render for TerminalView {
                     .key_context(key_context)
                     .on_action(cx.listener(Self::handle_toggle_command_palette_action))
                     .on_action(cx.listener(Self::handle_import_colors_action))
+                    .on_action(cx.listener(Self::handle_prettify_config_action))
                     .on_action(cx.listener(Self::handle_switch_theme_action))
                     .on_action(cx.listener(Self::handle_app_info_action))
                     .on_action(cx.listener(Self::handle_restart_app_action))


### PR DESCRIPTION
This pull request introduces a new safety feature to Termy: an optional warning prompt every time you try to quit the app, regardless of running processes. It also adds a "Prettify Settings File" command for formatting the config file, and updates documentation and UI to reflect these additions. The changes are grouped into new feature additions, documentation updates, and UI integration.

**New Features**

* Added a new root config setting `warn_on_quit` that, when enabled, prompts a warning every time you try to quit Termy. This includes support throughout the config schema, parser, default values, and tests. [[1]](diffhunk://#diff-ba3454d3a0dfdab541483a1257f632c01562be610aad81b032305523ee23676cR23) [[2]](diffhunk://#diff-bef00ecd4110c89ae0250f1e38b920ca3c38ae6eb18e426f0063df6722cc53bdR28-R29) [[3]](diffhunk://#diff-4cdcc88d9d69a2913bc512e810f669d843fd03a3035f51848338481daca7521bR248-R254) [[4]](diffhunk://#diff-f1bb1bd3718a1f2f0304bcec8d6e6fa566bbd3b994f827a0dc194da64f1144afR281) [[5]](diffhunk://#diff-f1bb1bd3718a1f2f0304bcec8d6e6fa566bbd3b994f827a0dc194da64f1144afR552-R555) [[6]](diffhunk://#diff-1c817464293b116b1ba5830d33be2ee0e5502399c91ca813c2bd8a6e5ccf960aL325-R326) [[7]](diffhunk://#diff-1c817464293b116b1ba5830d33be2ee0e5502399c91ca813c2bd8a6e5ccf960aR444) [[8]](diffhunk://#diff-689d9d0554e70c785d8b5e785be56a43a316dec6416e4ea53381195b87a774a3L7-R8) [[9]](diffhunk://#diff-689d9d0554e70c785d8b5e785be56a43a316dec6416e4ea53381195b87a774a3R283) [[10]](diffhunk://#diff-689d9d0554e70c785d8b5e785be56a43a316dec6416e4ea53381195b87a774a3R348)
* Introduced a new command `PrettifyConfig` in the command catalog and command palette, allowing users to format and tidy their settings file. Implementation is added in config mutation logic and UI feedback. [[1]](diffhunk://#diff-3f57944454704711b3e57f0e3998b6d416f24e9fc58550d8c39565f5bb2f36a7R42) [[2]](diffhunk://#diff-b86d43fce6a9c57160aa925719550d40a6ed3f5e5a0117679905f76e68acc520R720-R729) [[3]](diffhunk://#diff-b0ba3e54b6f5ef1fa6aed8075e352a68fda66067fbafa8421042a2347801338aL18-R19) [[4]](diffhunk://#diff-fece1f65b6b4ade713e58450363a73d97130b788aa7ee78ac639a7287eab4f0bL12-R12) [[5]](diffhunk://#diff-fece1f65b6b4ade713e58450363a73d97130b788aa7ee78ac639a7287eab4f0bR132-R138) [[6]](diffhunk://#diff-1604c68bc05431c1fbbf7e4f138940ef0f4afaf60c6611f6c2de94b260b4feadR923-R926) [[7]](diffhunk://#diff-479e62d61391406de3d6480cdb18cf0bc0cb8117463424fc15747a0b4e1bc33cR139) [[8]](diffhunk://#diff-479e62d61391406de3d6480cdb18cf0bc0cb8117463424fc15747a0b4e1bc33cR231-R239) [[9]](diffhunk://#diff-479e62d61391406de3d6480cdb18cf0bc0cb8117463424fc15747a0b4e1bc33cR778-R781)

**Documentation Updates**

* Added a comprehensive `CONTRIBUTING.md` guide for contributors, covering workflow, project layout, setup, commands, validation, and style expectations. Linked in `README.md` and referenced in the contributing section. [[1]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R1-R147) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R7) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R21-R24)
* Updated generated and user documentation to describe the new `warn_on_quit` setting and its default value. [[1]](diffhunk://#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180R224-R228) [[2]](diffhunk://#diff-91c66c1a507b4f58627b16efb854bb051e228edf333ae076849cdfe1dbee5314R172-R176)

**UI Integration**

* Updated the settings UI to expose both `warn_on_quit` and `warn_on_quit_with_running_process` as separate toggles in the "SAFETY" group, reflecting the new feature. [[1]](diffhunk://#diff-75044ee94d4c18488325a354f5954173a4ad6aed030807928c0804e89a7f0f05L1911-R1912) [[2]](diffhunk://#diff-75044ee94d4c18488325a354f5954173a4ad6aed030807928c0804e89a7f0f05L1985-R2003)
* Added command palette and overlay feedback for the new `PrettifyConfig` action, ensuring user-visible confirmation. [[1]](diffhunk://#diff-1604c68bc05431c1fbbf7e4f138940ef0f4afaf60c6611f6c2de94b260b4feadR923-R926) [[2]](diffhunk://#diff-479e62d61391406de3d6480cdb18cf0bc0cb8117463424fc15747a0b4e1bc33cR139) [[3]](diffhunk://#diff-479e62d61391406de3d6480cdb18cf0bc0cb8117463424fc15747a0b4e1bc33cR231-R239) [[4]](diffhunk://#diff-479e62d61391406de3d6480cdb18cf0bc0cb8117463424fc15747a0b4e1bc33cR778-R781)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Prettify Settings File" command to automatically format and organize your configuration file
  * Introduced "warn_on_quit" setting to control whether the app always prompts when quitting

* **Documentation**
  * Added CONTRIBUTING.md with detailed setup instructions and contribution workflow guidelines
  * Updated README with contributing section and validation commands
  * Enhanced configuration documentation for new settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->