### PR TITLE
feat: add tab bar visibility toggle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7333,7 +7333,7 @@ dependencies = [
 
 [[package]]
 name = "termy"
-version = "0.1.56"
+version = "0.1.57"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
@@ -7420,7 +7420,7 @@ dependencies = [
 
 [[package]]
 name = "termy_cli"
-version = "0.1.54"
+version = "0.1.57"
 dependencies = [
  "anyhow",
  "clap",

--- a/crates/command_core/src/catalog.rs
+++ b/crates/command_core/src/catalog.rs
@@ -60,6 +60,7 @@ macro_rules! termy_command_catalog {
             (ToggleSearchCaseSensitive, "toggle_search_case_sensitive"),
             (ToggleSearchRegex, "toggle_search_regex"),
             (InstallCli, "install_cli"),
+            (ToggleTabBarVisibility, "toggle_tab_bar_visibility"),
             (ToggleVerticalTabSidebar, "toggle_vertical_tab_sidebar"),
         }
     };

--- a/crates/command_core/src/keybind.rs
+++ b/crates/command_core/src/keybind.rs
@@ -535,6 +535,20 @@ mod tests {
     }
 
     #[test]
+    fn default_keybinds_do_not_include_toggle_tab_bar_visibility() {
+        for platform in KeybindPlatform::ALL {
+            let defaults = default_keybinds_for_platform(platform);
+            assert!(
+                !defaults
+                    .iter()
+                    .any(|binding| binding.action == CommandId::ToggleTabBarVisibility),
+                "unexpected default binding for toggle_tab_bar_visibility on {}",
+                platform.as_str()
+            );
+        }
+    }
+
+    #[test]
     fn default_keybinds_are_platform_explicit() {
         let mac = default_keybinds_for_platform(KeybindPlatform::MacOs);
         assert!(mac.iter().any(|binding| binding.trigger == "secondary-m"

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -250,6 +250,7 @@ Related UI option:
 - `toggle_search_case_sensitive`
 - `toggle_search_regex`
 - `install_cli`
+- `toggle_tab_bar_visibility`
 - `toggle_vertical_tab_sidebar`
 
 ## Customization Examples

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -946,6 +946,22 @@ define_commands!(
         ))
     ),
     (
+        ToggleTabBarVisibility,
+        TERMINAL_CONTEXT,
+        Some(palette(
+            "Toggle Tab Bar Visibility",
+            "tab bar tabs strip show hide visibility horizontal vertical",
+            CommandPaletteVisibility::Always
+        )),
+        Some(menu(
+            MenuRoot::View,
+            0,
+            "Tab Bar",
+            MenuVisibility::Always,
+            MenuActionRole::Normal
+        ))
+    ),
+    (
         ToggleVerticalTabSidebar,
         TERMINAL_CONTEXT,
         Some(palette(
@@ -1044,6 +1060,19 @@ mod tests {
             CommandAction::palette_entries()
                 .iter()
                 .any(|entry| entry.action == CommandAction::SwitchTheme)
+        );
+    }
+
+    #[test]
+    fn tab_bar_visibility_toggle_is_configurable_and_palette_visible() {
+        assert_eq!(
+            CommandAction::from_config_name("toggle_tab_bar_visibility"),
+            Some(CommandAction::ToggleTabBarVisibility)
+        );
+        assert!(
+            CommandAction::palette_entries()
+                .iter()
+                .any(|entry| entry.action == CommandAction::ToggleTabBarVisibility)
         );
     }
 
@@ -1172,6 +1201,16 @@ mod tests {
                 assert_eq!(entry.root, *root);
             }
         }
+    }
+
+    #[test]
+    fn view_menu_includes_tab_bar_toggle() {
+        let view_entries = CommandAction::menu_entries_for_root(MenuRoot::View);
+        assert!(
+            view_entries
+                .iter()
+                .any(|entry| entry.action == CommandAction::ToggleTabBarVisibility)
+        );
     }
 
     #[test]

--- a/src/terminal_view/command_palette/mod.rs
+++ b/src/terminal_view/command_palette/mod.rs
@@ -1409,6 +1409,7 @@ impl TerminalView {
             | CommandAction::OpenSettings
             | CommandAction::MinimizeWindow
             | CommandAction::InstallCli
+            | CommandAction::ToggleTabBarVisibility
             | CommandAction::ToggleVerticalTabSidebar => {}
         }
     }

--- a/src/terminal_view/interaction/actions.rs
+++ b/src/terminal_view/interaction/actions.rs
@@ -127,6 +127,16 @@ impl TerminalView {
                 }
                 cx.notify();
             }
+            CommandAction::ToggleTabBarVisibility => {
+                let next_visibility = if self.should_render_tab_strip_chrome() {
+                    TabBarVisibility::ForceHidden
+                } else {
+                    TabBarVisibility::ForceVisible
+                };
+                if self.set_tab_bar_visibility(next_visibility) {
+                    cx.notify();
+                }
+            }
             _ if shortcuts_suspended => {}
             CommandAction::OpenConfig
             | CommandAction::PrettifyConfig
@@ -275,6 +285,15 @@ impl TerminalView {
         cx: &mut Context<Self>,
     ) {
         self.execute_command_action(CommandAction::ToggleVerticalTabSidebar, true, window, cx);
+    }
+
+    pub(in super::super) fn handle_toggle_tab_bar_visibility_action(
+        &mut self,
+        _: &commands::ToggleTabBarVisibility,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.execute_command_action(CommandAction::ToggleTabBarVisibility, true, window, cx);
     }
 
     pub(in super::super) fn handle_new_tab_action(

--- a/src/terminal_view/mod.rs
+++ b/src/terminal_view/mod.rs
@@ -1243,6 +1243,14 @@ pub(crate) fn initial_window_background_appearance(
     .appearance
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) enum TabBarVisibility {
+    #[default]
+    FollowConfig,
+    ForceVisible,
+    ForceHidden,
+}
+
 /// The main terminal view component
 pub struct TerminalView {
     tabs: Vec<TerminalTab>,
@@ -1266,6 +1274,7 @@ pub struct TerminalView {
     vertical_tabs_width: f32,
     vertical_tabs_minimized: bool,
     auto_hide_tabbar: bool,
+    tab_bar_visibility: TabBarVisibility,
     new_tab_animation_tab_id: Option<TabId>,
     new_tab_animation_start: Option<Instant>,
     new_tab_animation_scheduled: bool,
@@ -2195,6 +2204,19 @@ impl TerminalView {
         }
     }
 
+    pub(super) fn set_tab_bar_visibility(&mut self, visibility: TabBarVisibility) -> bool {
+        if self.tab_bar_visibility == visibility {
+            return false;
+        }
+
+        self.tab_bar_visibility = visibility;
+        self.clear_pane_render_caches();
+        self.clear_terminal_scrollbar_marker_cache();
+        self.cell_size = None;
+        self.mark_tab_strip_layout_dirty();
+        true
+    }
+
     pub(super) fn mark_terminal_scrollbar_activity(&mut self, cx: &mut Context<Self>) {
         if self.terminal_scrollbar_mode() != ScrollbarVisibilityMode::OnScroll {
             return;
@@ -2524,6 +2546,7 @@ impl TerminalView {
             ),
             vertical_tabs_minimized: config.vertical_tabs_minimized,
             auto_hide_tabbar: config.auto_hide_tabbar,
+            tab_bar_visibility: TabBarVisibility::FollowConfig,
             new_tab_animation_tab_id: None,
             new_tab_animation_start: None,
             new_tab_animation_scheduled: false,

--- a/src/terminal_view/render.rs
+++ b/src/terminal_view/render.rs
@@ -2490,6 +2490,7 @@ impl Render for TerminalView {
         let hidden_titlebar_branding = Self::should_render_hidden_titlebar_branding(
             self.auto_hide_tabbar,
             self.tabs.len(),
+            self.tab_bar_visibility,
             self.show_termy_in_titlebar,
         )
             .then(|| {
@@ -2743,6 +2744,7 @@ impl Render for TerminalView {
                     .when(self.install_cli_available(), |s| {
                         s.on_action(cx.listener(Self::handle_install_cli_action))
                     })
+                    .on_action(cx.listener(Self::handle_toggle_tab_bar_visibility_action))
                     .on_action(cx.listener(Self::handle_toggle_vertical_tab_sidebar_action))
                     .on_action(cx.listener(Self::handle_inline_backspace_action))
                     .on_action(cx.listener(Self::handle_inline_delete_action))

--- a/src/terminal_view/tab_strip/render_shared.rs
+++ b/src/terminal_view/tab_strip/render_shared.rs
@@ -21,38 +21,94 @@ mod tests {
     use super::*;
 
     #[test]
-    fn tab_strip_chrome_visible_matches_auto_hide_policy() {
-        assert!(!TerminalView::tab_strip_chrome_visible(true, 1));
-        assert!(!TerminalView::tab_strip_chrome_visible(true, 0));
-        assert!(TerminalView::tab_strip_chrome_visible(false, 1));
-        assert!(TerminalView::tab_strip_chrome_visible(true, 2));
+    fn tab_strip_chrome_visible_follows_auto_hide_policy_by_default() {
+        assert!(!TerminalView::tab_strip_chrome_visible(
+            true,
+            1,
+            TabBarVisibility::FollowConfig
+        ));
+        assert!(!TerminalView::tab_strip_chrome_visible(
+            true,
+            0,
+            TabBarVisibility::FollowConfig
+        ));
+        assert!(TerminalView::tab_strip_chrome_visible(
+            false,
+            1,
+            TabBarVisibility::FollowConfig
+        ));
+        assert!(TerminalView::tab_strip_chrome_visible(
+            true,
+            2,
+            TabBarVisibility::FollowConfig
+        ));
+    }
+
+    #[test]
+    fn tab_strip_chrome_visible_force_hidden_overrides_visible_tab_strip() {
+        assert!(!TerminalView::tab_strip_chrome_visible(
+            false,
+            3,
+            TabBarVisibility::ForceHidden
+        ));
+    }
+
+    #[test]
+    fn tab_strip_chrome_visible_force_visible_overrides_hidden_single_tab_strip() {
+        assert!(TerminalView::tab_strip_chrome_visible(
+            true,
+            1,
+            TabBarVisibility::ForceVisible
+        ));
     }
 
     #[test]
     fn hidden_titlebar_branding_shows_when_auto_hide_hides_single_tab_chrome() {
         assert!(TerminalView::should_render_hidden_titlebar_branding(
-            true, 1, true
+            true,
+            1,
+            TabBarVisibility::FollowConfig,
+            true
         ));
     }
 
     #[test]
     fn hidden_titlebar_branding_shows_when_auto_hide_hides_empty_tab_chrome() {
         assert!(TerminalView::should_render_hidden_titlebar_branding(
-            true, 0, true
+            true,
+            0,
+            TabBarVisibility::FollowConfig,
+            true
         ));
     }
 
     #[test]
     fn hidden_titlebar_branding_hides_when_branding_is_disabled() {
         assert!(!TerminalView::should_render_hidden_titlebar_branding(
-            true, 1, false
+            true,
+            1,
+            TabBarVisibility::FollowConfig,
+            false
         ));
     }
 
     #[test]
     fn hidden_titlebar_branding_hides_when_tab_strip_chrome_is_visible() {
         assert!(!TerminalView::should_render_hidden_titlebar_branding(
-            false, 1, true
+            false,
+            1,
+            TabBarVisibility::FollowConfig,
+            true
+        ));
+    }
+
+    #[test]
+    fn hidden_titlebar_branding_shows_when_tab_strip_is_force_hidden() {
+        assert!(TerminalView::should_render_hidden_titlebar_branding(
+            false,
+            3,
+            TabBarVisibility::ForceHidden,
+            true
         ));
     }
 }
@@ -105,20 +161,34 @@ impl TerminalView {
         title.chars().next().unwrap_or('•').to_string()
     }
 
-    pub(crate) fn tab_strip_chrome_visible(auto_hide_tabbar: bool, tab_count: usize) -> bool {
-        !auto_hide_tabbar || tab_count > 1
+    pub(crate) fn tab_strip_chrome_visible(
+        auto_hide_tabbar: bool,
+        tab_count: usize,
+        visibility: TabBarVisibility,
+    ) -> bool {
+        match visibility {
+            TabBarVisibility::FollowConfig => !auto_hide_tabbar || tab_count > 1,
+            TabBarVisibility::ForceVisible => true,
+            TabBarVisibility::ForceHidden => false,
+        }
     }
 
     pub(crate) fn should_render_hidden_titlebar_branding(
         auto_hide_tabbar: bool,
         tab_count: usize,
+        visibility: TabBarVisibility,
         show_termy_in_titlebar: bool,
     ) -> bool {
-        !Self::tab_strip_chrome_visible(auto_hide_tabbar, tab_count) && show_termy_in_titlebar
+        !Self::tab_strip_chrome_visible(auto_hide_tabbar, tab_count, visibility)
+            && show_termy_in_titlebar
     }
 
     pub(crate) fn should_render_tab_strip_chrome(&self) -> bool {
-        Self::tab_strip_chrome_visible(self.auto_hide_tabbar, self.tabs.len())
+        Self::tab_strip_chrome_visible(
+            self.auto_hide_tabbar,
+            self.tabs.len(),
+            self.tab_bar_visibility,
+        )
     }
 
     pub(super) fn build_tab_strip_render_state(


### PR DESCRIPTION
## Summary

Adds a new `toggle_tab_bar_visibility` command that force-hides or force-shows the tab strip for the current window session.

This works for both horizontal and vertical tab layouts, does not add a default keybinding, and does not write any new persisted config. Vertical sidebar minimized/expanded state is preserved when the tab bar is shown again.

## Changes

- Added `toggle_tab_bar_visibility` to the shared command catalog
- Added the command to the command palette and View menu
- Wired the new GPUI action through terminal command handling
- Introduced a runtime-only tab bar visibility override with:
  - `FollowConfig`
  - `ForceVisible`
  - `ForceHidden`
- Centralized tab-strip chrome visibility so rendering/layout paths use the same effective visibility logic
- Regenerated keybindings docs so the new configurable action is listed

## Testing

- `cargo test -p termy_command_core --locked`
- `cargo run -p xtask --locked -- generate-keybindings-doc --check`

## Notes

- No default keybinding was added
- No new config setting was added
- `cargo test -p termy` still hits an existing/unrelated failure in `terminal_view::tab_strip::hit_test::tests::vertical_interactive_hit_test_excludes_noninteractive_chrome_backgrounds`
