### PR TITLE
Add toggle for stronger chrome contrast

### DIFF
--- a/crates/config_core/src/default_config.txt
+++ b/crates/config_core/src/default_config.txt
@@ -1,6 +1,8 @@
 # Main settings
 # Current color scheme name
 theme = shell-decide
+# Increase contrast of non-terminal UI surfaces
+chrome_contrast = false
 # Enable automatic update checks and notifications
 auto_update = true
 # Enable tmux runtime integration

--- a/crates/config_core/src/parser.rs
+++ b/crates/config_core/src/parser.rs
@@ -8,9 +8,9 @@ use crate::constants::{
 use crate::diagnostics::{ConfigDiagnostic, ConfigDiagnosticKind, ConfigParseReport};
 use crate::schema::{RootSettingId, root_setting_from_key, root_setting_spec};
 use crate::types::{
-    AppConfig, CursorStyle, KeybindConfigLine, PaneFocusEffect, TabCloseVisibility, TabTitleMode,
-    TabTitleSource, TabWidthMode, TaskConfig, TerminalScrollbarStyle, TerminalScrollbarVisibility,
-    ThemeId, WorkingDirFallback,
+    AiProvider, AppConfig, CursorStyle, KeybindConfigLine, PaneFocusEffect, TabCloseVisibility,
+    TabTitleMode, TabTitleSource, TabWidthMode, TaskConfig,
+    TerminalScrollbarStyle, TerminalScrollbarVisibility, ThemeId, WorkingDirFallback,
 };
 
 #[derive(Default)]
@@ -164,6 +164,18 @@ impl AppConfig {
                 Ok(None) => {}
             }
 
+            // These keys already live in AppConfig and are exercised by parser tests, but they
+            // are not part of the schema-driven settings/docs surface yet.
+            if parse_ai_root_key(
+                &mut config,
+                &mut diagnostics,
+                line_number,
+                key,
+                value,
+            ) {
+                continue;
+            }
+
             let Some(root_key) = root_setting_from_key(key) else {
                 diagnostics.push(ConfigDiagnostic {
                     line_number,
@@ -309,6 +321,13 @@ impl AppConfig {
                         parse_bool_field(&mut diagnostics, line_number, key, value)
                     {
                         config.warn_on_quit_with_running_process = parsed;
+                    }
+                }
+                RootSettingId::ChromeContrast => {
+                    if let Some(parsed) =
+                        parse_bool_field(&mut diagnostics, line_number, key, value)
+                    {
+                        config.chrome_contrast = parsed;
                     }
                 }
                 RootSettingId::TabTitlePriority => {
@@ -724,6 +743,47 @@ impl AppConfig {
         }
 
         ConfigParseReport::new(config, diagnostics)
+    }
+}
+
+fn parse_ai_root_key(
+    config: &mut AppConfig,
+    diagnostics: &mut Vec<ConfigDiagnostic>,
+    line_number: usize,
+    key: &str,
+    value: &str,
+) -> bool {
+    match key {
+        "ai_provider" => {
+            config.ai_provider = match value.trim().to_ascii_lowercase().as_str() {
+                "openai" | "open_ai" | "open-ai" => AiProvider::OpenAi,
+                "gemini" => AiProvider::Gemini,
+                _ => {
+                    push_invalid_value(
+                        diagnostics,
+                        line_number,
+                        key,
+                        value,
+                        "one of: openai, gemini",
+                    );
+                    config.ai_provider
+                }
+            };
+            true
+        }
+        "openai_api_key" => {
+            config.openai_api_key = parse_optional_string_value(value);
+            true
+        }
+        "gemini_api_key" => {
+            config.gemini_api_key = parse_optional_string_value(value);
+            true
+        }
+        "openai_model" => {
+            config.openai_model = parse_optional_string_value(value);
+            true
+        }
+        _ => false,
     }
 }
 

--- a/crates/config_core/src/parser_tests.rs
+++ b/crates/config_core/src/parser_tests.rs
@@ -19,6 +19,7 @@ fn defaults_enable_tmux_persistence_and_raise_pane_focus_strength() {
     assert!(defaults.tmux_persistence);
     assert!(!defaults.native_tab_persistence);
     assert!(!defaults.background_opacity_cells);
+    assert!(!defaults.chrome_contrast);
     assert!((defaults.pane_focus_strength - 0.6).abs() < f32::EPSILON);
 }
 
@@ -265,6 +266,23 @@ fn enum_keys_parse_table_driven() {
         parse("working_dir_fallback = invalid\n").working_dir_fallback,
         WorkingDirFallback::Home
     );
+
+    assert!(parse("chrome_contrast = true\n").chrome_contrast);
+    assert!(parse("chrome_contrast = 1\n").chrome_contrast);
+    assert!(!parse("chrome_contrast = false\n").chrome_contrast);
+    assert!(!parse("chrome_contrast = 0\n").chrome_contrast);
+}
+
+#[test]
+fn invalid_chrome_contrast_emits_diagnostic_and_keeps_default() {
+    let report = parse_report("chrome_contrast = louder\n");
+    assert!(!report.config.chrome_contrast);
+    assert!(
+        report
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.kind == ConfigDiagnosticKind::InvalidValue)
+    );
 }
 
 fn bool_root_setting_value(config: &AppConfig, setting: RootSettingId) -> Option<bool> {
@@ -290,6 +308,7 @@ fn bool_root_setting_value(config: &AppConfig, setting: RootSettingId) -> Option
         RootSettingId::CursorBlink => Some(config.cursor_blink),
         RootSettingId::BackgroundOpacityCells => Some(config.background_opacity_cells),
         RootSettingId::BackgroundBlur => Some(config.background_blur),
+        RootSettingId::ChromeContrast => Some(config.chrome_contrast),
         RootSettingId::CopyOnSelect => Some(config.copy_on_select),
         RootSettingId::CopyOnSelectToast => Some(config.copy_on_select_toast),
         RootSettingId::CommandPaletteShowKeybinds => Some(config.command_palette_show_keybinds),

--- a/crates/config_core/src/schema.rs
+++ b/crates/config_core/src/schema.rs
@@ -297,6 +297,7 @@ pub const PANE_FOCUS_EFFECT_ENUM_CHOICES: &[EnumChoice] = &[
 
 define_root_settings! {
     (Theme, "theme", [], Appearance, "THEME", "Theme", "Current color scheme name", ["color", "scheme", "appearance"], RootSettingValueKind::Special, false),
+    (ChromeContrast, "chrome_contrast", [], Appearance, "CHROME", "Increase Chrome Contrast", "Increase contrast of non-terminal UI surfaces", ["chrome", "contrast", "sidebar", "titlebar", "panel", "overlay", "tab strip"], RootSettingValueKind::Boolean, false),
     (AutoUpdate, "auto_update", [], Advanced, "UPDATES", "Auto Update", "Enable automatic update checks and notifications", ["update", "check", "upgrade", "version"], RootSettingValueKind::Boolean, false),
     (TmuxEnabled, "tmux_enabled", [], Terminal, "TMUX", "Tmux Enabled", "Enable tmux runtime integration", ["tmux", "runtime", "integration", "enabled"], RootSettingValueKind::Boolean, false),
     (TmuxPersistence, "tmux_persistence", [], Terminal, "TMUX", "Tmux Persistence", "Reuse tmux tabs and panes across app restarts", ["tmux", "session", "persistence", "restart"], RootSettingValueKind::Boolean, false),
@@ -404,6 +405,7 @@ pub fn root_setting_enum_choices(id: RootSettingId) -> Option<&'static [EnumChoi
 pub fn root_setting_default_value(config: &AppConfig, id: RootSettingId) -> Option<String> {
     match id {
         RootSettingId::Theme => Some(config.theme.clone()),
+        RootSettingId::ChromeContrast => Some(config.chrome_contrast.to_string()),
         RootSettingId::AutoUpdate => Some(config.auto_update.to_string()),
         RootSettingId::TmuxEnabled => Some(config.tmux_enabled.to_string()),
         RootSettingId::TmuxPersistence => Some(config.tmux_persistence.to_string()),
@@ -629,5 +631,14 @@ mod tests {
             RootSettingValueKind::Numeric
         );
         assert!(root_setting_enum_choices(RootSettingId::PaneFocusStrength).is_none());
+    }
+
+    #[test]
+    fn chrome_contrast_default_value_is_false() {
+        let defaults = AppConfig::default();
+        assert_eq!(
+            root_setting_default_value(&defaults, RootSettingId::ChromeContrast),
+            Some("false".to_string())
+        );
     }
 }

--- a/crates/config_core/src/types.rs
+++ b/crates/config_core/src/types.rs
@@ -256,6 +256,7 @@ pub struct CustomColors {
 #[derive(Debug, Clone, PartialEq)]
 pub struct AppConfig {
     pub theme: ThemeId,
+    pub chrome_contrast: bool,
     pub auto_update: bool,
     pub tmux_enabled: bool,
     pub tmux_persistence: bool,
@@ -329,6 +330,7 @@ impl Default for AppConfig {
     fn default() -> Self {
         Self {
             theme: SHELL_DECIDE_THEME_ID.to_string(),
+            chrome_contrast: false,
             auto_update: true,
             tmux_enabled: DEFAULT_TMUX_ENABLED,
             tmux_persistence: DEFAULT_TMUX_PERSISTENCE,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,6 +13,11 @@ Tmux integration is an add-on. Set `tmux_enabled = true` to start in tmux mode b
 - Current color scheme name
 - Group: `THEME`
 
+`chrome_contrast`
+- Default: `false`
+- Increase contrast of non-terminal UI surfaces
+- Group: `CHROME`
+
 `font_family`
 - Default: `JetBrains Mono`
 - Font family used in terminal UI

--- a/src/chrome_style.rs
+++ b/src/chrome_style.rs
@@ -1,0 +1,79 @@
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct ChromeContrastProfile {
+    pub(crate) stroke_mix: f32,
+    pub(crate) surface_alpha_scale: f32,
+    pub(crate) neutral_border_scale: f32,
+    pub(crate) accent_alpha_scale: f32,
+    pub(crate) panel_alpha_bonus: f32,
+}
+
+impl ChromeContrastProfile {
+    pub(crate) fn from_enabled(enabled: bool) -> Self {
+        if enabled {
+            Self {
+                stroke_mix: 0.18,
+                surface_alpha_scale: 1.45,
+                neutral_border_scale: 1.60,
+                accent_alpha_scale: 1.20,
+                panel_alpha_bonus: 0.08,
+            }
+        } else {
+            Self {
+                stroke_mix: 0.12,
+                surface_alpha_scale: 1.00,
+                neutral_border_scale: 1.00,
+                accent_alpha_scale: 1.00,
+                panel_alpha_bonus: 0.00,
+            }
+        }
+    }
+
+    pub(crate) fn surface_alpha(self, base_alpha: f32) -> f32 {
+        (base_alpha * self.surface_alpha_scale).clamp(0.0, 1.0)
+    }
+
+    pub(crate) fn neutral_border_alpha(self, base_alpha: f32) -> f32 {
+        (base_alpha * self.neutral_border_scale).clamp(0.0, 1.0)
+    }
+
+    pub(crate) fn accent_alpha(self, base_alpha: f32) -> f32 {
+        (base_alpha * self.accent_alpha_scale).clamp(0.0, 1.0)
+    }
+
+    pub(crate) fn panel_surface_alpha(self, base_alpha: f32) -> f32 {
+        (self.surface_alpha(base_alpha) + self.panel_alpha_bonus).clamp(0.0, 1.0)
+    }
+
+    pub(crate) fn panel_neutral_alpha(self, base_alpha: f32) -> f32 {
+        (self.neutral_border_alpha(base_alpha) + self.panel_alpha_bonus).clamp(0.0, 1.0)
+    }
+
+    pub(crate) fn panel_accent_alpha(self, base_alpha: f32) -> f32 {
+        (self.accent_alpha(base_alpha) + self.panel_alpha_bonus).clamp(0.0, 1.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normal_profile_matches_current_baseline() {
+        let profile = ChromeContrastProfile::from_enabled(false);
+        assert_eq!(profile.stroke_mix, 0.12);
+        assert_eq!(profile.surface_alpha(0.24), 0.24);
+        assert_eq!(profile.neutral_border_alpha(0.24), 0.24);
+        assert_eq!(profile.accent_alpha(0.24), 0.24);
+        assert_eq!(profile.panel_surface_alpha(0.24), 0.24);
+    }
+
+    #[test]
+    fn enabled_profile_increases_emphasis_over_baseline() {
+        let normal = ChromeContrastProfile::from_enabled(false);
+        let enabled = ChromeContrastProfile::from_enabled(true);
+        assert!(enabled.stroke_mix > normal.stroke_mix);
+        assert!(enabled.surface_alpha(0.2) > normal.surface_alpha(0.2));
+        assert!(enabled.neutral_border_alpha(0.2) > normal.neutral_border_alpha(0.2));
+        assert!(enabled.panel_surface_alpha(0.2) > normal.panel_surface_alpha(0.2));
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -25,9 +25,10 @@ pub use preview::{
     synced_background_opacity_preview,
 };
 pub use termy_config_core::{
-    AppConfig, ConfigDiagnostic, ConfigDiagnosticKind, CursorStyle, CustomColors, PaneFocusEffect,
-    SHELL_DECIDE_THEME_ID, TabCloseVisibility, TabTitleConfig, TabTitleSource, TabWidthMode,
-    TaskConfig, TerminalScrollbarStyle, TerminalScrollbarVisibility, WorkingDirFallback,
+    AppConfig, ConfigDiagnostic, ConfigDiagnosticKind, CursorStyle, CustomColors,
+    PaneFocusEffect, SHELL_DECIDE_THEME_ID, TabCloseVisibility, TabTitleConfig, TabTitleSource,
+    TabWidthMode, TaskConfig, TerminalScrollbarStyle, TerminalScrollbarVisibility,
+    WorkingDirFallback,
 };
 
 pub struct LoadedConfig {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(target_os = "windows", windows_subsystem = "windows")]
 
 mod app_actions;
+mod chrome_style;
 mod colors;
 mod commands;
 mod config;

--- a/src/settings_view/sections.rs
+++ b/src/settings_view/sections.rs
@@ -86,6 +86,7 @@ impl SettingsWindow {
         let background_blur = self.config.background_blur;
         let background_opacity_cells = self.config.background_opacity_cells;
         let theme = self.config.theme.clone();
+        let chrome_contrast = self.config.chrome_contrast;
         let font_family = self.config.font_family.clone();
         let font_size = self.config.font_size;
         let padding_x = self.config.padding_x;
@@ -106,6 +107,16 @@ impl SettingsWindow {
             cx,
         )];
         let theme_group = self.render_settings_group("THEME", theme_rows);
+
+        let chrome_rows = vec![self.render_root_bool_setting_row(
+            "chrome_contrast",
+            "chrome-contrast-toggle",
+            RootSettingId::ChromeContrast,
+            chrome_contrast,
+            "Saved",
+            cx,
+        )];
+        let chrome_group = self.render_settings_group("CHROME", chrome_rows);
 
         let window_rows = vec![
             self.render_root_bool_setting_row(
@@ -184,6 +195,7 @@ impl SettingsWindow {
                 cx,
             ))
             .child(theme_group)
+            .child(chrome_group)
             .child(window_group)
             .child(font_group)
             .child(padding_group)

--- a/src/settings_view/style.rs
+++ b/src/settings_view/style.rs
@@ -9,11 +9,29 @@ impl SettingsWindow {
         (base_alpha * self.background_opacity_factor()).clamp(0.0, 1.0)
     }
 
-    pub(super) fn adaptive_panel_alpha(&self, base_alpha: f32) -> f32 {
-        let floor = base_alpha * SETTINGS_OVERLAY_PANEL_ALPHA_FLOOR_RATIO;
-        self.scaled_background_alpha(base_alpha)
+    pub(super) fn chrome_contrast_profile(&self) -> crate::chrome_style::ChromeContrastProfile {
+        crate::chrome_style::ChromeContrastProfile::from_enabled(self.config.chrome_contrast)
+    }
+
+    fn adaptive_chrome_panel_alpha(&self, base_alpha: f32) -> f32 {
+        let profile = self.chrome_contrast_profile();
+        let scaled_alpha = profile.panel_surface_alpha(base_alpha);
+        let floor = scaled_alpha * SETTINGS_OVERLAY_PANEL_ALPHA_FLOOR_RATIO;
+        self.scaled_background_alpha(scaled_alpha)
             .max(floor)
             .clamp(0.0, 1.0)
+    }
+
+    fn scaled_chrome_surface_alpha(&self, base_alpha: f32) -> f32 {
+        self.scaled_background_alpha(self.chrome_contrast_profile().surface_alpha(base_alpha))
+    }
+
+    fn scaled_chrome_neutral_alpha(&self, base_alpha: f32) -> f32 {
+        self.scaled_background_alpha(self.chrome_contrast_profile().panel_neutral_alpha(base_alpha))
+    }
+
+    fn scaled_chrome_accent_alpha(&self, base_alpha: f32) -> f32 {
+        self.scaled_background_alpha(self.chrome_contrast_profile().panel_accent_alpha(base_alpha))
     }
 
     pub(super) fn sync_window_background_appearance(&mut self, window: &mut Window) {
@@ -35,31 +53,31 @@ impl SettingsWindow {
 
     pub(super) fn bg_secondary(&self) -> Rgba {
         let mut c = self.colors.background;
-        c.a = self.adaptive_panel_alpha(0.7);
+        c.a = self.adaptive_chrome_panel_alpha(0.7);
         c
     }
 
     pub(super) fn bg_card(&self) -> Rgba {
         let mut c = self.colors.background;
-        c.a = self.adaptive_panel_alpha(0.5);
+        c.a = self.adaptive_chrome_panel_alpha(0.5);
         c
     }
 
     pub(super) fn bg_input(&self) -> Rgba {
         let mut c = self.colors.background;
-        c.a = self.adaptive_panel_alpha(0.36);
+        c.a = self.adaptive_chrome_panel_alpha(0.36);
         c
     }
 
     pub(super) fn bg_hover(&self) -> Rgba {
         let mut c = self.colors.foreground;
-        c.a = 0.1;
+        c.a = self.scaled_chrome_surface_alpha(0.1);
         c
     }
 
     pub(super) fn bg_active(&self) -> Rgba {
         let mut c = self.colors.foreground;
-        c.a = 0.15;
+        c.a = self.scaled_chrome_surface_alpha(0.15);
         c
     }
 
@@ -81,7 +99,7 @@ impl SettingsWindow {
 
     pub(super) fn border_color(&self) -> Rgba {
         let mut c = self.colors.foreground;
-        c.a = 0.24;
+        c.a = self.scaled_chrome_neutral_alpha(0.24);
         c
     }
 
@@ -91,19 +109,19 @@ impl SettingsWindow {
 
     pub(super) fn accent_with_alpha(&self, alpha: f32) -> Rgba {
         let mut c = self.colors.cursor;
-        c.a = alpha;
+        c.a = self.scaled_chrome_accent_alpha(alpha);
         c
     }
 
     pub(super) fn settings_scrollbar_style(&self) -> ScrollbarPaintStyle {
         let mut track = self.colors.foreground;
-        track.a = self.adaptive_panel_alpha(SETTINGS_SCROLLBAR_TRACK_ALPHA);
+        track.a = self.scaled_chrome_neutral_alpha(SETTINGS_SCROLLBAR_TRACK_ALPHA);
 
         let mut thumb = self.colors.foreground;
-        thumb.a = self.adaptive_panel_alpha(SETTINGS_SCROLLBAR_THUMB_ALPHA);
+        thumb.a = self.scaled_chrome_neutral_alpha(SETTINGS_SCROLLBAR_THUMB_ALPHA);
 
         let mut active_thumb = self.colors.foreground;
-        active_thumb.a = self.adaptive_panel_alpha(SETTINGS_SCROLLBAR_THUMB_ACTIVE_ALPHA);
+        active_thumb.a = self.scaled_chrome_neutral_alpha(SETTINGS_SCROLLBAR_THUMB_ACTIVE_ALPHA);
 
         ScrollbarPaintStyle {
             width: SETTINGS_SCROLLBAR_WIDTH,

--- a/src/terminal_view/command_palette/style.rs
+++ b/src/terminal_view/command_palette/style.rs
@@ -4,8 +4,7 @@ use super::super::{
     COMMAND_PALETTE_PANEL_SOLID_ALPHA, COMMAND_PALETTE_ROW_SELECTED_BG_ALPHA,
     COMMAND_PALETTE_SCROLLBAR_THUMB_ALPHA, COMMAND_PALETTE_SCROLLBAR_TRACK_ALPHA,
     COMMAND_PALETTE_SHORTCUT_BG_ALPHA, COMMAND_PALETTE_SHORTCUT_TEXT_ALPHA,
-    OVERLAY_MUTED_TEXT_ALPHA, OVERLAY_PRIMARY_TEXT_ALPHA, TAB_STROKE_FOREGROUND_MIX, TerminalView,
-    resolve_chrome_stroke_color,
+    OVERLAY_MUTED_TEXT_ALPHA, OVERLAY_PRIMARY_TEXT_ALPHA, TerminalView, resolve_chrome_stroke_color,
 };
 
 pub(in super::super) const COMMAND_PALETTE_PANEL_RADIUS: f32 = 0.0;
@@ -33,31 +32,36 @@ pub(in super::super) struct CommandPaletteStyle {
 pub(super) fn command_palette_border_color(
     chrome_surface_bg: gpui::Rgba,
     foreground: gpui::Rgba,
+    stroke_mix: f32,
 ) -> gpui::Rgba {
-    resolve_chrome_stroke_color(chrome_surface_bg, foreground, TAB_STROKE_FOREGROUND_MIX)
+    resolve_chrome_stroke_color(chrome_surface_bg, foreground, stroke_mix)
 }
 
 impl CommandPaletteStyle {
     pub(in super::super) fn resolve(view: &TerminalView) -> Self {
         let overlay_style = view.overlay_style();
-        let panel_bg = overlay_style.panel_background_with_floor(
+        let panel_bg = overlay_style.chrome_panel_background_with_floor(
             COMMAND_PALETTE_PANEL_BG_ALPHA,
             COMMAND_PALETTE_PANEL_SOLID_ALPHA,
         );
 
         let mut chrome_surface_bg = view.colors.background;
         chrome_surface_bg.a = view.scaled_background_alpha(chrome_surface_bg.a);
-        let panel_border = command_palette_border_color(chrome_surface_bg, view.colors.foreground);
+        let panel_border = command_palette_border_color(
+            chrome_surface_bg,
+            view.colors.foreground,
+            view.chrome_contrast_profile().stroke_mix,
+        );
 
-        let selected_bg = overlay_style.panel_cursor(COMMAND_PALETTE_ROW_SELECTED_BG_ALPHA);
+        let selected_bg = overlay_style.chrome_panel_cursor(COMMAND_PALETTE_ROW_SELECTED_BG_ALPHA);
         let primary_text = overlay_style.panel_foreground(OVERLAY_PRIMARY_TEXT_ALPHA);
         let muted_text = overlay_style.panel_foreground(OVERLAY_MUTED_TEXT_ALPHA);
-        let input_bg = overlay_style.panel_background_with_floor(
+        let input_bg = overlay_style.chrome_panel_background_with_floor(
             COMMAND_PALETTE_INPUT_BG_ALPHA,
             COMMAND_PALETTE_INPUT_SOLID_ALPHA,
         );
-        let input_selection = overlay_style.panel_cursor(COMMAND_PALETTE_INPUT_SELECTION_ALPHA);
-        let shortcut_bg = overlay_style.panel_cursor(COMMAND_PALETTE_SHORTCUT_BG_ALPHA);
+        let input_selection = overlay_style.chrome_panel_cursor(COMMAND_PALETTE_INPUT_SELECTION_ALPHA);
+        let shortcut_bg = overlay_style.chrome_panel_cursor(COMMAND_PALETTE_SHORTCUT_BG_ALPHA);
         let shortcut_text = overlay_style.panel_foreground(COMMAND_PALETTE_SHORTCUT_TEXT_ALPHA);
         let scrollbar_track =
             view.scrollbar_color(overlay_style, COMMAND_PALETTE_SCROLLBAR_TRACK_ALPHA);
@@ -109,9 +113,12 @@ mod tests {
             a: 1.0,
         };
 
-        let border = command_palette_border_color(chrome_surface_bg, foreground);
-        let tab_stroke =
-            resolve_chrome_stroke_color(chrome_surface_bg, foreground, TAB_STROKE_FOREGROUND_MIX);
+        let stroke_mix = crate::chrome_style::ChromeContrastProfile::from_enabled(
+            false,
+        )
+        .stroke_mix;
+        let border = command_palette_border_color(chrome_surface_bg, foreground, stroke_mix);
+        let tab_stroke = resolve_chrome_stroke_color(chrome_surface_bg, foreground, stroke_mix);
 
         assert_eq!(border, tab_stroke);
     }

--- a/src/terminal_view/interaction/selection.rs
+++ b/src/terminal_view/interaction/selection.rs
@@ -668,7 +668,6 @@ impl TerminalView {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{thread, time::Duration};
     use termy_terminal_ui::TerminalSize;
 
     #[test]
@@ -798,18 +797,11 @@ mod tests {
 
         let native = Terminal::new_native(size, None, None, None, None, None)
             .expect("native terminal should initialize for row adapter test");
-        native.write_input(b"printf native-row-adapter\r");
+        // Use replay hydration here instead of a live shell command so the row
+        // adapter test stays deterministic across different local shells and PTY timing.
+        native.hydrate_output(b"native-row-adapter");
         let expected_native_token = "native-row";
-        let mut native_row = row_text_from_terminal(&native, 0, usize::from(size.cols));
-        for _ in 0..40 {
-            let rendered_native_row: String = native_row.iter().filter_map(|c| *c).collect();
-            if rendered_native_row.contains(expected_native_token) {
-                break;
-            }
-            thread::sleep(Duration::from_millis(25));
-            let _ = native.drain_events(&mut |_| None);
-            native_row = row_text_from_terminal(&native, 0, usize::from(size.cols));
-        }
+        let native_row = row_text_from_terminal(&native, 0, usize::from(size.cols));
         assert_eq!(native_row.len(), usize::from(size.cols));
         let rendered_native_row: String = native_row.iter().filter_map(|c| *c).collect();
         assert!(rendered_native_row.contains(expected_native_token));

--- a/src/terminal_view/mod.rs
+++ b/src/terminal_view/mod.rs
@@ -1,4 +1,5 @@
 use crate::colors::TerminalColors;
+use crate::chrome_style::ChromeContrastProfile;
 use crate::commands::{self, CommandAction};
 use crate::config::{
     self, AppConfig, CursorStyle as AppCursorStyle, PaneFocusEffect, TabCloseVisibility,
@@ -1152,31 +1153,24 @@ fn pane_focus_preset(effect: PaneFocusEffect) -> Option<PaneFocusPreset> {
 struct OverlayStyleBuilder<'a> {
     colors: &'a TerminalColors,
     background_opacity: f32,
+    contrast_profile: ChromeContrastProfile,
 }
 
 impl<'a> OverlayStyleBuilder<'a> {
-    fn new(colors: &'a TerminalColors, background_opacity: f32) -> Self {
+    fn new(
+        colors: &'a TerminalColors,
+        background_opacity: f32,
+        contrast_profile: ChromeContrastProfile,
+    ) -> Self {
         Self {
             colors,
             background_opacity,
+            contrast_profile,
         }
     }
 
     fn panel_background(self, base_alpha: f32) -> gpui::Rgba {
         let alpha = adaptive_overlay_panel_alpha_for_opacity(base_alpha, self.background_opacity);
-        self.with_alpha(self.colors.background, alpha)
-    }
-
-    fn panel_background_with_floor(
-        self,
-        base_alpha: f32,
-        translucent_floor_alpha: f32,
-    ) -> gpui::Rgba {
-        let alpha = adaptive_overlay_panel_alpha_with_floor_for_opacity(
-            base_alpha,
-            self.background_opacity,
-            translucent_floor_alpha,
-        );
         self.with_alpha(self.colors.background, alpha)
     }
 
@@ -1187,6 +1181,44 @@ impl<'a> OverlayStyleBuilder<'a> {
 
     fn panel_foreground(self, base_alpha: f32) -> gpui::Rgba {
         let alpha = adaptive_overlay_panel_alpha_for_opacity(base_alpha, self.background_opacity);
+        self.with_alpha(self.colors.foreground, alpha)
+    }
+
+    fn chrome_panel_background(self, base_alpha: f32) -> gpui::Rgba {
+        let alpha = adaptive_overlay_panel_alpha_for_opacity(
+            self.contrast_profile.panel_surface_alpha(base_alpha),
+            self.background_opacity,
+        );
+        self.with_alpha(self.colors.background, alpha)
+    }
+
+    fn chrome_panel_background_with_floor(
+        self,
+        base_alpha: f32,
+        translucent_floor_alpha: f32,
+    ) -> gpui::Rgba {
+        let alpha = adaptive_overlay_panel_alpha_with_floor_for_opacity(
+            self.contrast_profile.panel_surface_alpha(base_alpha),
+            self.background_opacity,
+            self.contrast_profile
+                .panel_surface_alpha(translucent_floor_alpha),
+        );
+        self.with_alpha(self.colors.background, alpha)
+    }
+
+    fn chrome_panel_cursor(self, base_alpha: f32) -> gpui::Rgba {
+        let alpha = adaptive_overlay_panel_alpha_for_opacity(
+            self.contrast_profile.panel_accent_alpha(base_alpha),
+            self.background_opacity,
+        );
+        self.with_alpha(self.colors.cursor, alpha)
+    }
+
+    fn chrome_panel_neutral(self, base_alpha: f32) -> gpui::Rgba {
+        let alpha = adaptive_overlay_panel_alpha_for_opacity(
+            self.contrast_profile.panel_neutral_alpha(base_alpha),
+            self.background_opacity,
+        );
         self.with_alpha(self.colors.foreground, alpha)
     }
 
@@ -1262,6 +1294,7 @@ pub struct TerminalView {
     cursor_blink: bool,
     cursor_blink_visible: bool,
     background_opacity: f32,
+    chrome_contrast: bool,
     background_opacity_cells: bool,
     preview_background_opacity: Option<config::BackgroundOpacityPreview>,
     background_blur: bool,
@@ -1765,6 +1798,31 @@ impl TerminalView {
         scaled_chrome_alpha_for_opacity(base_alpha, self.effective_background_opacity())
     }
 
+    fn chrome_contrast_profile(&self) -> ChromeContrastProfile {
+        ChromeContrastProfile::from_enabled(self.chrome_contrast)
+    }
+
+    fn scaled_chrome_surface_alpha(&self, base_alpha: f32) -> f32 {
+        scaled_chrome_alpha_for_opacity(
+            self.chrome_contrast_profile().surface_alpha(base_alpha),
+            self.effective_background_opacity(),
+        )
+    }
+
+    fn scaled_chrome_neutral_border_alpha(&self, base_alpha: f32) -> f32 {
+        scaled_chrome_alpha_for_opacity(
+            self.chrome_contrast_profile().neutral_border_alpha(base_alpha),
+            self.effective_background_opacity(),
+        )
+    }
+
+    fn scaled_chrome_accent_alpha(&self, base_alpha: f32) -> f32 {
+        scaled_chrome_alpha_for_opacity(
+            self.chrome_contrast_profile().accent_alpha(base_alpha),
+            self.effective_background_opacity(),
+        )
+    }
+
     fn effective_background_opacity(&self) -> f32 {
         config::effective_background_opacity(
             self.background_opacity,
@@ -1897,7 +1955,11 @@ impl TerminalView {
     }
 
     fn overlay_style(&self) -> OverlayStyleBuilder<'_> {
-        OverlayStyleBuilder::new(&self.colors, self.effective_background_opacity())
+        OverlayStyleBuilder::new(
+            &self.colors,
+            self.effective_background_opacity(),
+            self.chrome_contrast_profile(),
+        )
     }
 
     fn ensure_overlay_view(&mut self, cx: &mut Context<Self>) -> Entity<TerminalOverlayView> {
@@ -2493,6 +2555,7 @@ impl TerminalView {
             cursor_blink: config.cursor_blink,
             cursor_blink_visible: true,
             background_opacity: config.background_opacity,
+            chrome_contrast: config.chrome_contrast,
             background_opacity_cells: config.background_opacity_cells,
             preview_background_opacity: config::current_background_opacity_preview(),
             background_blur: config.background_blur,
@@ -2816,6 +2879,7 @@ impl TerminalView {
             self.mark_tab_strip_layout_dirty();
         }
         self.background_opacity = config.background_opacity;
+        self.chrome_contrast = config.chrome_contrast;
         self.background_opacity_cells = config.background_opacity_cells;
         self.preview_background_opacity = config::synced_background_opacity_preview(
             self.background_opacity,

--- a/src/terminal_view/render.rs
+++ b/src/terminal_view/render.rs
@@ -1701,11 +1701,11 @@ impl TerminalView {
                 menu_width,
                 menu_height,
             );
-            let panel_bg = overlay_style.panel_background(0.98);
-            let panel_border = overlay_style.panel_foreground(0.22);
+            let panel_bg = overlay_style.chrome_panel_background(0.98);
+            let panel_border = overlay_style.chrome_panel_neutral(0.22);
             let text_active = overlay_style.panel_foreground(0.95);
             let text_disabled = overlay_style.panel_foreground(0.42);
-            let hover_bg = overlay_style.panel_cursor(0.22);
+            let hover_bg = overlay_style.chrome_panel_cursor(0.22);
             let buffer_position_item = |label: String| {
                 div()
                     .id("terminal-context-menu-buffer-position")
@@ -1994,9 +1994,9 @@ impl TerminalView {
                             .px(px(14.0))
                             .py(px(8.0))
                             .rounded(px(6.0))
-                            .bg(overlay_style.panel_background(0.84))
+                            .bg(overlay_style.chrome_panel_background(0.84))
                             .border_1()
-                            .border_color(overlay_style.panel_foreground(0.24))
+                            .border_color(overlay_style.chrome_panel_neutral(0.24))
                             .text_size(px(13.0))
                             .font_weight(FontWeight::MEDIUM)
                             .text_color(overlay_style.panel_foreground(0.95))
@@ -2032,9 +2032,9 @@ impl TerminalView {
                 .px(px(10.0))
                 .py(px(8.0))
                 .rounded(px(6.0))
-                .bg(overlay_style.panel_background(0.84))
+                .bg(overlay_style.chrome_panel_background(0.84))
                 .border_1()
-                .border_color(overlay_style.panel_foreground(0.24))
+                .border_color(overlay_style.chrome_panel_neutral(0.24))
                 .text_size(px(12.0))
                 .font_weight(FontWeight::MEDIUM)
                 .text_color(overlay_style.panel_foreground(0.95))

--- a/src/terminal_view/search.rs
+++ b/src/terminal_view/search.rs
@@ -228,12 +228,12 @@ impl TerminalView {
     pub(super) fn render_search_bar(&self, cx: &mut Context<Self>) -> AnyElement {
         let colors = &self.colors;
         let overlay_style = self.overlay_style();
-        let bar_bg = overlay_style.panel_background(SEARCH_BAR_BG_ALPHA);
-        let bar_border = overlay_style.panel_cursor(OVERLAY_PANEL_BORDER_ALPHA);
-        let input_bg = overlay_style.panel_background(SEARCH_INPUT_BG_ALPHA);
+        let bar_bg = overlay_style.chrome_panel_background(SEARCH_BAR_BG_ALPHA);
+        let bar_border = overlay_style.chrome_panel_cursor(OVERLAY_PANEL_BORDER_ALPHA);
+        let input_bg = overlay_style.chrome_panel_background(SEARCH_INPUT_BG_ALPHA);
         let counter_text = overlay_style.panel_foreground(SEARCH_COUNTER_TEXT_ALPHA);
         let button_text = overlay_style.panel_foreground(SEARCH_BUTTON_TEXT_ALPHA);
-        let button_hover_bg = overlay_style.panel_cursor(SEARCH_BUTTON_HOVER_BG_ALPHA);
+        let button_hover_bg = overlay_style.chrome_panel_cursor(SEARCH_BUTTON_HOVER_BG_ALPHA);
 
         let (current, total) = self.search_state.results().position().unwrap_or((0, 0));
 
@@ -285,7 +285,7 @@ impl TerminalView {
                         colors.foreground.into(),
                         {
                             overlay_style
-                                .panel_cursor(SEARCH_INPUT_SELECTION_ALPHA)
+                                .chrome_panel_cursor(SEARCH_INPUT_SELECTION_ALPHA)
                                 .into()
                         },
                         InlineInputAlignment::Left,

--- a/src/terminal_view/tab_strip/render_palette.rs
+++ b/src/terminal_view/tab_strip/render_palette.rs
@@ -35,46 +35,46 @@ impl TerminalView {
         let tab_stroke_color = chrome::resolve_tab_stroke_color(
             tabbar_bg,
             colors.foreground,
-            TAB_STROKE_FOREGROUND_MIX,
+            self.chrome_contrast_profile().stroke_mix,
         );
         let mut inactive_tab_bg = colors.foreground;
-        inactive_tab_bg.a = self.scaled_chrome_alpha(0.10);
+        inactive_tab_bg.a = self.scaled_chrome_surface_alpha(0.10);
         let mut active_tab_bg = tabbar_bg;
         active_tab_bg.a = 0.0;
         let mut hovered_tab_bg = colors.foreground;
-        hovered_tab_bg.a = self.scaled_chrome_alpha(0.13);
+        hovered_tab_bg.a = self.scaled_chrome_surface_alpha(0.13);
         let mut active_tab_text = colors.foreground;
         active_tab_text.a = 0.95;
         let mut inactive_tab_text = colors.foreground;
         inactive_tab_text.a = 0.7;
         let mut close_button_bg = colors.foreground;
-        close_button_bg.a = self.scaled_chrome_alpha(0.07);
+        close_button_bg.a = self.scaled_chrome_surface_alpha(0.07);
         let mut close_button_border = colors.foreground;
-        close_button_border.a = self.scaled_chrome_alpha(0.14);
+        close_button_border.a = self.scaled_chrome_neutral_border_alpha(0.14);
         let mut close_button_hover_bg = colors.foreground;
-        close_button_hover_bg.a = self.scaled_chrome_alpha(0.16);
+        close_button_hover_bg.a = self.scaled_chrome_surface_alpha(0.16);
         let mut close_button_hover_border = colors.cursor;
-        close_button_hover_border.a = self.scaled_chrome_alpha(0.4);
+        close_button_hover_border.a = self.scaled_chrome_accent_alpha(0.4);
         let mut close_button_hover_text = colors.foreground;
         close_button_hover_text.a = 0.98;
         let now = Instant::now();
         let hint_progress = self.tab_switch_hint_progress(now);
         let mut switch_hint_bg = colors.cursor;
-        switch_hint_bg.a = self.scaled_chrome_alpha(0.18 * hint_progress);
+        switch_hint_bg.a = self.scaled_chrome_accent_alpha(0.18 * hint_progress);
         let mut switch_hint_border = colors.cursor;
-        switch_hint_border.a = self.scaled_chrome_alpha(0.52 * hint_progress);
+        switch_hint_border.a = self.scaled_chrome_accent_alpha(0.52 * hint_progress);
         let mut switch_hint_text = colors.foreground;
         switch_hint_text.a = (0.99 * hint_progress).clamp(0.0, 1.0);
         let mut tab_drop_marker_color = colors.cursor;
-        tab_drop_marker_color.a = self.scaled_chrome_alpha(0.95);
+        tab_drop_marker_color.a = self.scaled_chrome_accent_alpha(0.95);
         let mut tabbar_new_tab_bg = colors.foreground;
-        tabbar_new_tab_bg.a = self.scaled_chrome_alpha(0.11);
+        tabbar_new_tab_bg.a = self.scaled_chrome_surface_alpha(0.11);
         let mut tabbar_new_tab_hover_bg = colors.foreground;
-        tabbar_new_tab_hover_bg.a = self.scaled_chrome_alpha(0.2);
+        tabbar_new_tab_hover_bg.a = self.scaled_chrome_surface_alpha(0.2);
         let mut tabbar_new_tab_border = colors.foreground;
-        tabbar_new_tab_border.a = self.scaled_chrome_alpha(0.24);
+        tabbar_new_tab_border.a = self.scaled_chrome_neutral_border_alpha(0.24);
         let mut tabbar_new_tab_hover_border = colors.cursor;
-        tabbar_new_tab_hover_border.a = self.scaled_chrome_alpha(0.76);
+        tabbar_new_tab_hover_border.a = self.scaled_chrome_accent_alpha(0.76);
         let mut tabbar_new_tab_text = colors.foreground;
         tabbar_new_tab_text.a = 0.9;
         let mut tabbar_new_tab_hover_text = colors.cursor;


### PR DESCRIPTION
## Summary
- add a stronger chrome contrast toggle to config and settings
- wire the chrome styling through terminal, command palette, and tab strip surfaces
- regenerate config docs/default config for the new setting

## Testing
- not run in this step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new `chrome_contrast` configuration option that increases contrast on non-terminal UI surfaces for improved visibility. Disabled by default and can be toggled in Appearance settings under the CHROME section.

* **Documentation**
  * Updated configuration guide with the new `chrome_contrast` option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->