### PR TITLE
fix: make Termy behave like a normal macOS window

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -109,6 +109,7 @@ fn open_main_window(cx: &mut App, startup_config: config::AppConfig) -> Result<(
             window_background,
             is_movable: true,
             is_resizable: true,
+            window_min_size: Some(size(px(MIN_WINDOW_WIDTH), px(MIN_WINDOW_HEIGHT))),
             ..Default::default()
         },
         move |window, cx| {


### PR DESCRIPTION
## Summary

Fixes the macOS main window so Termy behaves like a normal window again. This restores compatibility with tools like Swish and AltTab by giving the app standard window metadata and affordances.

## Testing

- `cargo bundle --release`
- focused validation of the macOS window path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Main window is now movable on all platforms.
* **New Features**
  * Main window is resizable and enforces a minimum window size.
  * On macOS, the titlebar now displays the application name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->