### PR TITLE
fix: restore Windows terminal view compile

### DIFF
--- a/src/terminal_view/interaction/chrome.rs
+++ b/src/terminal_view/interaction/chrome.rs
@@ -131,7 +131,7 @@ impl TerminalView {
     ) -> f32 {
         Self::window_titlebar_height_for(vertical_tabs, show_tab_strip_chrome)
             + if show_update_banner {
-                UPDATE_BANNER_HEIGHT
+                Self::update_banner_height()
             } else {
                 0.0
             }
@@ -150,7 +150,7 @@ impl TerminalView {
         } else {
             titlebar_height
                 + if show_update_banner {
-                    UPDATE_BANNER_HEIGHT
+                    Self::update_banner_height()
                 } else {
                     0.0
                 }
@@ -161,7 +161,7 @@ impl TerminalView {
         Self::terminal_content_top_inset_for(
             self.vertical_tabs,
             self.should_render_tab_strip_chrome(),
-            self.show_update_banner,
+            self.update_banner_visible(),
         )
     }
 
@@ -169,7 +169,7 @@ impl TerminalView {
         Self::vertical_tab_strip_top_inset_for(
             self.vertical_tabs,
             self.should_render_tab_strip_chrome(),
-            self.show_update_banner,
+            self.update_banner_visible(),
         )
     }
 }
@@ -218,7 +218,7 @@ mod tests {
     fn terminal_content_top_inset_includes_banner_for_horizontal_tabs() {
         assert_eq!(
             TerminalView::terminal_content_top_inset_for(false, true, true),
-            TerminalView::titlebar_height() + UPDATE_BANNER_HEIGHT
+            TerminalView::titlebar_height() + TerminalView::update_banner_height()
         );
     }
 
@@ -226,7 +226,7 @@ mod tests {
     fn terminal_content_top_inset_includes_banner_for_visible_vertical_tabs() {
         assert_eq!(
             TerminalView::terminal_content_top_inset_for(true, true, true),
-            UPDATE_BANNER_HEIGHT
+            TerminalView::update_banner_height()
         );
     }
 
@@ -242,7 +242,7 @@ mod tests {
     fn vertical_tab_strip_top_inset_keeps_banner_when_sidebar_chrome_is_hidden() {
         assert_eq!(
             TerminalView::vertical_tab_strip_top_inset_for(true, false, true),
-            TerminalView::titlebar_height() + UPDATE_BANNER_HEIGHT
+            TerminalView::titlebar_height() + TerminalView::update_banner_height()
         );
     }
 

--- a/src/terminal_view/mod.rs
+++ b/src/terminal_view/mod.rs
@@ -1521,6 +1521,30 @@ impl TerminalView {
         self.install_cli_available
     }
 
+    pub(super) const fn update_banner_height() -> f32 {
+        #[cfg(target_os = "macos")]
+        {
+            UPDATE_BANNER_HEIGHT
+        }
+
+        #[cfg(not(target_os = "macos"))]
+        {
+            0.0
+        }
+    }
+
+    pub(super) fn update_banner_visible(&self) -> bool {
+        #[cfg(target_os = "macos")]
+        {
+            self.show_update_banner
+        }
+
+        #[cfg(not(target_os = "macos"))]
+        {
+            false
+        }
+    }
+
     #[cfg(target_os = "macos")]
     pub(crate) fn set_native_file_drop_enabled(&mut self, enabled: bool) {
         self.native_file_drop_enabled = enabled;

--- a/src/terminal_view/render.rs
+++ b/src/terminal_view/render.rs
@@ -463,10 +463,10 @@ impl TerminalView {
             root_spacer_height: if right_pane_only {
                 0.0
             } else {
-                UPDATE_BANNER_HEIGHT
+                Self::update_banner_height()
             },
             terminal_pane_spacer_height: if right_pane_only {
-                UPDATE_BANNER_HEIGHT
+                Self::update_banner_height()
             } else {
                 0.0
             },
@@ -475,7 +475,7 @@ impl TerminalView {
 
     fn update_banner_layout(&self) -> Option<UpdateBannerLayout> {
         Self::update_banner_layout_for(
-            self.show_update_banner,
+            self.update_banner_visible(),
             self.vertical_tabs,
             self.should_render_tab_strip_chrome(),
             self.tab_strip_sidebar_width(),
@@ -1250,7 +1250,7 @@ impl TerminalView {
             div()
                 .id("update-banner")
                 .w_full()
-                .h(px(UPDATE_BANNER_HEIGHT))
+                .h(px(Self::update_banner_height()))
                 .flex_none()
                 .bg(banner_bg)
                 .border_b_1()
@@ -1982,7 +1982,7 @@ impl TerminalView {
         });
 
         #[cfg(target_os = "macos")]
-        let banner_overlay: Option<AnyElement> = if self.show_update_banner {
+        let banner_overlay: Option<AnyElement> = if self.update_banner_visible() {
             let banner_state = self.auto_updater.as_ref().map(|e| e.read(cx).state.clone());
             let banner_layout = self.update_banner_layout();
             banner_state
@@ -2773,7 +2773,7 @@ mod tests {
             Some(UpdateBannerLayout {
                 overlay_top: TerminalView::titlebar_height(),
                 overlay_left: 0.0,
-                root_spacer_height: UPDATE_BANNER_HEIGHT,
+                root_spacer_height: TerminalView::update_banner_height(),
                 terminal_pane_spacer_height: 0.0,
             })
         );
@@ -2787,7 +2787,7 @@ mod tests {
                 overlay_top: 0.0,
                 overlay_left: 224.0,
                 root_spacer_height: 0.0,
-                terminal_pane_spacer_height: UPDATE_BANNER_HEIGHT,
+                terminal_pane_spacer_height: TerminalView::update_banner_height(),
             })
         );
     }

--- a/src/terminal_view/runtime/mod.rs
+++ b/src/terminal_view/runtime/mod.rs
@@ -39,14 +39,14 @@ impl RuntimeKind {
         matches!(self, Self::Tmux)
     }
 
-    pub(super) const fn from_app_config(config: &AppConfig) -> Self {
-        #[cfg(target_os = "windows")]
-        {
-            let _ = config;
-            // Hard cutover: tmux runtime is unsupported on Windows, regardless of config value.
-            return Self::Native;
-        }
+    #[cfg(target_os = "windows")]
+    pub(super) fn from_app_config(_config: &AppConfig) -> Self {
+        // Hard cutover: tmux runtime is unsupported on Windows, regardless of config value.
+        Self::Native
+    }
 
+    #[cfg(not(target_os = "windows"))]
+    pub(super) fn from_app_config(config: &AppConfig) -> Self {
         if config.tmux_enabled {
             Self::Tmux
         } else {


### PR DESCRIPTION
## Summary
- add cross-platform `TerminalView` banner helpers so shared layout and render code no longer touches macOS-only update state directly
- switch terminal view chrome and banner layout code to use those helpers
- split `RuntimeKind::from_app_config` by target so Windows hard-cuts to native mode without unreachable-code warnings

## Testing
- `cargo check -p termy --tests`
- `cargo test -p termy terminal_view::tests::runtime_kind_follows_tmux_enabled_flag -- --exact`
- `cargo test -p termy terminal_view::render::tests::update_banner_layout_stays_full_width_without_vertical_sidebar_chrome -- --exact`

## Notes
- left the unrelated local `Cargo.lock` modification uncommitted
- Windows CI remains the final verifier for the original compile failure because this host does not have the MSVC and Windows SDK toolchain needed for a full local Windows build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured platform-specific implementation logic for terminal display features.
  * Converted constant-based references to dynamic function calls for improved flexibility.
  * Enhanced platform-conditional behavior for Windows and non-Windows systems.

* **Tests**
  * Updated test references to reflect refactored implementation approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->