### PR TITLE
Fix top-chrome window drag hit-testing when tab strip is hidden

### DIFF
--- a/src/terminal_view/tab_strip/hit_test.rs
+++ b/src/terminal_view/tab_strip/hit_test.rs
@@ -3,6 +3,24 @@ use super::layout::{TabStripGeometry, VerticalTabStripLayoutSnapshot};
 use super::state::TabStripOrientation;
 
 impl TerminalView {
+    pub(crate) fn unified_titlebar_top_chrome_interactive_hit_test(
+        &self,
+        x: f32,
+        y: f32,
+        window: &Window,
+    ) -> bool {
+        let geometry = self.tab_strip_geometry(window);
+        let scroll_offset_x: f32 = self.tab_strip.horizontal_scroll_handle.offset().x.into();
+        Self::unified_titlebar_top_chrome_interactive_hit_test_for_geometry(
+            x,
+            y,
+            self.should_render_tab_strip_chrome(),
+            geometry,
+            self.tabs.iter().map(|tab| tab.display_width),
+            scroll_offset_x,
+        )
+    }
+
     pub(crate) fn unified_titlebar_tab_shell_hit_test(
         pointer_x: f32,
         pointer_y: f32,
@@ -27,30 +45,21 @@ impl TerminalView {
         false
     }
 
-    pub(crate) fn unified_titlebar_tab_interactive_hit_test(
-        &self,
+    pub(crate) fn unified_titlebar_top_chrome_interactive_hit_test_for_geometry(
         x: f32,
         y: f32,
-        window: &Window,
-    ) -> bool {
-        let geometry = self.tab_strip_geometry(window);
-        let scroll_offset_x: f32 = self.tab_strip.horizontal_scroll_handle.offset().x.into();
-        Self::unified_titlebar_tab_interactive_hit_test_for_geometry(
-            x,
-            y,
-            geometry,
-            self.tabs.iter().map(|tab| tab.display_width),
-            scroll_offset_x,
-        )
-    }
-
-    pub(crate) fn unified_titlebar_tab_interactive_hit_test_for_geometry(
-        x: f32,
-        y: f32,
+        show_tab_strip_chrome: bool,
         geometry: TabStripGeometry,
         tab_widths: impl IntoIterator<Item = f32>,
         scroll_offset_x: f32,
     ) -> bool {
+        // Hidden-titlebar states still render top padding/branding, but no tab-strip controls.
+        // Treat that entire surface as noninteractive so it can arm window dragging instead of
+        // reusing invisible tab geometry from the collapsed strip layout.
+        if !show_tab_strip_chrome {
+            return false;
+        }
+
         if geometry.contains_tabs_viewport_x(x) {
             let pointer_x = (x - geometry.row_start_x).clamp(0.0, geometry.tabs_viewport_width);
             if Self::unified_titlebar_tab_shell_hit_test(pointer_x, y, tab_widths, scroll_offset_x)
@@ -66,7 +75,7 @@ impl TerminalView {
         geometry.new_tab_button_contains(x, y)
     }
 
-    pub(crate) fn tab_strip_interactive_hit_test(
+    pub(crate) fn top_chrome_interactive_hit_test(
         &self,
         orientation: TabStripOrientation,
         x: f32,
@@ -75,9 +84,13 @@ impl TerminalView {
     ) -> bool {
         match orientation {
             TabStripOrientation::Horizontal => {
-                self.unified_titlebar_tab_interactive_hit_test(x, y, window)
+                self.unified_titlebar_top_chrome_interactive_hit_test(x, y, window)
             }
-            TabStripOrientation::Vertical => self.vertical_tab_strip_interactive_hit_test(x, y),
+            TabStripOrientation::Vertical => {
+                self.vertical_tabs
+                    && self.should_render_tab_strip_chrome()
+                    && self.vertical_tab_strip_interactive_hit_test(x, y)
+            }
         }
     }
 
@@ -89,7 +102,12 @@ impl TerminalView {
 
         let layout = self.vertical_tab_strip_layout_snapshot();
         let scroll_offset_y: f32 = self.tab_strip.vertical_scroll_handle.offset().y.into();
-        Self::vertical_tab_strip_interactive_hit_test_for_layout(x, local_y, &layout, scroll_offset_y)
+        Self::vertical_tab_strip_interactive_hit_test_for_layout(
+            x,
+            local_y,
+            &layout,
+            scroll_offset_y,
+        )
     }
 
     pub(super) fn vertical_tab_strip_interactive_hit_test_for_layout(
@@ -181,9 +199,10 @@ mod tests {
         let geometry = TerminalView::tab_strip_geometry_for_viewport_width(1280.0);
         let x = geometry.row_start_x + TAB_HORIZONTAL_PADDING + 12.0;
         assert!(
-            TerminalView::unified_titlebar_tab_interactive_hit_test_for_geometry(
+            TerminalView::unified_titlebar_top_chrome_interactive_hit_test_for_geometry(
                 x,
                 tab_hit_test_y(),
+                true,
                 geometry,
                 [120.0, 120.0],
                 0.0,
@@ -197,9 +216,10 @@ mod tests {
         let center_x = (geometry.button_start_x + geometry.button_end_x) * 0.5;
         let center_y = (geometry.button_start_y + geometry.button_end_y) * 0.5;
         assert!(
-            TerminalView::unified_titlebar_tab_interactive_hit_test_for_geometry(
+            TerminalView::unified_titlebar_top_chrome_interactive_hit_test_for_geometry(
                 center_x,
                 center_y,
+                true,
                 geometry,
                 [120.0, 120.0],
                 0.0,
@@ -215,9 +235,10 @@ mod tests {
         assert!(!geometry.new_tab_button_contains(x, y));
         assert!(geometry.contains_action_rail_x(x));
         assert!(
-            !TerminalView::unified_titlebar_tab_interactive_hit_test_for_geometry(
+            !TerminalView::unified_titlebar_top_chrome_interactive_hit_test_for_geometry(
                 x,
                 y,
+                true,
                 geometry,
                 [120.0, 120.0],
                 0.0,
@@ -231,9 +252,10 @@ mod tests {
         let x = geometry.gutter_start_x + (geometry.gutter_width * 0.5);
         assert!(geometry.contains_gutter_x(x));
         assert!(
-            !TerminalView::unified_titlebar_tab_interactive_hit_test_for_geometry(
+            !TerminalView::unified_titlebar_top_chrome_interactive_hit_test_for_geometry(
                 x,
                 tab_hit_test_y(),
+                true,
                 geometry,
                 [120.0, 120.0],
                 0.0,
@@ -250,9 +272,10 @@ mod tests {
         );
         let x = geometry.left_inset_width - 1.0;
         assert!(
-            !TerminalView::unified_titlebar_tab_interactive_hit_test_for_geometry(
+            !TerminalView::unified_titlebar_top_chrome_interactive_hit_test_for_geometry(
                 x,
                 tab_hit_test_y(),
+                true,
                 geometry,
                 [120.0, 120.0],
                 0.0,
@@ -265,9 +288,10 @@ mod tests {
         let geometry = TerminalView::tab_strip_geometry_for_viewport_width(1280.0);
         let x = geometry.action_rail_end_x() + (geometry.right_inset_width * 0.5);
         assert!(
-            !TerminalView::unified_titlebar_tab_interactive_hit_test_for_geometry(
+            !TerminalView::unified_titlebar_top_chrome_interactive_hit_test_for_geometry(
                 x,
                 tab_hit_test_y(),
+                true,
                 geometry,
                 [120.0, 120.0],
                 0.0,
@@ -284,9 +308,10 @@ mod tests {
         let action_start = geometry.gutter_end_x();
         assert!(geometry.contains_action_rail_x(action_start));
         assert!(
-            !TerminalView::unified_titlebar_tab_interactive_hit_test_for_geometry(
+            !TerminalView::unified_titlebar_top_chrome_interactive_hit_test_for_geometry(
                 action_start,
                 tab_hit_test_y(),
+                true,
                 geometry,
                 [120.0, 120.0],
                 0.0,
@@ -296,11 +321,47 @@ mod tests {
         let action_end = geometry.action_rail_end_x();
         assert!(!geometry.contains_action_rail_x(action_end));
         assert!(
-            !TerminalView::unified_titlebar_tab_interactive_hit_test_for_geometry(
+            !TerminalView::unified_titlebar_top_chrome_interactive_hit_test_for_geometry(
                 action_end,
                 tab_hit_test_y(),
+                true,
                 geometry,
                 [120.0, 120.0],
+                0.0,
+            )
+        );
+    }
+
+    #[test]
+    fn hidden_horizontal_titlebar_ignores_invisible_tab_shells() {
+        let geometry = TerminalView::tab_strip_geometry_for_viewport_width(1280.0);
+        let x = geometry.row_start_x + TAB_HORIZONTAL_PADDING + 12.0;
+
+        assert!(
+            !TerminalView::unified_titlebar_top_chrome_interactive_hit_test_for_geometry(
+                x,
+                tab_hit_test_y(),
+                false,
+                geometry,
+                [120.0],
+                0.0,
+            )
+        );
+    }
+
+    #[test]
+    fn hidden_vertical_titlebar_ignores_invisible_action_rail_controls() {
+        let geometry = TerminalView::tab_strip_geometry_for_viewport_width(1280.0);
+        let center_x = (geometry.button_start_x + geometry.button_end_x) * 0.5;
+        let center_y = (geometry.button_start_y + geometry.button_end_y) * 0.5;
+
+        assert!(
+            !TerminalView::unified_titlebar_top_chrome_interactive_hit_test_for_geometry(
+                center_x,
+                center_y,
+                false,
+                geometry,
+                [120.0],
                 0.0,
             )
         );
@@ -312,12 +373,14 @@ mod tests {
         let compact = false;
         let layout = vertical_hit_test_layout(strip_width, compact);
 
-        assert!(TerminalView::vertical_tab_strip_interactive_hit_test_for_layout(
-            24.0,
-            layout.list_top + 12.0,
-            &layout,
-            0.0,
-        ));
+        assert!(
+            TerminalView::vertical_tab_strip_interactive_hit_test_for_layout(
+                24.0,
+                layout.list_top + 12.0,
+                &layout,
+                0.0,
+            )
+        );
     }
 
     #[test]
@@ -330,26 +393,33 @@ mod tests {
         let top_button_y = layout.header_height
             + layout.top_shelf_layout.button_y
             + (layout.top_shelf_layout.button_height * 0.5);
-        assert!(TerminalView::vertical_tab_strip_interactive_hit_test_for_layout(
-            top_button_x,
-            top_button_y,
-            &layout,
-            0.0,
-        ));
-        assert!(TerminalView::vertical_tab_strip_interactive_hit_test_for_layout(
-            layout.bottom_shelf_layout.button_x + (layout.bottom_shelf_layout.button_size * 0.5),
-            layout.bottom_shelf_top
-                + layout.bottom_shelf_layout.button_y
-                + (layout.bottom_shelf_layout.button_size * 0.5),
-            &layout,
-            0.0,
-        ));
-        assert!(TerminalView::vertical_tab_strip_interactive_hit_test_for_layout(
-            strip_width - 1.0,
-            24.0,
-            &layout,
-            0.0,
-        ));
+        assert!(
+            TerminalView::vertical_tab_strip_interactive_hit_test_for_layout(
+                top_button_x,
+                top_button_y,
+                &layout,
+                0.0,
+            )
+        );
+        assert!(
+            TerminalView::vertical_tab_strip_interactive_hit_test_for_layout(
+                layout.bottom_shelf_layout.button_x
+                    + (layout.bottom_shelf_layout.button_size * 0.5),
+                layout.bottom_shelf_top
+                    + layout.bottom_shelf_layout.button_y
+                    + (layout.bottom_shelf_layout.button_size * 0.5),
+                &layout,
+                0.0,
+            )
+        );
+        assert!(
+            TerminalView::vertical_tab_strip_interactive_hit_test_for_layout(
+                strip_width - 1.0,
+                24.0,
+                &layout,
+                0.0,
+            )
+        );
     }
 
     #[test]
@@ -358,23 +428,26 @@ mod tests {
         let compact = false;
         let layout = vertical_hit_test_layout(strip_width, compact);
 
-        assert!(!TerminalView::vertical_tab_strip_interactive_hit_test_for_layout(
-            24.0,
-            12.0,
-            &layout,
-            0.0,
-        ));
-        assert!(!TerminalView::vertical_tab_strip_interactive_hit_test_for_layout(
-            12.0,
-            layout.header_height + 8.0,
-            &layout,
-            0.0,
-        ));
-        assert!(!TerminalView::vertical_tab_strip_interactive_hit_test_for_layout(
-            24.0,
-            layout.list_top + TAB_ITEM_HEIGHT + 40.0,
-            &layout,
-            0.0,
-        ));
+        assert!(
+            !TerminalView::vertical_tab_strip_interactive_hit_test_for_layout(
+                24.0, 12.0, &layout, 0.0,
+            )
+        );
+        assert!(
+            !TerminalView::vertical_tab_strip_interactive_hit_test_for_layout(
+                12.0,
+                layout.header_height + 8.0,
+                &layout,
+                0.0,
+            )
+        );
+        assert!(
+            !TerminalView::vertical_tab_strip_interactive_hit_test_for_layout(
+                24.0,
+                layout.list_top + TAB_ITEM_HEIGHT + 40.0,
+                &layout,
+                0.0,
+            )
+        );
     }
 }

--- a/src/terminal_view/tab_strip/titlebar_drag.rs
+++ b/src/terminal_view/tab_strip/titlebar_drag.rs
@@ -19,7 +19,7 @@ impl TerminalView {
 
         let x: f32 = event.position.x.into();
         let y: f32 = event.position.y.into();
-        let interactive_hit = self.tab_strip_interactive_hit_test(orientation, x, y, window);
+        let interactive_hit = self.top_chrome_interactive_hit_test(orientation, x, y, window);
         let outcome = self
             .tab_strip
             .titlebar
@@ -166,8 +166,8 @@ impl TerminalView {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::terminal_view::tab_strip::state::TabStripTitlebarState;
     use crate::terminal_view::tab_strip::layout::VerticalTabStripLayoutInput;
+    use crate::terminal_view::tab_strip::state::TabStripTitlebarState;
 
     fn vertical_layout(
         strip_width: f32,
@@ -189,6 +189,21 @@ mod tests {
         state
     }
 
+    fn hidden_titlebar_interactive_hit() -> bool {
+        let geometry = TerminalView::tab_strip_geometry_for_viewport_width(1280.0);
+        let x = geometry.row_start_x + TAB_HORIZONTAL_PADDING + 12.0;
+        let y = TOP_STRIP_CONTENT_OFFSET_Y + TABBAR_HEIGHT - 1.0;
+
+        TerminalView::unified_titlebar_top_chrome_interactive_hit_test_for_geometry(
+            x,
+            y,
+            false,
+            geometry,
+            [120.0],
+            0.0,
+        )
+    }
+
     #[test]
     fn titlebar_window_move_requires_armed_and_dragging() {
         assert!(!TabStripTitlebarState::default().should_start_window_move(true, false));
@@ -205,10 +220,7 @@ mod tests {
     fn vertical_noninteractive_chrome_hit_arms_window_move() {
         let layout = vertical_layout(220.0, false);
         let interactive = TerminalView::vertical_tab_strip_interactive_hit_test_for_layout(
-            24.0,
-            12.0,
-            &layout,
-            0.0,
+            24.0, 12.0, &layout, 0.0,
         );
         let mut state = TabStripTitlebarState::default();
 
@@ -232,13 +244,30 @@ mod tests {
     }
 
     #[test]
+    fn hidden_horizontal_titlebar_arms_window_move() {
+        let interactive = hidden_titlebar_interactive_hit();
+        let mut state = TabStripTitlebarState::default();
+
+        assert!(!interactive);
+        assert!(state.on_mouse_down(interactive, 1).arm_move);
+    }
+
+    #[test]
+    fn hidden_vertical_titlebar_double_click_uses_titlebar_double_click_branch() {
+        let interactive = hidden_titlebar_interactive_hit();
+        let mut state = TabStripTitlebarState::default();
+
+        assert!(!interactive);
+        let outcome = state.on_mouse_down(interactive, 2);
+        assert!(!outcome.arm_move);
+        assert!(outcome.trigger_window_action);
+    }
+
+    #[test]
     fn vertical_noninteractive_double_click_uses_titlebar_double_click_branch() {
         let layout = vertical_layout(220.0, false);
         let interactive = TerminalView::vertical_tab_strip_interactive_hit_test_for_layout(
-            24.0,
-            12.0,
-            &layout,
-            0.0,
+            24.0, 12.0, &layout, 0.0,
         );
         let mut state = TabStripTitlebarState::default();
 


### PR DESCRIPTION
## Summary
- make top-chrome drag hit testing aware of whether tab strip chrome is actually visible
- allow hidden horizontal and hidden vertical titlebar padding/branding areas to arm window dragging
- add regressions for hidden titlebar drag arming and double-click behavior

## Testing
- cargo test hidden_horizontal_titlebar
- cargo test hidden_vertical_titlebar
- cargo test interactive_hit_test_detects_tab_shell
- cargo test vertical_noninteractive_chrome_hit_arms_window_move

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined interactive region detection in the titlebar and tab strip for more accurate click and drag responses
  * Improved window dragging behavior when interacting with the titlebar, with enhanced support for hidden titlebar and chrome scenarios
  * Enhanced interaction detection to ensure correct window-move functionality in edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->