### PR TITLE
Implement Search Google context menu feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7342,6 +7342,7 @@ dependencies = [
  "dirs 6.0.0",
  "env_logger",
  "flume",
+ "form_urlencoded",
  "fs4",
  "futures",
  "gpui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ rfd = "0.15"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 url = "2.5"
+form_urlencoded = "1.0"
 
 # File I/O
 tempfile = "3"

--- a/src/terminal_view/interaction/context_menu.rs
+++ b/src/terminal_view/interaction/context_menu.rs
@@ -1,4 +1,5 @@
 use super::*;
+use form_urlencoded;
 
 impl TerminalView {
     pub(in super::super) fn format_terminal_buffer_position(position: SelectionPos) -> String {
@@ -90,6 +91,54 @@ impl TerminalView {
         ));
         termy_toast::success("Copied buffer position");
         self.notify_overlay(cx);
+    }
+
+    pub(in super::super) fn execute_terminal_context_menu_search_google(
+        &mut self,
+        cx: &mut Context<Self>,
+    ) {
+        let _ = self.close_terminal_context_menu(cx);
+
+        let Some(text) = self.selected_text() else {
+            return;
+        };
+
+        if text.trim().is_empty() {
+            return;
+        }
+
+        // URL-encode the search query for Google
+        let encoded = form_urlencoded::byte_serialize(text.as_bytes()).collect::<String>();
+        let google_url = format!("https://www.google.com/search?q={}", encoded);
+
+        // Open the URL in browser
+        #[cfg(target_os = "macos")]
+        {
+            let _ = Command::new("open")
+                .arg(&google_url)
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn();
+        }
+        #[cfg(target_os = "linux")]
+        {
+            let _ = Command::new("xdg-open")
+                .arg(&google_url)
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn();
+        }
+        #[cfg(target_os = "windows")]
+        {
+            let _ = Command::new("cmd")
+                .args(["/C", "start", "", &google_url])
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn();
+        }
     }
 
     fn execute_terminal_context_menu_action(

--- a/src/terminal_view/render.rs
+++ b/src/terminal_view/render.rs
@@ -1617,10 +1617,10 @@ impl TerminalView {
         {
             let state = self.terminal_context_menu.clone()?;
             let overlay_style = self.overlay_style();
-            let menu_width = 220.0;
+            let menu_width = 240.0;
             let row_height = 30.0;
             let row_count =
-                5.0 + if state.buffer_position.is_some() {
+                6.0 + if state.buffer_position.is_some() {
                     1.0
                 } else {
                     0.0
@@ -1818,6 +1818,7 @@ impl TerminalView {
                                 state.can_paste,
                                 CommandAction::Paste,
                             ))
+                            .child(search_google_item(state.can_copy))
                             .child(open_search_item()),
                     )
                     .into_any_element(),


### PR DESCRIPTION
## Summary

This PR implements the 'Improve google' feature (Issue #275).

### Changes:

1. **Added  method** in :
   - Gets selected text from terminal
   - URL-encodes the text for safe URL inclusion
   - Constructs Google search URL ()
   - Opens URL in default browser via platform-specific commands ( on Linux,  on macOS,  on Windows)

2. **Added  to terminal context menu** in :
   - Menu item is enabled when text is selected ()
   - Menu item is disabled when no text is selected
   - Updated menu dimensions to accommodate the new item

3. **Added  dependency** to 

### Before:
- The  was defined but never added to the context menu
- The  method was called but not implemented

### After:
- Right-clicking in the terminal with selected text shows 'Search Google' option
- Clicking it opens the selected text searched on Google.com

Fixes #275