### PR TITLE
fix: unify shared scrollbar and pane geometry

### DIFF
--- a/src/terminal_view/interaction/mouse.rs
+++ b/src/terminal_view/interaction/mouse.rs
@@ -1018,13 +1018,17 @@ impl TerminalView {
             cx.stop_propagation();
             return;
         }
-        if event.dragging()
-            && self.terminal_scrollbar_track_hold_local_y.is_some()
-            && let Some(hit) = self.terminal_scrollbar_hit_test(event.position, window)
-        {
-            self.update_terminal_scrollbar_track_hold(hit.local_y);
-            cx.stop_propagation();
-            return;
+        if event.dragging() && self.terminal_scrollbar_track_hold.is_some() {
+            if let Some(hit) = self.terminal_scrollbar_hit_test(event.position, window) {
+                self.update_terminal_scrollbar_track_hold(hit.local_y);
+                cx.stop_propagation();
+                return;
+            }
+            if self.stop_terminal_scrollbar_track_hold() {
+                cx.stop_propagation();
+                cx.notify();
+                return;
+            }
         }
         if self.pane_resize_drag.is_some() {
             if event.dragging() {

--- a/src/terminal_view/interaction/scroll.rs
+++ b/src/terminal_view/interaction/scroll.rs
@@ -16,21 +16,20 @@ enum WheelScrollRetargetResult {
     NotRetargeted,
 }
 
-fn terminal_scrollbar_local_y_from_window_y(
-    window_y: f32,
-    content_top_inset: f32,
-    surface_origin_y: f32,
-    surface_height: f32,
-) -> Option<f32> {
-    let content_y = TerminalView::window_y_to_terminal_content_y(window_y, content_top_inset);
-    if content_y < surface_origin_y || content_y > surface_origin_y + surface_height {
-        return None;
+impl TerminalView {
+    fn terminal_scrollbar_interaction_layout(
+        &self,
+        window: &Window,
+    ) -> Option<(
+        TerminalScrollbarSurfaceGeometry,
+        terminal_scrollbar::TerminalScrollbarLayout,
+    )> {
+        let pane_layout = self.active_terminal_pane_layout(window)?;
+        let surface = pane_layout.scrollbar_surface;
+        let layout = self.terminal_scrollbar_layout_for_track(surface.height)?;
+        Some((surface, layout))
     }
 
-    Some(content_y - surface_origin_y)
-}
-
-impl TerminalView {
     fn should_attempt_wheel_scroll_retarget(touch_phase: TouchPhase, delta_lines: i32) -> bool {
         matches!(touch_phase, TouchPhase::Moved) && delta_lines != 0
     }
@@ -218,29 +217,14 @@ impl TerminalView {
             return None;
         }
 
-        let surface = self.terminal_surface_geometry(window)?;
-        let gutter_width = TERMINAL_SCROLLBAR_GUTTER_WIDTH.min(surface.width.max(0.0));
-        if gutter_width <= f32::EPSILON {
-            return None;
-        }
-        let scrollbar_left =
-            (surface.origin_x + surface.width.max(0.0) - gutter_width).max(surface.origin_x);
-        let scrollbar_right = scrollbar_left + gutter_width;
-
-        let x: f32 = position.x.into();
-        if x < scrollbar_left || x > scrollbar_right {
+        let (surface, layout) = self.terminal_scrollbar_interaction_layout(window)?;
+        let gutter = surface.gutter_frame()?;
+        let (x, y) = self.terminal_content_position(position);
+        if x < gutter.left || x > gutter.left + gutter.width {
             return None;
         }
 
-        let window_y: f32 = position.y.into();
-        let local_y = terminal_scrollbar_local_y_from_window_y(
-            window_y,
-            self.terminal_content_top_inset(),
-            surface.origin_y,
-            surface.height,
-        )?;
-
-        let layout = self.terminal_scrollbar_layout_for_track(surface.height)?;
+        let local_y = surface.local_y(y)?;
         let metrics = layout.metrics;
         let thumb_hit =
             local_y >= metrics.thumb_top && local_y <= metrics.thumb_top + metrics.thumb_height;
@@ -286,10 +270,8 @@ impl TerminalView {
         window: &Window,
         cx: &mut Context<Self>,
     ) {
-        let Some(surface) = self.terminal_surface_geometry(window) else {
-            return;
-        };
-        let Some(layout) = self.terminal_scrollbar_layout_for_track(surface.height) else {
+        let Some((surface, layout)) = self.terminal_scrollbar_interaction_layout(window) else {
+            self.stop_terminal_scrollbar_track_hold();
             return;
         };
         let range = layout.range;
@@ -297,7 +279,8 @@ impl TerminalView {
 
         if hit.thumb_hit {
             self.stop_terminal_scrollbar_track_hold();
-            let thumb_grab_offset = (hit.local_y - hit.thumb_top).clamp(0.0, metrics.thumb_height);
+            let thumb_grab_offset =
+                (hit.local_y - hit.thumb_top).clamp(0.0, metrics.thumb_height);
             self.start_terminal_scrollbar_drag(thumb_grab_offset, cx);
             cx.notify();
             return;
@@ -311,7 +294,13 @@ impl TerminalView {
             self.terminal_scroll_accumulator_y = 0.0;
             self.sync_content_scroll_baseline();
         }
-        self.start_terminal_scrollbar_track_hold(hit.local_y, cx);
+        self.start_terminal_scrollbar_track_hold(
+            TerminalScrollbarTrackHoldState {
+                local_y: hit.local_y,
+                track_height: surface.height,
+            },
+            cx,
+        );
         self.mark_terminal_scrollbar_activity(cx);
         cx.notify();
     }
@@ -320,43 +309,40 @@ impl TerminalView {
         &mut self,
         cx: &mut Context<Self>,
     ) -> bool {
-        let Some(local_y) = self.terminal_scrollbar_track_hold_local_y else {
+        let Some(state) = self.terminal_scrollbar_track_hold else {
             return false;
         };
         if self.terminal_scrollbar_drag.is_some() {
             return false;
         }
 
-        let Some(surface) = self.terminal_viewport_geometry() else {
-            self.terminal_scrollbar_track_hold_local_y = None;
-            return false;
-        };
-        let Some(layout) = self.terminal_scrollbar_layout_for_track(surface.height) else {
-            self.terminal_scrollbar_track_hold_local_y = None;
+        let Some(layout) = self.terminal_scrollbar_layout_for_track(state.track_height) else {
+            self.terminal_scrollbar_track_hold = None;
             return false;
         };
         let range = layout.range;
         let metrics = layout.metrics;
         let thumb_contains_point =
-            local_y >= metrics.thumb_top && local_y <= metrics.thumb_top + metrics.thumb_height;
+            state.local_y >= metrics.thumb_top
+                && state.local_y <= metrics.thumb_top + metrics.thumb_height;
         if thumb_contains_point {
-            self.terminal_scrollbar_track_hold_local_y = None;
+            self.terminal_scrollbar_track_hold = None;
             return false;
         }
 
         let changed = self.apply_terminal_scroll_offset(
-            ui_scrollbar::offset_from_track_click(local_y, range, metrics),
+            ui_scrollbar::offset_from_track_click(state.local_y, range, metrics),
             layout,
         );
         if !changed {
-            self.terminal_scrollbar_track_hold_local_y = None;
+            self.terminal_scrollbar_track_hold = None;
             return false;
         }
         self.terminal_scroll_accumulator_y = 0.0;
         self.sync_content_scroll_baseline();
         cx.notify();
         self.mark_terminal_scrollbar_activity(cx);
-        self.terminal_scrollbar_track_hold_local_y.is_some()
+        self.terminal_scrollbar_track_hold.is_some()
     }
 
     pub(in super::super) fn handle_terminal_scrollbar_drag(
@@ -368,10 +354,10 @@ impl TerminalView {
         let Some(drag) = self.terminal_scrollbar_drag else {
             return;
         };
-        let Some(surface) = self.terminal_surface_geometry(window) else {
-            return;
-        };
-        let Some(layout) = self.terminal_scrollbar_layout_for_track(surface.height) else {
+        let Some((surface, layout)) = self.terminal_scrollbar_interaction_layout(window) else {
+            if self.finish_terminal_scrollbar_drag(cx) {
+                cx.notify();
+            }
             return;
         };
         let range = layout.range;
@@ -584,14 +570,28 @@ mod tests {
     }
 
     #[test]
-    fn terminal_scrollbar_local_y_from_window_y_subtracts_content_top_inset_before_surface_math() {
-        let local_y = terminal_scrollbar_local_y_from_window_y(164.0, 44.0, 100.0, 300.0);
+    fn terminal_scrollbar_surface_local_y_uses_content_space_origin() {
+        let surface =
+            TerminalScrollbarSurfaceGeometry::new(600.0, 100.0, 12.0, 300.0).expect("surface");
+        let local_y = surface.local_y(120.0);
         assert_eq!(local_y, Some(20.0));
     }
 
     #[test]
-    fn terminal_scrollbar_local_y_from_window_y_rejects_points_outside_surface() {
-        let local_y = terminal_scrollbar_local_y_from_window_y(120.0, 44.0, 100.0, 300.0);
+    fn terminal_scrollbar_surface_local_y_rejects_points_outside_surface() {
+        let surface =
+            TerminalScrollbarSurfaceGeometry::new(600.0, 100.0, 12.0, 300.0).expect("surface");
+        let local_y = surface.local_y(80.0);
         assert_eq!(local_y, None);
+    }
+
+    #[test]
+    fn terminal_scrollbar_gutter_frame_anchors_to_surface_right_edge() {
+        let surface = TerminalScrollbarSurfaceGeometry::new(600.0, 400.0, 407.0, 409.0)
+            .expect("surface");
+
+        let frame = surface.gutter_frame().expect("frame");
+        assert_eq!(frame.left, 995.0);
+        assert_eq!(frame.width, 12.0);
     }
 }

--- a/src/terminal_view/mod.rs
+++ b/src/terminal_view/mod.rs
@@ -182,13 +182,124 @@ struct SelectionPos {
 pub(super) struct TerminalViewportGeometry {
     origin_x: f32,
     origin_y: f32,
+    height: f32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct TerminalContentRect {
+    origin_x: f32,
+    origin_y: f32,
     width: f32,
     height: f32,
+}
+
+impl TerminalContentRect {
+    fn new(origin_x: f32, origin_y: f32, width: f32, height: f32) -> Option<Self> {
+        if width <= f32::EPSILON || height <= f32::EPSILON {
+            return None;
+        }
+
+        Some(Self {
+            origin_x,
+            origin_y,
+            width,
+            height,
+        })
+    }
+
+    fn right(self) -> f32 {
+        self.origin_x + self.width
+    }
+
+    fn bottom(self) -> f32 {
+        self.origin_y + self.height
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct TerminalScrollbarSurfaceGeometry {
+    origin_x: f32,
+    origin_y: f32,
+    width: f32,
+    height: f32,
+}
+
+impl TerminalScrollbarSurfaceGeometry {
+    fn new(origin_x: f32, origin_y: f32, width: f32, height: f32) -> Option<Self> {
+        if width <= f32::EPSILON || height <= f32::EPSILON {
+            return None;
+        }
+
+        Some(Self {
+            origin_x,
+            origin_y,
+            width,
+            height,
+        })
+    }
+
+    fn gutter_frame(self) -> Option<TerminalScrollbarGutterFrame> {
+        let gutter_width = TERMINAL_SCROLLBAR_GUTTER_WIDTH.min(self.width.max(0.0));
+        if gutter_width <= f32::EPSILON {
+            return None;
+        }
+
+        Some(TerminalScrollbarGutterFrame {
+            left: (self.origin_x + self.width.max(0.0) - gutter_width).max(self.origin_x),
+            top: self.origin_y,
+            width: gutter_width,
+            height: self.height,
+        })
+    }
+
+    fn local_y(self, content_y: f32) -> Option<f32> {
+        if content_y < self.origin_y || content_y > self.origin_y + self.height {
+            return None;
+        }
+
+        Some(content_y - self.origin_y)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct TerminalScrollbarGutterFrame {
+    left: f32,
+    top: f32,
+    width: f32,
+    height: f32,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct TerminalPaneNeighborGaps {
+    right_cells: Option<u32>,
+    bottom_cells: Option<u32>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct TerminalPaneLayout {
+    frame: TerminalContentRect,
+    content_frame: TerminalContentRect,
+    scrollbar_surface: TerminalScrollbarSurfaceGeometry,
+    cell_width: f32,
+    cell_height: f32,
+    extends_right_edge: bool,
+    extends_bottom_edge: bool,
+    gaps: TerminalPaneNeighborGaps,
+}
+
+fn cell_ranges_overlap(start_a: u32, end_a: u32, start_b: u32, end_b: u32) -> bool {
+    start_a < end_b && start_b < end_a
 }
 
 #[derive(Clone, Copy, Debug)]
 struct TerminalScrollbarDragState {
     thumb_grab_offset: f32,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct TerminalScrollbarTrackHoldState {
+    local_y: f32,
+    track_height: f32,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1356,7 +1467,7 @@ pub struct TerminalView {
     terminal_scrollbar_visibility_controller: ScrollbarVisibilityController,
     terminal_scrollbar_animation_active: bool,
     terminal_scrollbar_drag: Option<TerminalScrollbarDragState>,
-    terminal_scrollbar_track_hold_local_y: Option<f32>,
+    terminal_scrollbar_track_hold: Option<TerminalScrollbarTrackHoldState>,
     terminal_scrollbar_track_hold_active: bool,
     pane_resize_drag: Option<PaneResizeDragState>,
     vertical_tab_strip_resize_drag: Option<VerticalTabStripResizeDragState>,
@@ -2162,6 +2273,141 @@ impl TerminalView {
         )
     }
 
+    fn terminal_content_bounds(&self, window: &Window) -> Option<TerminalContentRect> {
+        let viewport = window.viewport_size();
+        let viewport_width: f32 = viewport.width.into();
+        let viewport_height: f32 = viewport.height.into();
+        TerminalContentRect::new(
+            0.0,
+            0.0,
+            viewport_width - self.tab_strip_sidebar_width(),
+            viewport_height - self.terminal_content_top_inset(),
+        )
+    }
+
+    fn pane_neighbor_gaps(pane: &TerminalPane, panes: &[TerminalPane]) -> TerminalPaneNeighborGaps {
+        let pane_left = u32::from(pane.left);
+        let pane_top = u32::from(pane.top);
+        let pane_right = pane_left + u32::from(pane.width);
+        let pane_bottom = pane_top + u32::from(pane.height);
+        let mut gaps = TerminalPaneNeighborGaps::default();
+
+        for candidate in panes {
+            if candidate.id == pane.id {
+                continue;
+            }
+
+            let candidate_left = u32::from(candidate.left);
+            let candidate_top = u32::from(candidate.top);
+            let candidate_right = candidate_left + u32::from(candidate.width);
+            let candidate_bottom = candidate_top + u32::from(candidate.height);
+
+            if candidate_left >= pane_right
+                && cell_ranges_overlap(pane_top, pane_bottom, candidate_top, candidate_bottom)
+            {
+                let gap = candidate_left.saturating_sub(pane_right);
+                gaps.right_cells = Some(gaps.right_cells.map_or(gap, |current| current.min(gap)));
+            }
+
+            if candidate_top >= pane_bottom
+                && cell_ranges_overlap(pane_left, pane_right, candidate_left, candidate_right)
+            {
+                let gap = candidate_top.saturating_sub(pane_bottom);
+                gaps.bottom_cells = Some(gaps.bottom_cells.map_or(gap, |current| current.min(gap)));
+            }
+        }
+
+        gaps
+    }
+
+    fn terminal_pane_layout(
+        &self,
+        tab: &TerminalTab,
+        pane: &TerminalPane,
+        content_bounds: TerminalContentRect,
+    ) -> Option<TerminalPaneLayout> {
+        let terminal_size = pane.terminal.size();
+        if terminal_size.cols == 0 || terminal_size.rows == 0 {
+            return None;
+        }
+
+        let cell_width: f32 = terminal_size.cell_width.into();
+        let cell_height: f32 = terminal_size.cell_height.into();
+        if cell_width <= f32::EPSILON || cell_height <= f32::EPSILON {
+            return None;
+        }
+
+        let (outer_padding_x, outer_padding_y) = self.effective_terminal_padding();
+        let (content_padding_x, content_padding_y) = self.native_split_content_padding();
+        let frame = TerminalContentRect::new(
+            outer_padding_x + (f32::from(pane.left) * cell_width),
+            outer_padding_y + (f32::from(pane.top) * cell_height),
+            f32::from(pane.width) * cell_width,
+            f32::from(pane.height) * cell_height,
+        )?;
+        let content_frame = TerminalContentRect::new(
+            frame.origin_x + content_padding_x,
+            frame.origin_y + content_padding_y,
+            f32::from(terminal_size.cols) * cell_width,
+            f32::from(terminal_size.rows) * cell_height,
+        )?;
+        let gaps = Self::pane_neighbor_gaps(pane, &tab.panes);
+        let pane_right = u32::from(pane.left).saturating_add(u32::from(pane.width));
+        let pane_bottom = u32::from(pane.top).saturating_add(u32::from(pane.height));
+        let max_right = tab
+            .panes
+            .iter()
+            .map(|candidate| u32::from(candidate.left).saturating_add(u32::from(candidate.width)))
+            .max()
+            .unwrap_or(pane_right);
+        let max_bottom = tab
+            .panes
+            .iter()
+            .map(|candidate| u32::from(candidate.top).saturating_add(u32::from(candidate.height)))
+            .max()
+            .unwrap_or(pane_bottom);
+        let multi_pane = tab.panes.len() > 1;
+        let extends_right_edge = !multi_pane || pane_right == max_right;
+        let extends_bottom_edge = !multi_pane || pane_bottom == max_bottom;
+        let scrollbar_surface = TerminalScrollbarSurfaceGeometry::new(
+            if multi_pane { frame.origin_x } else { content_bounds.origin_x },
+            if multi_pane { frame.origin_y } else { content_bounds.origin_y },
+            if multi_pane && !extends_right_edge {
+                frame.width
+            } else if multi_pane {
+                (content_bounds.right() - frame.origin_x).max(0.0)
+            } else {
+                content_bounds.width
+            },
+            if multi_pane && !extends_bottom_edge {
+                frame.height
+            } else if multi_pane {
+                (content_bounds.bottom() - frame.origin_y).max(0.0)
+            } else {
+                content_bounds.height
+            },
+        )?;
+
+        Some(TerminalPaneLayout {
+            frame,
+            content_frame,
+            scrollbar_surface,
+            cell_width,
+            cell_height,
+            extends_right_edge,
+            extends_bottom_edge,
+            gaps,
+        })
+    }
+
+    fn active_terminal_pane_layout(&self, window: &Window) -> Option<TerminalPaneLayout> {
+        let content_bounds = self.terminal_content_bounds(window)?;
+        let tab = self.active_tab_ref()?;
+        let pane_index = tab.active_pane_index()?;
+        let pane = tab.panes.get(pane_index)?;
+        self.terminal_pane_layout(tab, pane, content_bounds)
+    }
+
     pub(super) fn terminal_viewport_geometry(&self) -> Option<TerminalViewportGeometry> {
         let pane = self.active_pane_ref()?;
         let size = pane.terminal.size();
@@ -2180,16 +2426,8 @@ impl TerminalView {
         Some(TerminalViewportGeometry {
             origin_x: padding_x + (f32::from(pane.left) * cell_width) + content_padding_x,
             origin_y: padding_y + (f32::from(pane.top) * cell_height) + content_padding_y,
-            width: cell_width * f32::from(size.cols),
             height: cell_height * f32::from(size.rows),
         })
-    }
-
-    pub(super) fn terminal_surface_geometry(
-        &self,
-        _window: &Window,
-    ) -> Option<TerminalViewportGeometry> {
-        self.terminal_viewport_geometry()
     }
 
     pub(super) fn clear_terminal_scrollbar_marker_cache(&mut self) {
@@ -2232,7 +2470,7 @@ impl TerminalView {
         thumb_grab_offset: f32,
         cx: &mut Context<Self>,
     ) {
-        self.terminal_scrollbar_track_hold_local_y = None;
+        self.terminal_scrollbar_track_hold = None;
         self.terminal_scrollbar_drag = Some(TerminalScrollbarDragState { thumb_grab_offset });
         self.terminal_scrollbar_visibility_controller
             .start_drag(Instant::now());
@@ -2250,12 +2488,12 @@ impl TerminalView {
         true
     }
 
-    pub(super) fn start_terminal_scrollbar_track_hold(
+    fn start_terminal_scrollbar_track_hold(
         &mut self,
-        local_y: f32,
+        state: TerminalScrollbarTrackHoldState,
         cx: &mut Context<Self>,
     ) {
-        self.terminal_scrollbar_track_hold_local_y = Some(local_y);
+        self.terminal_scrollbar_track_hold = Some(state);
         self.mark_terminal_scrollbar_activity(cx);
         if self.terminal_scrollbar_track_hold_active {
             return;
@@ -2287,11 +2525,13 @@ impl TerminalView {
     }
 
     pub(super) fn update_terminal_scrollbar_track_hold(&mut self, local_y: f32) {
-        self.terminal_scrollbar_track_hold_local_y = Some(local_y);
+        if let Some(state) = self.terminal_scrollbar_track_hold.as_mut() {
+            state.local_y = local_y;
+        }
     }
 
     pub(super) fn stop_terminal_scrollbar_track_hold(&mut self) -> bool {
-        self.terminal_scrollbar_track_hold_local_y.take().is_some()
+        self.terminal_scrollbar_track_hold.take().is_some()
     }
 
     fn terminal_scrollbar_needs_animation(&self, now: Instant) -> bool {
@@ -2628,7 +2868,7 @@ impl TerminalView {
             terminal_scrollbar_visibility_controller: ScrollbarVisibilityController::default(),
             terminal_scrollbar_animation_active: false,
             terminal_scrollbar_drag: None,
-            terminal_scrollbar_track_hold_local_y: None,
+            terminal_scrollbar_track_hold: None,
             terminal_scrollbar_track_hold_active: false,
             pane_resize_drag: None,
             vertical_tab_strip_resize_drag: None,
@@ -2920,7 +3160,7 @@ impl TerminalView {
             self.terminal_scrollbar_visibility = config.terminal_scrollbar_visibility;
             self.terminal_scrollbar_visibility_controller.reset();
             self.terminal_scrollbar_drag = None;
-            self.terminal_scrollbar_track_hold_local_y = None;
+            self.terminal_scrollbar_track_hold = None;
             self.terminal_scrollbar_track_hold_active = false;
             self.terminal_scrollbar_animation_active = false;
             self.clear_terminal_scrollbar_marker_cache();
@@ -3626,6 +3866,20 @@ mod tests {
         assert!(!TerminalView::uses_native_split_content_padding(false, 1));
         assert!(TerminalView::uses_native_split_content_padding(false, 2));
         assert!(!TerminalView::uses_native_split_content_padding(true, 2));
+    }
+
+    #[test]
+    fn terminal_content_rect_reports_right_and_bottom_edges() {
+        let rect = TerminalContentRect::new(32.0, 48.0, 640.0, 420.0).expect("rect");
+
+        assert_eq!(rect.right(), 672.0);
+        assert_eq!(rect.bottom(), 468.0);
+    }
+
+    #[test]
+    fn terminal_scrollbar_surface_geometry_requires_positive_size() {
+        assert!(TerminalScrollbarSurfaceGeometry::new(0.0, 0.0, 0.0, 10.0).is_none());
+        assert!(TerminalScrollbarSurfaceGeometry::new(0.0, 0.0, 10.0, 0.0).is_none());
     }
 
     #[test]

--- a/src/terminal_view/render.rs
+++ b/src/terminal_view/render.rs
@@ -8,10 +8,6 @@ use gpui::prelude::FluentBuilder;
 use gpui::{ElementInputHandler, canvas};
 use std::sync::Arc;
 
-fn cell_ranges_overlap(start_a: u32, end_a: u32, start_b: u32, end_b: u32) -> bool {
-    start_a < end_b && start_b < end_a
-}
-
 fn blend_rgb_only(base: gpui::Rgba, target: gpui::Rgba, factor: f32) -> gpui::Rgba {
     let factor = factor.clamp(0.0, 1.0);
     let inv = 1.0 - factor;
@@ -425,26 +421,10 @@ fn pane_focus_factors(is_active_pane: bool, pane_focus_enabled: bool) -> (f32, f
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
-struct TerminalScrollbarOverlayFrame {
-    left: f32,
-    top: f32,
-    width: f32,
-    height: f32,
-}
-
 fn terminal_scrollbar_overlay_frame(
-    surface: TerminalViewportGeometry,
-) -> TerminalScrollbarOverlayFrame {
-    let surface_width = surface.width.max(0.0);
-    let effective_gutter = TERMINAL_SCROLLBAR_GUTTER_WIDTH.min(surface_width);
-    let left = (surface.origin_x + surface_width - effective_gutter).max(surface.origin_x);
-    TerminalScrollbarOverlayFrame {
-        left,
-        top: surface.origin_y,
-        width: effective_gutter,
-        height: surface.height,
-    }
+    surface: TerminalScrollbarSurfaceGeometry,
+) -> Option<TerminalScrollbarGutterFrame> {
+    surface.gutter_frame()
 }
 
 fn terminal_scrollbar_track_width(frame_width: f32) -> f32 {
@@ -501,63 +481,6 @@ impl TerminalView {
             self.tab_strip_sidebar_width(),
         )
     }
-
-    fn pane_right_gap_cells(pane: &TerminalPane, panes: &[TerminalPane]) -> Option<u32> {
-        let pane_right = u32::from(pane.left) + u32::from(pane.width);
-        let pane_top = u32::from(pane.top);
-        let pane_bottom = pane_top + u32::from(pane.height);
-
-        panes
-            .iter()
-            .filter_map(|candidate| {
-                if candidate.id == pane.id {
-                    return None;
-                }
-
-                let candidate_left = u32::from(candidate.left);
-                if candidate_left < pane_right {
-                    return None;
-                }
-
-                let candidate_top = u32::from(candidate.top);
-                let candidate_bottom = candidate_top + u32::from(candidate.height);
-                if !cell_ranges_overlap(pane_top, pane_bottom, candidate_top, candidate_bottom) {
-                    return None;
-                }
-
-                Some(candidate_left.saturating_sub(pane_right))
-            })
-            .min()
-    }
-
-    fn pane_bottom_gap_cells(pane: &TerminalPane, panes: &[TerminalPane]) -> Option<u32> {
-        let pane_left = u32::from(pane.left);
-        let pane_right = pane_left + u32::from(pane.width);
-        let pane_bottom = u32::from(pane.top) + u32::from(pane.height);
-
-        panes
-            .iter()
-            .filter_map(|candidate| {
-                if candidate.id == pane.id {
-                    return None;
-                }
-
-                let candidate_top = u32::from(candidate.top);
-                if candidate_top < pane_bottom {
-                    return None;
-                }
-
-                let candidate_left = u32::from(candidate.left);
-                let candidate_right = candidate_left + u32::from(candidate.width);
-                if !cell_ranges_overlap(pane_left, pane_right, candidate_left, candidate_right) {
-                    return None;
-                }
-
-                Some(candidate_top.saturating_sub(pane_bottom))
-            })
-            .min()
-    }
-
     fn pane_render_cache_key(
         &self,
         is_active_pane: bool,
@@ -1105,7 +1028,7 @@ impl TerminalView {
 
     fn render_terminal_scrollbar_overlay(
         &mut self,
-        surface: TerminalViewportGeometry,
+        surface: TerminalScrollbarSurfaceGeometry,
         layout: terminal_scrollbar::TerminalScrollbarLayout,
         force_visible: bool,
     ) -> Option<AnyElement> {
@@ -1122,7 +1045,7 @@ impl TerminalView {
         }
         let overlay_style = self.overlay_style();
         let gutter_bg = overlay_style.panel_background(TERMINAL_SCROLLBAR_GUTTER_ALPHA);
-        let frame = terminal_scrollbar_overlay_frame(surface);
+        let frame = terminal_scrollbar_overlay_frame(surface)?;
         let track_width = terminal_scrollbar_track_width(frame.width);
         let style = ScrollbarPaintStyle {
             width: track_width,
@@ -2120,8 +2043,6 @@ impl Render for TerminalView {
         let font_size = self.font_size;
         self.sync_window_background_appearance(window);
         let effective_background_opacity = self.background_opacity_factor();
-        let (effective_padding_x, effective_padding_y) = self.effective_terminal_padding();
-        let (native_split_padding_x, native_split_padding_y) = self.native_split_content_padding();
         let mut terminal_surface_bg = colors.background;
         terminal_surface_bg.a = self.scaled_background_alpha(terminal_surface_bg.a);
 
@@ -2151,22 +2072,12 @@ impl Render for TerminalView {
         #[cfg(debug_assertions)]
         let mut render_pass_cache_counts = RenderPassCacheStrategyCounts::default();
 
-        if let Some(active_tab) = self.tabs.get(self.active_tab) {
+        if let Some(active_tab) = self.tabs.get(self.active_tab)
+            && let Some(content_bounds) = self.terminal_content_bounds(window)
+        {
             let multi_pane = active_tab.panes.len() > 1;
             let pane_focus_enabled =
                 multi_pane && pane_focus_config.is_some() && !command_palette_open;
-            let max_right_cells = active_tab
-                .panes
-                .iter()
-                .map(|pane| u32::from(pane.left).saturating_add(u32::from(pane.width)))
-                .max()
-                .unwrap_or(0);
-            let max_bottom_cells = active_tab
-                .panes
-                .iter()
-                .map(|pane| u32::from(pane.top).saturating_add(u32::from(pane.height)))
-                .max()
-                .unwrap_or(0);
 
             for pane in &active_tab.panes {
                 let terminal = &pane.terminal;
@@ -2301,28 +2212,24 @@ impl Render for TerminalView {
                     terminal_surface_bg,
                 );
 
-                let cell_width: f32 = cell_size.width.into();
-                let cell_height: f32 = cell_size.height.into();
-                let pane_frame_left = effective_padding_x + (f32::from(pane.left) * cell_width);
-                let pane_frame_top = effective_padding_y + (f32::from(pane.top) * cell_height);
-                let pane_frame_width = f32::from(pane.width) * cell_width;
-                let pane_frame_height = f32::from(pane.height) * cell_height;
-                let pane_left = pane_frame_left + native_split_padding_x;
-                let pane_top = pane_frame_top + native_split_padding_y;
-                let pane_width = f32::from(terminal_size.cols) * cell_width;
-                let pane_height = f32::from(terminal_size.rows) * cell_height;
-                if pane_width <= f32::EPSILON || pane_height <= f32::EPSILON {
+                let Some(pane_layout) = self.terminal_pane_layout(active_tab, pane, content_bounds)
+                else {
                     continue;
-                }
-
-                let pane_right_cells = u32::from(pane.left).saturating_add(u32::from(pane.width));
-                let pane_bottom_cells = u32::from(pane.top).saturating_add(u32::from(pane.height));
+                };
+                let pane_frame_left = pane_layout.frame.origin_x;
+                let pane_frame_top = pane_layout.frame.origin_y;
+                let pane_frame_width = pane_layout.frame.width;
+                let pane_frame_height = pane_layout.frame.height;
+                let pane_left = pane_layout.content_frame.origin_x;
+                let pane_top = pane_layout.content_frame.origin_y;
+                let pane_width = pane_layout.content_frame.width;
+                let pane_height = pane_layout.content_frame.height;
 
                 if multi_pane
-                    && pane_right_cells < max_right_cells
-                    && let Some(gap_cells) = Self::pane_right_gap_cells(pane, &active_tab.panes)
+                    && !pane_layout.extends_right_edge
+                    && let Some(gap_cells) = pane_layout.gaps.right_cells
                 {
-                    let gap_px = (gap_cells as f32) * cell_width;
+                    let gap_px = (gap_cells as f32) * pane_layout.cell_width;
                     let divider_left = pane_frame_left + pane_frame_width + (gap_px * 0.5) - 0.5;
                     let handle_width = gap_px.max(8.0);
                     let handle_left = divider_left - ((handle_width - 1.0) * 0.5);
@@ -2365,10 +2272,10 @@ impl Render for TerminalView {
                     );
                 }
                 if multi_pane
-                    && pane_bottom_cells < max_bottom_cells
-                    && let Some(gap_cells) = Self::pane_bottom_gap_cells(pane, &active_tab.panes)
+                    && !pane_layout.extends_bottom_edge
+                    && let Some(gap_cells) = pane_layout.gaps.bottom_cells
                 {
-                    let gap_px = (gap_cells as f32) * cell_height;
+                    let gap_px = (gap_cells as f32) * pane_layout.cell_height;
                     let divider_top = pane_frame_top + pane_frame_height + (gap_px * 0.5) - 0.5;
                     let handle_height = gap_px.max(8.0);
                     let handle_top = divider_top - ((handle_height - 1.0) * 0.5);
@@ -2541,7 +2448,9 @@ impl Render for TerminalView {
         {
             self.start_terminal_scrollbar_animation(cx);
         }
-        let terminal_surface = self.terminal_surface_geometry(window);
+        let terminal_surface = self
+            .active_terminal_pane_layout(window)
+            .map(|pane_layout| pane_layout.scrollbar_surface);
         let terminal_scrollbar_layout = terminal_surface.and_then(|surface| {
             self.terminal_scrollbar_layout_for_track(surface.height)
                 .map(|layout| (surface, layout))
@@ -3125,14 +3034,10 @@ mod tests {
 
     #[test]
     fn terminal_scrollbar_overlay_frame_anchors_to_active_pane_geometry() {
-        let surface = TerminalViewportGeometry {
-            origin_x: 32.0,
-            origin_y: 48.0,
-            width: 640.0,
-            height: 420.0,
-        };
+        let surface = TerminalScrollbarSurfaceGeometry::new(32.0, 48.0, 640.0, 420.0)
+            .expect("surface");
 
-        let frame = terminal_scrollbar_overlay_frame(surface);
+        let frame = terminal_scrollbar_overlay_frame(surface).expect("frame");
         assert_eq!(
             frame.left,
             surface.origin_x + surface.width - TERMINAL_SCROLLBAR_GUTTER_WIDTH
@@ -3144,17 +3049,24 @@ mod tests {
 
     #[test]
     fn terminal_scrollbar_overlay_frame_clamps_when_surface_is_narrower_than_gutter() {
-        let surface = TerminalViewportGeometry {
-            origin_x: 10.0,
-            origin_y: 20.0,
-            width: 6.0,
-            height: 100.0,
-        };
+        let surface =
+            TerminalScrollbarSurfaceGeometry::new(10.0, 20.0, 6.0, 100.0).expect("surface");
 
-        let frame = terminal_scrollbar_overlay_frame(surface);
+        let frame = terminal_scrollbar_overlay_frame(surface).expect("frame");
         assert_eq!(frame.left, surface.origin_x);
         assert_eq!(frame.top, surface.origin_y);
         assert_eq!(frame.width, surface.width);
+        assert_eq!(frame.height, surface.height);
+    }
+
+    #[test]
+    fn terminal_scrollbar_overlay_frame_uses_scrollbar_surface_width() {
+        let surface =
+            TerminalScrollbarSurfaceGeometry::new(0.0, 0.0, 1007.0, 809.0).expect("surface");
+
+        let frame = terminal_scrollbar_overlay_frame(surface).expect("frame");
+        assert_eq!(frame.left, 1007.0 - TERMINAL_SCROLLBAR_GUTTER_WIDTH);
+        assert_eq!(frame.width, TERMINAL_SCROLLBAR_GUTTER_WIDTH);
         assert_eq!(frame.height, surface.height);
     }
 
@@ -3225,22 +3137,25 @@ mod tests {
     }
 
     #[test]
-    fn pane_right_gap_cells_returns_zero_for_adjacent_overlapping_pane() {
+    fn pane_neighbor_gaps_return_zero_for_adjacent_overlapping_panes() {
         let base = tmux_test_pane("%1", 0, 0, 10, 6);
-        let adjacent = tmux_test_pane("%2", 10, 2, 5, 2);
-        let panes = vec![base, adjacent];
-        assert_eq!(
-            TerminalView::pane_right_gap_cells(&panes[0], &panes),
-            Some(0)
-        );
+        let right_adjacent = tmux_test_pane("%2", 10, 2, 5, 2);
+        let bottom_adjacent = tmux_test_pane("%3", 2, 6, 3, 3);
+        let panes = vec![base, right_adjacent, bottom_adjacent];
+        let gaps = TerminalView::pane_neighbor_gaps(&panes[0], &panes);
+        assert_eq!(gaps.right_cells, Some(0));
+        assert_eq!(gaps.bottom_cells, Some(0));
     }
 
     #[test]
-    fn pane_right_gap_cells_returns_none_without_vertical_overlap() {
+    fn pane_neighbor_gaps_return_none_without_overlapping_neighbor() {
         let base = tmux_test_pane("%1", 0, 0, 10, 6);
-        let separated = tmux_test_pane("%2", 10, 6, 5, 3);
-        let panes = vec![base, separated];
-        assert_eq!(TerminalView::pane_right_gap_cells(&panes[0], &panes), None);
+        let separated_right = tmux_test_pane("%2", 10, 6, 5, 3);
+        let separated_bottom = tmux_test_pane("%3", 10, 6, 4, 3);
+        let panes = vec![base, separated_right, separated_bottom];
+        let gaps = TerminalView::pane_neighbor_gaps(&panes[0], &panes);
+        assert_eq!(gaps.right_cells, None);
+        assert_eq!(gaps.bottom_cells, None);
     }
 
     #[test]
@@ -3441,48 +3356,17 @@ mod tests {
     }
 
     #[test]
-    fn pane_right_gap_cells_prefers_smallest_matching_candidate_gap() {
+    fn pane_neighbor_gaps_prefer_smallest_matching_candidate_gap() {
         let base = tmux_test_pane("%1", 0, 0, 10, 6);
         let far = tmux_test_pane("%2", 15, 0, 3, 6);
         let near = tmux_test_pane("%3", 12, 1, 3, 2);
-        let non_overlap = tmux_test_pane("%4", 11, 7, 3, 2);
-        let panes = vec![base, far, near, non_overlap];
-        assert_eq!(
-            TerminalView::pane_right_gap_cells(&panes[0], &panes),
-            Some(2)
-        );
-    }
-
-    #[test]
-    fn pane_bottom_gap_cells_returns_zero_for_adjacent_overlapping_pane() {
-        let base = tmux_test_pane("%1", 0, 0, 10, 6);
-        let adjacent = tmux_test_pane("%2", 2, 6, 3, 3);
-        let panes = vec![base, adjacent];
-        assert_eq!(
-            TerminalView::pane_bottom_gap_cells(&panes[0], &panes),
-            Some(0)
-        );
-    }
-
-    #[test]
-    fn pane_bottom_gap_cells_returns_none_without_horizontal_overlap() {
-        let base = tmux_test_pane("%1", 0, 0, 10, 6);
-        let separated = tmux_test_pane("%2", 10, 6, 4, 3);
-        let panes = vec![base, separated];
-        assert_eq!(TerminalView::pane_bottom_gap_cells(&panes[0], &panes), None);
-    }
-
-    #[test]
-    fn pane_bottom_gap_cells_prefers_smallest_matching_candidate_gap() {
-        let base = tmux_test_pane("%1", 0, 0, 10, 6);
-        let far = tmux_test_pane("%2", 0, 10, 10, 2);
-        let near = tmux_test_pane("%3", 3, 8, 2, 2);
-        let non_overlap = tmux_test_pane("%4", 11, 9, 2, 2);
-        let panes = vec![base, far, near, non_overlap];
-        assert_eq!(
-            TerminalView::pane_bottom_gap_cells(&panes[0], &panes),
-            Some(2)
-        );
+        let bottom_far = tmux_test_pane("%4", 0, 10, 10, 2);
+        let bottom_near = tmux_test_pane("%5", 3, 8, 2, 2);
+        let non_overlap = tmux_test_pane("%6", 11, 9, 2, 2);
+        let panes = vec![base, far, near, bottom_far, bottom_near, non_overlap];
+        let gaps = TerminalView::pane_neighbor_gaps(&panes[0], &panes);
+        assert_eq!(gaps.right_cells, Some(2));
+        assert_eq!(gaps.bottom_cells, Some(2));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- replace ad hoc scrollbar geometry helpers with a shared active-pane layout path
- separate content-space scrollbar surface geometry from window-space viewport geometry
- harden scrollbar drag and track-hold behavior by removing viewport-cache fallbacks and making hold state explicit

## Testing
- cargo test -p termy terminal_scrollbar_ -- --nocapture
- cargo test -p termy pane_neighbor_gaps -- --nocapture
- cargo check -p termy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced scrollbar drag interaction handling and multi-pane layout calculations for improved responsiveness
  * Refined terminal viewport geometry management for more reliable pane rendering and positioning

<!-- end of auto-generated comment: release notes by coderabbit.ai -->