### PR TITLE
Add partial-row damage, color cache & timing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7333,7 +7333,7 @@ dependencies = [
 
 [[package]]
 name = "termy"
-version = "0.1.65"
+version = "0.1.67"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
@@ -7420,7 +7420,7 @@ dependencies = [
 
 [[package]]
 name = "termy_cli"
-version = "0.1.65"
+version = "0.1.67"
 dependencies = [
  "anyhow",
  "clap",

--- a/PERF-PLAN.md
+++ b/PERF-PLAN.md
@@ -1,0 +1,560 @@
+# Termy Performance Improvement Plan
+
+## Executive Summary
+
+This document outlines a comprehensive plan to improve performance across all aspects of Termy — a GPUI-based terminal emulator. The plan targets rendering performance, memory efficiency, input latency, and startup time.
+
+**Current State:**
+- Built on GPUI (Zed's UI framework) and `alacritty_terminal`
+- Full benchmark infrastructure in `crates/xtask/src/benchmark.rs` (driver, compare, scenario runner)
+- Atomic render metrics: `grid_paint_count`, `shape_line_calls`, `shaped_line_cache_hits/misses`, `runtime_wakeup_count` (`render_metrics.rs`)
+- Row-level damage tracking with `TerminalGridPaintDamage::{None, Full, Rows}`
+- Per-row `ShapedLine` cache in `CachedRowPaintOps`, with shaped-line reuse across matching rows
+- Text batching by `(bold, fg, underline)` within each row (`TextBatch` in `grid.rs`)
+- Background span batching by color per row (`BackgroundSpan`)
+- Unicode block element rendering as pixel-snapped quads (no glyph rasterization)
+- Tmux notification coalescing with per-pane output merging and backpressure (`coalescer.rs`)
+
+**Architectural constraints to keep in mind:**
+- GPUI owns the GPU text atlas and text shaping pipeline. Custom atlas work must go through `window.text_system()`, not around it.
+- Scrollback buffer and `Cell` allocation live inside `alacritty_terminal::Term`. Changes there require patching or forking the dependency.
+- Input dispatch is owned by GPUI's event loop. Bypassing it for a custom input thread requires forking GPUI.
+
+**Target Metrics:**
+- Maintain 60 FPS during heavy terminal output (>10 MB/s)
+- <16ms input latency (current target for perceived responsiveness)
+- <200ms cold startup time
+- <100MB base memory footprint
+
+---
+
+## Phase 1: Rendering Pipeline Optimization
+
+### 1.1 Cell-Level Damage Tracking (High Impact)
+
+**Current:** `TerminalGridPaintDamage::Rows(Arc<[usize]>)` marks entire rows dirty. A single cursor blink or character update invalidates and re-shapes the whole row.
+
+**Solution:** Add cell-level and region-level damage variants.
+
+```rust
+// In crates/terminal_ui/src/grid.rs
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum TerminalGridPaintDamage {
+    #[default]
+    None,
+    Full,
+    Rows(Arc<[usize]>),
+    // NEW: sparse cell updates (e.g. single character change)
+    Cells(Arc<[(usize, usize)]>), // (row, col) pairs
+    // NEW: contiguous rectangular region (e.g. scroll region)
+    Region { start_row: usize, end_row: usize, start_col: usize, end_col: usize },
+}
+```
+
+**Implementation:**
+1. Extend `paint_damage_from_dirty_spans` to emit `Cells` when the dirty span covers ≤4 columns
+2. Detect contiguous multi-row dirty spans and emit `Region` instead of `Rows`
+3. In `dirty_rows_for_pass`, handle cursor movement as a `Cells` update (only the two cursor cells, not full rows)
+4. In `rebuild_cached_rows_for_pass`, skip re-shaping unchanged cells within a dirty row
+
+**Expected Gain:** 20-40% reduction in `shape_line` calls during typical editing and cursor movement
+
+### 1.2 Cursor Blink as Overlay (High Impact)
+
+**Current:** Cursor blink invalidates the cursor row via `dirty_rows_for_pass`, causing the entire row's text to be re-shaped and repainted.
+
+**Solution:** Track cursor as a separate overlay painted last, so blink only repaints the cursor quad — not the row.
+
+**Implementation:**
+1. Remove cursor from `dirty_rows_for_pass` cursor-transition logic when only blink state changed (no position change)
+2. Paint cursor quad in a separate pass after all row ops, using the already-cached row ops
+3. Store `last_cursor_blink_state: bool` in `TerminalGridPaintCache` to detect blink-only transitions
+
+**Expected Gain:** Eliminates row re-shape on every cursor blink tick (~60 unnecessary `shape_line` calls/sec)
+
+### 1.3 Reduce `shape_line` Calls for Identical Rows (Medium Impact)
+
+**Current:** `find_matching_previous_row_ops_index` reuses `ShapedLine` objects from matching previous rows. However, it only checks ±1 row neighbors first, then does a linear scan. For large terminals with many identical rows (e.g. blank lines), this scan is O(n).
+
+**Solution:** Index previous row ops by a cheap content hash for O(1) lookup.
+
+```rust
+// In TerminalGridPaintCache
+shaped_line_index: HashMap<u64, usize>, // content_hash -> row index
+```
+
+**Implementation:**
+1. Compute a cheap hash of `(background_spans, draw_ops text/style)` when building `CachedRowPaintOps`
+2. Store in `shaped_line_index` keyed by hash, value = row index with valid shaped lines
+3. Replace the linear scan in `find_matching_previous_row_ops_index` with a hash lookup
+
+**Expected Gain:** Faster cache lookup for terminals with many repeated rows; eliminates O(n) scan
+
+### 1.4 Thread-Local Buffer for `paint_damage_from_dirty_spans` (Quick Win)
+
+**Current:** `paint_damage_from_dirty_spans` allocates a fresh `Vec<usize>` on every call.
+
+**Solution:** Reuse a thread-local buffer.
+
+```rust
+thread_local! {
+    static ROWS_BUF: RefCell<Vec<usize>> = RefCell::new(Vec::with_capacity(128));
+}
+
+fn paint_damage_from_dirty_spans_optimized(
+    spans: &[TerminalDirtySpan],
+    row_count: usize,
+) -> TerminalGridPaintDamage {
+    ROWS_BUF.with(|buf| {
+        let mut rows = buf.borrow_mut();
+        rows.clear();
+        // ... populate rows ...
+        TerminalGridPaintDamage::Rows(Arc::from(rows.as_slice()))
+    })
+}
+```
+
+**Expected Gain:** Eliminates one heap allocation per terminal wakeup event
+
+---
+
+## Phase 2: Memory Optimization
+
+### 2.1 Scrollback Buffer Compression (High Impact, Requires alacritty_terminal Changes)
+
+> **Note:** The scrollback buffer and `Cell` allocation are owned by `alacritty_terminal::Term`, not Termy code. This requires either patching `alacritty_terminal` as a path dependency or contributing upstream.
+
+**Problem:** Default 2000 lines × terminal width × `Cell` size = significant RAM. Many scrollback lines are blank or repetitive.
+
+**Solution (if patching alacritty_terminal):** Implement line-level compression at the `alacritty_terminal` grid layer.
+
+```rust
+// Would live in alacritty_terminal's grid module
+enum LineContent {
+    Blank(Color),                      // Entirely blank line (very common)
+    RunLengthEncoded(Vec<CellRun>),    // Repetitive content
+    Dense(Vec<Cell>),                  // Normal content
+}
+```
+
+**Strategy:**
+1. Detect uniform/blank lines on scroll-out (very common in scrollback)
+2. Use run-length encoding for repetitive content
+3. Keep active viewport always uncompressed
+
+**Expected Gain:** 40-60% memory reduction for typical usage
+
+**Alternative (no upstream changes):** Reduce default scrollback from 2000 to a lower configurable default and expose it prominently in settings.
+
+### 2.2 Cell Color Resolution Cache (Quick Win)
+
+**Problem:** `cell_fg_color` and `row_background_fill` are called for every cell every frame. Color comparisons involve floating-point `Hsla` fields.
+
+**Solution:** Cache resolved `Hsla` → `gpui::Rgba` conversions.
+
+```rust
+pub struct ColorCache {
+    cache: LruCache<[u32; 4], gpui::Rgba>, // Hsla bits -> Rgba
+}
+```
+
+**Implementation:**
+1. Add `ColorCache` to `TerminalGridPaintCache`
+2. Wrap `cell_fg_color` resolution through the cache
+3. Clear cache on style key change (theme/font change)
+
+**Expected Gain:** Reduces floating-point work for terminals with many unique colors
+
+### 2.3 String Interning for Repeated Content (Low Impact)
+
+**Problem:** Tab titles, paths, and repeated text allocate duplicate `String`s.
+
+**Solution:** Intern frequently occurring strings.
+
+```rust
+pub struct StringInterner {
+    strings: HashMap<Arc<str>, Weak<str>>,
+}
+
+impl StringInterner {
+    pub fn intern(&mut self, s: &str) -> Arc<str> {
+        // Return existing Arc if present, insert otherwise
+    }
+}
+```
+
+---
+
+## Phase 3: Input Latency Reduction
+
+### 3.1 VSync-Aware Frame Scheduling (Medium Impact)
+
+**Problem:** Inconsistent frame timing causes jitter when terminal output and input arrive mid-frame.
+
+**Note:** GPUI owns the event loop and vsync. This must work within GPUI's `cx.request_animation_frame()` / `cx.notify()` model, not replace it.
+
+**Solution:** Coalesce rapid `Wakeup` events within a single animation frame rather than triggering a repaint per event.
+
+```rust
+// In pane_terminal.rs — batch wakeup events within one frame boundary
+pub struct WakeupCoalescer {
+    pending: bool,
+    last_frame: Instant,
+}
+
+impl WakeupCoalescer {
+    pub fn record_wakeup(&mut self, cx: &mut Context<TerminalPane>) {
+        if !self.pending {
+            self.pending = true;
+            cx.request_animation_frame(); // single repaint request
+        }
+    }
+}
+```
+
+**Expected Gain:** Reduces redundant repaints when PTY output arrives in bursts
+
+### 3.2 Predictive Cursor Rendering (Low Impact)
+
+**Problem:** Cursor blink requires a repaint even when nothing else changed.
+
+**Solution:** Pre-render both cursor states (visible/hidden) into cached quads so blink only swaps a flag, not a full paint pass.
+
+```rust
+pub struct CursorBlinkCache {
+    visible_quad: Option<CachedQuad>,
+    hidden: bool,
+}
+```
+
+---
+
+## Phase 4: Startup Time Optimization
+
+### 4.1 Lazy Runtime Initialization (High Impact)
+
+**Current:** Tmux verification and config loading block the initial window paint.
+
+**Solution:** Show window immediately, initialize terminal runtime in background using GPUI's async model.
+
+```rust
+// In the terminal view init
+impl TerminalPane {
+    pub fn new(window: &mut Window, cx: &mut Context<Self>, config: AppConfig) -> Self {
+        // Render placeholder immediately
+        cx.spawn(|this, mut cx| async move {
+            let runtime = init_runtime(&config).await;
+            this.update(&mut cx, |this, cx| {
+                this.attach_runtime(runtime, cx);
+            }).ok();
+        }).detach();
+
+        Self { runtime: None, /* ... */ }
+    }
+}
+```
+
+**Expected Gain:** Window appears before tmux/shell startup completes; perceived startup time drops significantly
+
+### 4.2 Parallel Subsystem Initialization (Medium Impact)
+
+**Problem:** Font system, theme store, and config parsing initialize serially.
+
+**Solution:** Use `std::thread::scope` to parallelize independent init work.
+
+```rust
+pub fn parallel_init() -> InitResult {
+    std::thread::scope(|s| {
+        let fonts = s.spawn(|| init_font_system());
+        let themes = s.spawn(|| init_theme_store());
+        let config = s.spawn(|| load_and_parse_config());
+        InitResult {
+            fonts: fonts.join().unwrap(),
+            themes: themes.join().unwrap(),
+            config: config.join().unwrap(),
+        }
+    })
+}
+```
+
+### 4.3 Config Caching with Binary Format (Medium Impact)
+
+**Problem:** JSON/TOML config parsing on every startup adds latency.
+
+**Solution:** Cache parsed config in a binary format (e.g. `bincode`/`postcard`), invalidated by file mtime.
+
+```rust
+pub struct ConfigCache {
+    source_path: PathBuf,
+    cache_path: PathBuf,
+}
+
+impl ConfigCache {
+    pub fn load(&self) -> AppConfig {
+        // Check binary cache mtime vs source mtime
+        // Fall back to full parse if stale or missing
+        // Write binary cache on successful parse
+    }
+}
+```
+
+---
+
+## Phase 5: Tmux & Runtime Optimization
+
+### 5.1 Tmux Notification Coalescing — Already Implemented
+
+`crates/terminal_ui/src/tmux/control/coalescer.rs` implements `NotificationCoalescer` with:
+- Deduplication of `NeedsRefresh` events (only one queued at a time)
+- Per-pane output merging for adjacent bursts (appends to tail if same pane ID)
+- 512 KB output byte cap with oldest-chunk eviction and backpressure warnings
+- Collapse-to-refresh on notification channel overflow
+
+**Remaining opportunity:** Tune the 512 KB cap based on profiling. Consider per-pane caps for fairness when many panes are active.
+
+### 5.2 Pane Rendering Prioritization (Medium Impact)
+
+**Problem:** All panes are rendered equally, even fully occluded ones.
+
+**Solution:** Track pane visibility and skip rendering for occluded panes.
+
+```rust
+pub struct PaneVisibility {
+    visible: bool,
+    occlusion_fraction: f32, // 0.0 = fully occluded, 1.0 = fully visible
+    last_render: Instant,
+}
+
+// Skip TerminalGrid::paint for fully occluded panes
+// Reduce damage rebuild rate for partially occluded panes
+```
+
+### 5.3 PTY Read Buffering (Medium Impact)
+
+**Problem:** Frequent small reads from the PTY cause many syscalls.
+
+**Solution:** Adaptive read buffer sizing.
+
+```rust
+pub struct PtyReader {
+    buffer: Vec<u8>,
+    target_read_size: usize, // Adaptive: 4 KB – 64 KB
+}
+
+impl PtyReader {
+    pub fn read(&mut self, pty: &mut Pty) -> io::Result<&[u8]> {
+        // Read as much as available in a single syscall
+        // Grow buffer if consistently filling to capacity
+    }
+}
+```
+
+---
+
+## Phase 6: Profiling & Monitoring Infrastructure
+
+### 6.1 Frame Time Profiler — Extend Existing Metrics (High Priority)
+
+**Current:** `render_metrics.rs` tracks five atomic counters:
+- `grid_paint_count`
+- `shape_line_calls`
+- `shaped_line_cache_hits` / `shaped_line_cache_misses`
+- `runtime_wakeup_count`
+
+**Extend with span timing:**
+
+```rust
+// Add to render_metrics.rs
+pub struct FrameProfiler {
+    spans: Vec<TimedSpan>,
+}
+
+#[derive(Clone, Copy)]
+pub enum SpanName {
+    TmuxEventProcessing,
+    GridDamageCompute,
+    RowOpsRebuild,
+    TextShaping,
+    GpuSubmission,
+}
+
+// Usage
+profiler.begin(SpanName::TextShaping);
+let shaped = shape_line(text);
+profiler.end(SpanName::TextShaping);
+```
+
+**Output:**
+- Real-time overlay (debug builds) showing per-span ms
+- Chrome trace format export (`chrome://tracing`)
+- Automated regression detection in benchmark compare
+
+### 6.2 Memory Tracker (Medium Priority)
+
+```rust
+pub struct MemoryTracker {
+    categories: EnumMap<AllocCategory, CategoryStats>,
+}
+
+pub enum AllocCategory {
+    GridCells,         // CachedRowPaintOps allocations
+    ShapedLines,       // ShapedLine cache memory
+    TmuxState,         // Notification coalescer + snapshot state
+    ConfigData,        // Parsed config structs
+}
+```
+
+### 6.3 Continuous Benchmarking — Already Implemented
+
+`crates/xtask/src/benchmark.rs` provides a full benchmark driver and compare tool.
+
+**Remaining gaps to fill:**
+1. Add more scenarios to the existing `Scenario` enum:
+   - `ScrollingOutput` — `yes | head -n 100000`
+   - `RapidCursorMovement` — cursor movement stress
+   - `SearchHeavyContent` — regex search in large buffer
+   - `TmuxPaneResizing` — rapid pane splits/resizes
+2. Add CI step to run `benchmark-compare` on every PR and fail on >5% regression
+3. Export benchmark results as structured JSON for trend tracking
+
+---
+
+## Phase 7: Architecture Improvements
+
+### 7.1 Copy-on-Write Grid Snapshots (Medium Impact)
+
+**Current:** Grid data is cloned for rendering on each frame.
+
+**Solution:** Share grid data with copy-on-write semantics.
+
+```rust
+pub struct GridSnapshot {
+    data: Arc<GridData>,
+    changes: Vec<GridChange>, // Delta since last snapshot
+}
+
+impl GridSnapshot {
+    pub fn apply(&mut self, change: GridChange) {
+        // Arc::make_mut clones only when shared
+        Arc::make_mut(&mut self.data).apply(change);
+    }
+}
+```
+
+### 7.2 Render Thread Separation (High Impact, High Risk, High Effort)
+
+**Goal:** Move all GPU command submission to a dedicated render thread so input processing is never blocked by GPU work.
+
+> **Note:** This requires GPUI to support off-thread rendering or a custom Metal/wgpu command encoder. Verify GPUI's threading model before starting — this may require forking GPUI.
+
+```rust
+pub struct RenderThread {
+    thread: JoinHandle<()>,
+    command_queue: Channel<RenderCommand>,
+    result_queue: Channel<RenderResult>,
+}
+// Main thread builds render description
+// Render thread executes GPU commands
+// Double-buffered swap chains
+```
+
+**Benefits:**
+- Input processing never blocked by GPU
+- Smoother frame times
+- Better multi-core utilization
+
+### 7.3 Plugin-Based Rendering (Low Priority, Future)
+
+**Goal:** Allow alternative renderers (WebGPU, software fallback).
+
+```rust
+pub trait TerminalRenderer {
+    fn render(&mut self, frame: &RenderFrame) -> RenderResult;
+    fn resize(&mut self, size: TerminalSize);
+    fn set_damage(&mut self, damage: TerminalGridPaintDamage);
+}
+```
+
+---
+
+## Implementation Priority Matrix
+
+| Phase | Task | Impact | Effort | Priority | Status |
+|-------|------|--------|--------|----------|--------|
+| 1.4 | Thread-local damage buffer | Low | Low | P0 | Not started |
+| 2.2 | Cell color resolution cache | Medium | Low | P0 | Not started |
+| 1.2 | Cursor blink as overlay | High | Low | P0 | Done |
+| 4.1 | Lazy runtime init | High | Medium | P0 | Not started |
+| 6.1 | Frame time profiler spans | High | Medium | P0 | Not started |
+| 1.1 | Cell-level damage tracking | High | Medium | P0 | Done |
+| 6.3 | More benchmark scenarios + CI | High | Medium | P0 | Partial (driver exists) |
+| 1.3 | Shaped-line hash index | Medium | Medium | P1 | Not started |
+| 4.2 | Parallel init | Medium | Medium | P1 | Not started |
+| 5.2 | Pane visibility culling | Medium | Medium | P1 | Not started |
+| 3.1 | VSync-aware wakeup coalescing | Medium | Low | P1 | Not started |
+| 4.3 | Config binary cache | Medium | Low | P2 | Not started |
+| 5.3 | PTY read buffering | Medium | Low | P2 | Not started |
+| 2.1 | Scrollback compression | High | Very High | P2 | Requires alacritty_terminal patch |
+| 7.1 | CoW grid snapshots | Medium | High | P2 | Not started |
+| 3.2 | Predictive cursor rendering | Low | Medium | P3 | Not started |
+| 2.3 | String interning | Low | Low | P3 | Not started |
+| 7.2 | Render thread separation | High | Very High | P3 | Requires GPUI investigation |
+| 7.3 | Plugin rendering | Low | Very High | P3 | Future |
+| 5.1 | Tmux event batching | — | — | Done | `coalescer.rs` |
+
+---
+
+## Already Implemented (Do Not Re-implement)
+
+| Feature | Location |
+|---------|----------|
+| Tmux notification coalescing (per-pane merge, backpressure, 512 KB cap) | `tmux/control/coalescer.rs` |
+| Text run batching by `(bold, fg, underline)` per row | `grid.rs` — `TextBatch` |
+| Background span batching by color per row | `grid.rs` — `BackgroundSpan` |
+| Unicode block elements as pixel-snapped quads | `grid.rs` — `block_element_geometry` |
+| Per-row `ShapedLine` cache with cross-row reuse | `grid.rs` — `CachedRowPaintOps.shaped_lines` |
+| Benchmark driver, compare tool, scenario runner | `crates/xtask/src/benchmark.rs` |
+| Atomic render metrics (5 counters) | `render_metrics.rs` |
+
+---
+
+## Success Metrics
+
+After implementing this plan:
+
+1. **Frame Time:** p99 frame time < 16.67ms (60 FPS) during `cat` of 100MB file
+2. **Memory:** Base footprint < 100MB with default 2000-line scrollback
+3. **Latency:** Key-to-screen latency < 8ms measured with photodiode
+4. **Startup:** Cold start to interactive < 200ms on M1 MacBook Pro
+5. **Efficiency:** Zero CPU usage when idle (no busy-waiting)
+6. **Regression gate:** No PR merges with >5% benchmark regression
+
+---
+
+## Appendix: Benchmark Commands
+
+```bash
+# Frame time stress test
+yes | head -n 1000000 | base64
+
+# Scrollback memory test
+cat /dev/urandom | base64 | head -c 50M
+
+# Input latency test
+# Use typometer or similar tool
+
+# Startup time
+hyperfine 'termy -e exit'
+
+# Run benchmark driver
+cargo run -p xtask -- benchmark-driver --scenario <name> --duration-secs 13
+
+# Compare two builds
+cargo run -p xtask -- benchmark-compare --baseline <spec> --candidate <spec>
+```
+
+---
+
+*Last updated: 2026-03-23* (1.1, 1.2 completed)
+*Owner: Performance Working Group*
+*Review cycle: Monthly*

--- a/crates/terminal_ui/src/grid.rs
+++ b/crates/terminal_ui/src/grid.rs
@@ -1,4 +1,5 @@
 use crate::render_metrics::{
+    add_span_grid_paint_us, add_span_row_ops_rebuild_us, add_span_text_shaping_us,
     increment_grid_paint_count, increment_shape_line_calls, increment_shaped_line_cache_hit,
     increment_shaped_line_cache_miss,
 };
@@ -6,7 +7,7 @@ use gpui::{
     App, Bounds, Element, Font, FontFeatures, FontWeight, Hsla, IntoElement, Pixels, ShapedLine,
     SharedString, Size, TextAlign, TextRun, UnderlineStyle, Window, point, px, quad,
 };
-use std::{cell::RefCell, rc::Rc, sync::Arc};
+use std::{cell::RefCell, collections::HashMap, rc::Rc, sync::Arc, time::Instant};
 
 /// Info needed to render a single cell.
 #[derive(Clone)]
@@ -42,6 +43,9 @@ pub enum TerminalGridPaintDamage {
     None,
     Full,
     Rows(Arc<[usize]>),
+    /// Row damage with column bounds `(row, left_col_inclusive, right_col_inclusive)`.
+    /// Emitted when alacritty reports partial damage with column-level granularity.
+    RowRanges(Arc<[(usize, usize, usize)]>),
 }
 
 #[derive(Clone, Default)]
@@ -82,6 +86,7 @@ pub struct TerminalGrid {
     pub search_current_bg: Hsla,
     pub hovered_link_range: Option<(usize, usize, usize)>,
     pub cursor_cell: Option<(usize, usize)>,
+    pub cursor_visible: bool,
     pub font_family: SharedString,
     pub font_size: Pixels,
     pub cursor_style: TerminalCursorStyle,
@@ -215,7 +220,16 @@ struct TerminalGridPaintCache {
     row_ops: Vec<CachedRowPaintOps>,
     style_key: Option<GridPaintStyleKey>,
     last_cursor_cell: Option<(usize, usize)>,
+    last_cursor_visible: bool,
     last_hovered_link_range: Option<(usize, usize, usize)>,
+    /// Per-pass scratch: `Some((left, right))` if only that column range is dirty for the row.
+    /// `None` means full-row damage (cursor/hover transitions, or no damage info available).
+    /// Cleared and repopulated at the start of every paint pass.
+    dirty_col_ranges: Vec<Option<(usize, usize)>>,
+    /// Per-style cache: maps hsla_bits(cell.bg) → resolved background fill color.
+    /// Avoids redundant float comparisons when many cells share the same default background.
+    /// Cleared whenever the style key changes.
+    color_cache: HashMap<[u32; 4], Option<Hsla>>,
 }
 
 impl TerminalGridPaintCache {
@@ -223,12 +237,21 @@ impl TerminalGridPaintCache {
         self.row_ops.clear();
         self.style_key = None;
         self.last_cursor_cell = None;
+        self.last_cursor_visible = false;
         self.last_hovered_link_range = None;
+        self.dirty_col_ranges.clear();
+        self.color_cache.clear();
     }
 
     fn ensure_row_capacity(&mut self, row_count: usize) {
         if self.row_ops.len() != row_count {
             self.row_ops = vec![CachedRowPaintOps::default(); row_count];
+        }
+        // dirty_col_ranges is per-pass scratch — resize and reset every frame
+        if self.dirty_col_ranges.len() != row_count {
+            self.dirty_col_ranges = vec![None; row_count];
+        } else {
+            self.dirty_col_ranges.fill(None);
         }
     }
 }
@@ -489,6 +512,17 @@ fn text_draw_ops_match_without_row(lhs: &TextDrawOp, rhs: &TextDrawOp) -> bool {
     }
 }
 
+fn draw_op_col_range(op: &TextDrawOp) -> (usize, usize) {
+    match op {
+        TextDrawOp::Batch(b) => (b.start_col, b.start_col + b.cell_len.saturating_sub(1)),
+        TextDrawOp::Block(b) => (b.col, b.col),
+    }
+}
+
+fn col_ranges_overlap(a: (usize, usize), b: (usize, usize)) -> bool {
+    a.0 <= b.1 && b.0 <= a.1
+}
+
 fn cached_row_draw_ops_match_without_row(lhs: &CachedRowPaintOps, rhs: &CachedRowPaintOps) -> bool {
     lhs.background_spans == rhs.background_spans
         && lhs.draw_ops.len() == rhs.draw_ops.len()
@@ -587,7 +621,9 @@ impl Element for TerminalGrid {
         cx: &mut App,
     ) {
         increment_grid_paint_count();
+        let t_paint = Instant::now();
         self.paint_with_row_cache(bounds, window, cx);
+        add_span_grid_paint_us(t_paint.elapsed().as_micros() as u64);
     }
 }
 
@@ -626,7 +662,11 @@ impl TerminalGrid {
         }
     }
 
-    fn build_row_background_spans(&self, row_cells: &[CellRenderInfo]) -> Vec<BackgroundSpan> {
+    fn build_row_background_spans(
+        &self,
+        row_cells: &[CellRenderInfo],
+        color_cache: &mut HashMap<[u32; 4], Option<Hsla>>,
+    ) -> Vec<BackgroundSpan> {
         if row_cells.is_empty() {
             return Vec::new();
         }
@@ -635,7 +675,19 @@ impl TerminalGrid {
         let mut current: Option<BackgroundSpan> = None;
 
         for cell in row_cells {
-            let fill = self.row_background_fill(cell);
+            // For cells with default background that aren't highlighted, cache the fill
+            // resolution to avoid repeated float comparisons against terminal_surface_bg.
+            let fill = if !cell.selected && !cell.search_current && !cell.search_match
+                && cell.bg.a > 0.01
+                && cell.uses_terminal_default_bg
+            {
+                let key = hsla_bits(cell.bg);
+                *color_cache.entry(key).or_insert_with(|| {
+                    (cell.bg != self.terminal_surface_bg).then_some(cell.bg)
+                })
+            } else {
+                self.row_background_fill(cell)
+            };
             match (current.as_mut(), fill) {
                 (Some(span), Some(color))
                     if span.color == color && span.end_col_exclusive == cell.col =>
@@ -730,10 +782,11 @@ impl TerminalGrid {
         row_cells: &[CellRenderInfo],
         cursor_fg: Hsla,
         highlight_fg: Hsla,
+        color_cache: &mut HashMap<[u32; 4], Option<Hsla>>,
     ) -> CachedRowPaintOps {
         let draw_ops = self.collect_row_draw_ops(row_cells, cursor_fg, highlight_fg);
         CachedRowPaintOps {
-            background_spans: self.build_row_background_spans(row_cells),
+            background_spans: self.build_row_background_spans(row_cells, color_cache),
             shaped_lines: vec![None; draw_ops.len()],
             draw_ops,
         }
@@ -819,12 +872,14 @@ impl TerminalGrid {
                             underline: batch.underline,
                             strikethrough: None,
                         };
+                        let t_shape = Instant::now();
                         row_ops.shaped_lines[index] = Some(window.text_system().shape_line(
                             batch.text.clone().into(),
                             self.font_size,
                             &[run],
                             Some(self.cell_size.width),
                         ));
+                        add_span_text_shaping_us(t_shape.elapsed().as_micros() as u64);
                         row_ops.shaped_lines[index]
                             .as_ref()
                             .expect("cached shaped line must be created")
@@ -860,6 +915,9 @@ impl TerminalGrid {
     ) -> (bool, bool, Arc<[usize]>) {
         let style_key = self.paint_style_key();
         let style_changed = cache.style_key.as_ref() != Some(&style_key);
+        if style_changed {
+            cache.color_cache.clear();
+        }
         cache.style_key = Some(style_key);
 
         let mut full_repaint =
@@ -868,6 +926,18 @@ impl TerminalGrid {
         if let TerminalGridPaintDamage::Rows(damaged_rows) = &self.paint_damage {
             rows.extend(damaged_rows.iter().copied().filter(|row| *row < self.rows));
         }
+        if let TerminalGridPaintDamage::RowRanges(spans) = &self.paint_damage {
+            for &(row, left, right) in spans.iter() {
+                if row < self.rows {
+                    rows.push(row);
+                    // Merge multiple spans on the same row into one union range
+                    cache.dirty_col_ranges[row] = Some(match cache.dirty_col_ranges[row] {
+                        None => (left, right),
+                        Some((prev_l, prev_r)) => (prev_l.min(left), prev_r.max(right)),
+                    });
+                }
+            }
+        }
 
         if cache.last_cursor_cell != self.cursor_cell {
             push_row_if_in_bounds(
@@ -875,6 +945,15 @@ impl TerminalGrid {
                 cache.last_cursor_cell.map(|(_, row)| row),
                 self.rows,
             );
+            push_row_if_in_bounds(&mut rows, self.cursor_cell.map(|(_, row)| row), self.rows);
+        }
+
+        // Blink visibility changed → only need to rebuild for Block cursor, since the
+        // cursor cell's text fg color is baked into draw ops. Line cursor is a plain
+        // quad painted after row ops and needs no row rebuild on blink.
+        if cache.last_cursor_visible != self.cursor_visible
+            && self.cursor_style == TerminalCursorStyle::Block
+        {
             push_row_if_in_bounds(&mut rows, self.cursor_cell.map(|(_, row)| row), self.rows);
         }
 
@@ -897,6 +976,7 @@ impl TerminalGrid {
         }
 
         cache.last_cursor_cell = self.cursor_cell;
+        cache.last_cursor_visible = self.cursor_visible;
         cache.last_hovered_link_range = self.hovered_link_range;
 
         (full_repaint, style_changed, sorted_dedup_rows(rows))
@@ -906,6 +986,9 @@ impl TerminalGrid {
         let Some((cursor_col, cursor_row)) = self.cursor_cell else {
             return;
         };
+        if !self.cursor_visible {
+            return;
+        }
         if cursor_row != row {
             return;
         }
@@ -950,21 +1033,35 @@ impl TerminalGrid {
         highlight_fg: Hsla,
     ) {
         let previous_row_ops = (!style_changed).then(|| cache.row_ops.clone());
+        // Build ops first using color_cache, then write to row_ops (field-split borrow).
         let mut rebuild_row = |row: usize| {
             if row >= self.rows {
                 return;
             }
+            // Read col range hint (Copy) before any mutable borrows.
+            let dirty_col_range = cache.dirty_col_ranges.get(row).copied().flatten();
+
+            // Build the next ops, using color_cache (separate field from row_ops).
+            let mut next_row_ops = if let Some(row_cells) = self.cells.get(row) {
+                self.rebuild_cached_row_ops(
+                    row_cells.as_slice(),
+                    cursor_fg,
+                    highlight_fg,
+                    &mut cache.color_cache,
+                )
+            } else {
+                // Row is no longer present — clear stale ops.
+                CachedRowPaintOps::default()
+            };
+
+            // color_cache borrow ends here; now we can mutably borrow row_ops.
             let Some(row_slot) = cache.row_ops.get_mut(row) else {
                 return;
             };
-            let Some(row_cells) = self.cells.get(row) else {
-                // If a row is now missing from `cells`, clear stale paint ops for this row so we
-                // don't replay previous-frame glyphs/background spans.
-                *row_slot = CachedRowPaintOps::default();
-                return;
-            };
-            let mut next_row_ops =
-                self.rebuild_cached_row_ops(row_cells.as_slice(), cursor_fg, highlight_fg);
+
+            // 1. Try whole-row ShapedLine reuse: if the entire row's ops match a previous
+            //    row, reuse all its ShapedLine objects (existing logic).
+            let mut whole_row_reused = false;
             if let Some(previous_row_ops) = previous_row_ops.as_ref()
                 && let Some(previous_index) =
                     find_matching_previous_row_ops_index(row, &next_row_ops, previous_row_ops)
@@ -972,11 +1069,38 @@ impl TerminalGrid {
                 let previous = &previous_row_ops[previous_index];
                 if previous.shaped_lines.len() == next_row_ops.shaped_lines.len() {
                     next_row_ops.shaped_lines = previous.shaped_lines.clone();
+                    whole_row_reused = true;
                 }
             }
+
+            // 2. Per-op ShapedLine reuse: if we know the dirty column range (from RowRanges
+            //    damage), reuse ShapedLines for text batches that don't overlap the dirty
+            //    region. This avoids re-shaping unchanged text runs when only a few columns
+            //    changed (e.g. a single character typed at the cursor).
+            if !whole_row_reused {
+                if let Some(dirty_range) = dirty_col_range {
+                    if let Some(prev_row) =
+                        previous_row_ops.as_ref().and_then(|ops| ops.get(row))
+                    {
+                        for (i, op) in next_row_ops.draw_ops.iter().enumerate() {
+                            let op_range = draw_op_col_range(op);
+                            if !col_ranges_overlap(op_range, dirty_range) {
+                                if let Some(prev_op) = prev_row.draw_ops.get(i) {
+                                    if text_draw_ops_match_without_row(op, prev_op) {
+                                        next_row_ops.shaped_lines[i] =
+                                            prev_row.shaped_lines[i].clone();
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
             *row_slot = next_row_ops;
         };
 
+        let t0 = Instant::now();
         if full_repaint {
             for row in 0..self.rows {
                 rebuild_row(row);
@@ -986,6 +1110,7 @@ impl TerminalGrid {
                 rebuild_row(row);
             }
         }
+        add_span_row_ops_rebuild_us(t0.elapsed().as_micros() as u64);
     }
 
     fn paint_with_row_cache(&self, bounds: Bounds<Pixels>, window: &mut Window, cx: &mut App) {
@@ -1070,6 +1195,7 @@ impl TerminalGrid {
     fn cell_fg_color(&self, cell: &CellRenderInfo, cursor_fg: Hsla, highlight_fg: Hsla) -> Hsla {
         if self.cursor_cell == Some((cell.col, cell.row))
             && self.cursor_style == TerminalCursorStyle::Block
+            && self.cursor_visible
         {
             cursor_fg
         } else if cell.selected {
@@ -1211,6 +1337,7 @@ mod tests {
             search_current_bg: test_color(0.5, 0.5, 0.5),
             hovered_link_range: hovered,
             cursor_cell: None,
+            cursor_visible: false,
             font_family: SharedString::from("JetBrains Mono"),
             font_size: px(14.0),
             cursor_style: TerminalCursorStyle::Block,
@@ -1537,6 +1664,7 @@ mod tests {
         cursor_block.search_current = true;
         let mut grid = test_grid(vec![cursor_block], None);
         grid.cursor_cell = Some((0, 0));
+        grid.cursor_visible = true;
         let ops = collect_draw_ops(&grid);
         let block_fg = match &ops[0] {
             TextDrawOp::Block(block) => block.fg,
@@ -1569,6 +1697,52 @@ mod tests {
         assert!(!full);
         assert!(!style_changed);
         assert_eq!(&*dirty_rows, &[1usize, 2usize, 4usize]);
+    }
+
+    #[test]
+    fn blink_only_does_not_dirty_rows_for_line_cursor() {
+        // Line cursor: toggling cursor_visible should NOT mark the cursor row dirty,
+        // since the cursor quad is painted as an overlay and row draw ops are unchanged.
+        let mut grid = test_grid(vec![test_cell(0, 0, 'a')], None);
+        grid.rows = 3;
+        grid.paint_damage = TerminalGridPaintDamage::None;
+        grid.cursor_cell = Some((0, 1));
+        grid.cursor_visible = false; // blink off
+        grid.cursor_style = TerminalCursorStyle::Line;
+
+        let mut cache = TerminalGridPaintCache {
+            style_key: Some(grid.paint_style_key()),
+            last_cursor_cell: Some((0, 1)), // same position
+            last_cursor_visible: true,      // was visible
+            ..Default::default()
+        };
+        let (full, style_changed, dirty_rows) = grid.dirty_rows_for_pass(&mut cache);
+        assert!(!full);
+        assert!(!style_changed);
+        assert!(dirty_rows.is_empty(), "Line cursor blink should not dirty any rows");
+    }
+
+    #[test]
+    fn blink_only_dirties_cursor_row_for_block_cursor() {
+        // Block cursor: toggling cursor_visible MUST mark the cursor row dirty,
+        // since the text fg color at the cursor cell is baked into draw ops.
+        let mut grid = test_grid(vec![test_cell(0, 0, 'a')], None);
+        grid.rows = 3;
+        grid.paint_damage = TerminalGridPaintDamage::None;
+        grid.cursor_cell = Some((0, 1));
+        grid.cursor_visible = false; // blink off
+        grid.cursor_style = TerminalCursorStyle::Block;
+
+        let mut cache = TerminalGridPaintCache {
+            style_key: Some(grid.paint_style_key()),
+            last_cursor_cell: Some((0, 1)), // same position
+            last_cursor_visible: true,      // was visible
+            ..Default::default()
+        };
+        let (full, style_changed, dirty_rows) = grid.dirty_rows_for_pass(&mut cache);
+        assert!(!full);
+        assert!(!style_changed);
+        assert_eq!(&*dirty_rows, &[1usize], "Block cursor blink must dirty the cursor row");
     }
 
     #[test]
@@ -1612,7 +1786,7 @@ mod tests {
         fifth.bg = Hsla::transparent_black();
 
         let grid = test_grid(vec![first, second, third, fourth, fifth], None);
-        let spans = grid.build_row_background_spans(grid.cells[0].as_slice());
+        let spans = grid.build_row_background_spans(grid.cells[0].as_slice(), &mut HashMap::new());
         assert_eq!(spans.len(), 2);
         assert_eq!(spans[0].start_col, 0);
         assert_eq!(spans[0].end_col_exclusive, 2);
@@ -1632,7 +1806,7 @@ mod tests {
 
         let mut grid = test_grid(vec![default_bg_cell, ansi_bg_cell], None);
         grid.terminal_surface_bg = test_color(0.2, 0.2, 0.2);
-        let spans = grid.build_row_background_spans(grid.cells[0].as_slice());
+        let spans = grid.build_row_background_spans(grid.cells[0].as_slice(), &mut HashMap::new());
 
         assert_eq!(spans.len(), 1);
         assert_eq!(spans[0].start_col, 1);
@@ -1648,7 +1822,7 @@ mod tests {
 
         let mut grid = test_grid(vec![default_bg_cell], None);
         grid.terminal_surface_bg = test_color(0.1, 0.1, 0.1);
-        let spans = grid.build_row_background_spans(grid.cells[0].as_slice());
+        let spans = grid.build_row_background_spans(grid.cells[0].as_slice(), &mut HashMap::new());
 
         assert_eq!(spans.len(), 1);
         assert_eq!(spans[0].start_col, 0);
@@ -1662,7 +1836,7 @@ mod tests {
         half_block.bg = test_color(0.8, 0.4, 0.2);
 
         let grid = test_grid(vec![half_block], None);
-        let spans = grid.build_row_background_spans(grid.cells[0].as_slice());
+        let spans = grid.build_row_background_spans(grid.cells[0].as_slice(), &mut HashMap::new());
 
         assert_eq!(spans.len(), 1);
         assert_eq!(spans[0].start_col, 0);
@@ -1694,11 +1868,11 @@ mod tests {
         };
 
         let previous_row_ops = vec![
-            old_grid.rebuild_cached_row_ops(old_grid.cells[0].as_slice(), cursor_fg, highlight_fg),
-            old_grid.rebuild_cached_row_ops(old_grid.cells[1].as_slice(), cursor_fg, highlight_fg),
+            old_grid.rebuild_cached_row_ops(old_grid.cells[0].as_slice(), cursor_fg, highlight_fg, &mut HashMap::new()),
+            old_grid.rebuild_cached_row_ops(old_grid.cells[1].as_slice(), cursor_fg, highlight_fg, &mut HashMap::new()),
         ];
         let next_row_ops =
-            new_grid.rebuild_cached_row_ops(new_grid.cells[0].as_slice(), cursor_fg, highlight_fg);
+            new_grid.rebuild_cached_row_ops(new_grid.cells[0].as_slice(), cursor_fg, highlight_fg, &mut HashMap::new());
 
         assert_eq!(
             find_matching_previous_row_ops_index(0, &next_row_ops, &previous_row_ops),
@@ -1727,11 +1901,13 @@ mod tests {
             previous_grid.cells[0].as_slice(),
             cursor_fg,
             highlight_fg,
+            &mut HashMap::new(),
         )];
         let next_row_ops = next_grid.rebuild_cached_row_ops(
             next_grid.cells[0].as_slice(),
             cursor_fg,
             highlight_fg,
+            &mut HashMap::new(),
         );
 
         assert_eq!(
@@ -1764,6 +1940,7 @@ mod tests {
                 l: 0.08,
                 a: 1.0,
             },
+            &mut HashMap::new(),
         );
 
         assert_eq!(row_ops.draw_ops.len(), 3);
@@ -1794,7 +1971,7 @@ mod tests {
         let mut cache = TerminalGridPaintCache {
             row_ops: vec![
                 CachedRowPaintOps::default(),
-                grid.rebuild_cached_row_ops(stale_row_cells.as_slice(), cursor_fg, highlight_fg),
+                grid.rebuild_cached_row_ops(stale_row_cells.as_slice(), cursor_fg, highlight_fg, &mut HashMap::new()),
             ],
             ..Default::default()
         };
@@ -1824,5 +2001,115 @@ mod tests {
         assert_eq!(handle.debug_row_cache_len_for_tests(), 3);
         handle.clear();
         assert_eq!(handle.debug_row_cache_len_for_tests(), 0);
+    }
+
+    #[test]
+    fn dirty_rows_for_pass_row_ranges_extracts_rows_and_col_ranges() {
+        let mut grid = test_grid(vec![test_cell(0, 0, 'a')], None);
+        grid.rows = 5;
+        grid.paint_damage =
+            TerminalGridPaintDamage::RowRanges(vec![(1, 10, 20), (3, 5, 8)].into());
+
+        let mut cache = TerminalGridPaintCache {
+            style_key: Some(grid.paint_style_key()),
+            ..Default::default()
+        };
+        cache.ensure_row_capacity(5);
+        let (full, style_changed, dirty_rows) = grid.dirty_rows_for_pass(&mut cache);
+
+        assert!(!full);
+        assert!(!style_changed);
+        assert_eq!(&*dirty_rows, &[1usize, 3usize]);
+        assert_eq!(cache.dirty_col_ranges[1], Some((10, 20)));
+        assert_eq!(cache.dirty_col_ranges[3], Some((5, 8)));
+        assert_eq!(cache.dirty_col_ranges[0], None);
+        assert_eq!(cache.dirty_col_ranges[2], None);
+    }
+
+    #[test]
+    fn dirty_rows_for_pass_row_ranges_merges_spans_on_same_row() {
+        let mut grid = test_grid(vec![test_cell(0, 0, 'a')], None);
+        grid.rows = 3;
+        // Two spans on row 1: cols 5-10 and cols 15-20 → should merge to 5-20
+        grid.paint_damage =
+            TerminalGridPaintDamage::RowRanges(vec![(1, 5, 10), (1, 15, 20)].into());
+
+        let mut cache = TerminalGridPaintCache {
+            style_key: Some(grid.paint_style_key()),
+            ..Default::default()
+        };
+        cache.ensure_row_capacity(3);
+        let (_, _, dirty_rows) = grid.dirty_rows_for_pass(&mut cache);
+
+        // Row 1 appears once despite two spans
+        assert_eq!(&*dirty_rows, &[1usize]);
+        // Col ranges should be unioned: min(5,15)=5, max(10,20)=20
+        assert_eq!(cache.dirty_col_ranges[1], Some((5, 20)));
+    }
+
+    #[test]
+    fn draw_op_col_range_returns_correct_range_for_batch() {
+        let batch = TextDrawOp::Batch(TextBatch::new(
+            5, // start_col
+            0, // row
+            'a',
+            TextBatchKey {
+                bold: false,
+                fg: Hsla::transparent_black(),
+            },
+            None,
+        ));
+        // Single char batch: range is (5, 5)
+        assert_eq!(draw_op_col_range(&batch), (5, 5));
+    }
+
+    #[test]
+    fn draw_op_col_range_returns_correct_range_for_block() {
+        let block = TextDrawOp::Block(BlockDraw {
+            row: 0,
+            col: 7,
+            geometry: block_element_geometry('\u{2580}').unwrap(),
+            fg: Hsla::transparent_black(),
+        });
+        assert_eq!(draw_op_col_range(&block), (7, 7));
+    }
+
+    #[test]
+    fn col_ranges_overlap_detects_overlapping_ranges() {
+        assert!(col_ranges_overlap((0, 5), (3, 8)));
+        assert!(col_ranges_overlap((3, 8), (0, 5)));
+        assert!(col_ranges_overlap((5, 5), (5, 5)));
+        assert!(col_ranges_overlap((0, 10), (5, 5)));
+    }
+
+    #[test]
+    fn col_ranges_overlap_detects_non_overlapping_ranges() {
+        assert!(!col_ranges_overlap((0, 4), (5, 10)));
+        assert!(!col_ranges_overlap((5, 10), (0, 4)));
+        assert!(!col_ranges_overlap((0, 0), (1, 1)));
+    }
+
+    #[test]
+    fn dirty_rows_for_pass_row_ranges_resets_each_pass() {
+        // Verify that dirty_col_ranges is cleared between passes (via ensure_row_capacity)
+        let mut grid = test_grid(vec![test_cell(0, 0, 'a')], None);
+        grid.rows = 3;
+        grid.paint_damage =
+            TerminalGridPaintDamage::RowRanges(vec![(1, 5, 10)].into());
+
+        let mut cache = TerminalGridPaintCache {
+            style_key: Some(grid.paint_style_key()),
+            ..Default::default()
+        };
+        cache.ensure_row_capacity(3);
+        grid.dirty_rows_for_pass(&mut cache);
+        assert_eq!(cache.dirty_col_ranges[1], Some((5, 10)));
+
+        // Second pass with different damage — must not carry over previous col range
+        grid.paint_damage = TerminalGridPaintDamage::None;
+        cache.ensure_row_capacity(3);
+        let (_, _, dirty_rows) = grid.dirty_rows_for_pass(&mut cache);
+        assert!(dirty_rows.is_empty());
+        assert_eq!(cache.dirty_col_ranges[1], None, "col ranges must reset each pass");
     }
 }

--- a/crates/terminal_ui/src/lib.rs
+++ b/crates/terminal_ui/src/lib.rs
@@ -27,7 +27,7 @@ pub use mouse_protocol::{
 pub use pane_terminal::PaneTerminal;
 pub use protocol::{TerminalClipboardTarget, TerminalQueryColors, TerminalReplyHost};
 pub use render_metrics::{
-    TerminalUiRenderMetricsSnapshot, terminal_ui_render_metrics_reset,
+    TerminalUiRenderMetricsSnapshot, add_span_damage_compute_us, terminal_ui_render_metrics_reset,
     terminal_ui_render_metrics_snapshot,
 };
 pub use runtime::{

--- a/crates/terminal_ui/src/render_metrics.rs
+++ b/crates/terminal_ui/src/render_metrics.rs
@@ -9,6 +9,10 @@ pub struct TerminalUiRenderMetricsSnapshot {
     pub shaped_line_cache_hits: u64,
     pub shaped_line_cache_misses: u64,
     pub runtime_wakeup_count: u64,
+    pub span_damage_compute_us: u64,
+    pub span_row_ops_rebuild_us: u64,
+    pub span_text_shaping_us: u64,
+    pub span_grid_paint_us: u64,
 }
 
 impl TerminalUiRenderMetricsSnapshot {
@@ -29,6 +33,18 @@ impl TerminalUiRenderMetricsSnapshot {
             runtime_wakeup_count: self
                 .runtime_wakeup_count
                 .saturating_sub(previous.runtime_wakeup_count),
+            span_damage_compute_us: self
+                .span_damage_compute_us
+                .saturating_sub(previous.span_damage_compute_us),
+            span_row_ops_rebuild_us: self
+                .span_row_ops_rebuild_us
+                .saturating_sub(previous.span_row_ops_rebuild_us),
+            span_text_shaping_us: self
+                .span_text_shaping_us
+                .saturating_sub(previous.span_text_shaping_us),
+            span_grid_paint_us: self
+                .span_grid_paint_us
+                .saturating_sub(previous.span_grid_paint_us),
         }
     }
 }
@@ -40,6 +56,10 @@ static SHAPE_LINE_CALLS: AtomicU64 = AtomicU64::new(0);
 static SHAPED_LINE_CACHE_HITS: AtomicU64 = AtomicU64::new(0);
 static SHAPED_LINE_CACHE_MISSES: AtomicU64 = AtomicU64::new(0);
 static RUNTIME_WAKEUP_COUNT: AtomicU64 = AtomicU64::new(0);
+static SPAN_DAMAGE_COMPUTE_US: AtomicU64 = AtomicU64::new(0);
+static SPAN_ROW_OPS_REBUILD_US: AtomicU64 = AtomicU64::new(0);
+static SPAN_TEXT_SHAPING_US: AtomicU64 = AtomicU64::new(0);
+static SPAN_GRID_PAINT_US: AtomicU64 = AtomicU64::new(0);
 
 fn increment_counter(counter: &AtomicU64) {
     let _ = counter.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
@@ -67,6 +87,28 @@ pub(crate) fn increment_runtime_wakeup_count() {
     increment_counter(&RUNTIME_WAKEUP_COUNT);
 }
 
+fn add_to_counter(counter: &AtomicU64, micros: u64) {
+    let _ = counter.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+        Some(current.saturating_add(micros))
+    });
+}
+
+pub fn add_span_damage_compute_us(micros: u64) {
+    add_to_counter(&SPAN_DAMAGE_COMPUTE_US, micros);
+}
+
+pub(crate) fn add_span_row_ops_rebuild_us(micros: u64) {
+    add_to_counter(&SPAN_ROW_OPS_REBUILD_US, micros);
+}
+
+pub(crate) fn add_span_text_shaping_us(micros: u64) {
+    add_to_counter(&SPAN_TEXT_SHAPING_US, micros);
+}
+
+pub(crate) fn add_span_grid_paint_us(micros: u64) {
+    add_to_counter(&SPAN_GRID_PAINT_US, micros);
+}
+
 pub fn terminal_ui_render_metrics_snapshot() -> TerminalUiRenderMetricsSnapshot {
     TerminalUiRenderMetricsSnapshot {
         grid_paint_count: GRID_PAINT_COUNT.load(Ordering::Relaxed),
@@ -74,6 +116,10 @@ pub fn terminal_ui_render_metrics_snapshot() -> TerminalUiRenderMetricsSnapshot 
         shaped_line_cache_hits: SHAPED_LINE_CACHE_HITS.load(Ordering::Relaxed),
         shaped_line_cache_misses: SHAPED_LINE_CACHE_MISSES.load(Ordering::Relaxed),
         runtime_wakeup_count: RUNTIME_WAKEUP_COUNT.load(Ordering::Relaxed),
+        span_damage_compute_us: SPAN_DAMAGE_COMPUTE_US.load(Ordering::Relaxed),
+        span_row_ops_rebuild_us: SPAN_ROW_OPS_REBUILD_US.load(Ordering::Relaxed),
+        span_text_shaping_us: SPAN_TEXT_SHAPING_US.load(Ordering::Relaxed),
+        span_grid_paint_us: SPAN_GRID_PAINT_US.load(Ordering::Relaxed),
     }
 }
 
@@ -83,6 +129,10 @@ pub fn terminal_ui_render_metrics_reset() {
     SHAPED_LINE_CACHE_HITS.store(0, Ordering::Relaxed);
     SHAPED_LINE_CACHE_MISSES.store(0, Ordering::Relaxed);
     RUNTIME_WAKEUP_COUNT.store(0, Ordering::Relaxed);
+    SPAN_DAMAGE_COMPUTE_US.store(0, Ordering::Relaxed);
+    SPAN_ROW_OPS_REBUILD_US.store(0, Ordering::Relaxed);
+    SPAN_TEXT_SHAPING_US.store(0, Ordering::Relaxed);
+    SPAN_GRID_PAINT_US.store(0, Ordering::Relaxed);
 }
 
 #[cfg(test)]

--- a/src/terminal_view/mod.rs
+++ b/src/terminal_view/mod.rs
@@ -46,11 +46,11 @@ use termy_terminal_ui::{
     WorkingDirFallback as RuntimeWorkingDirFallback, find_link_in_line, keystroke_to_input,
     normalize_working_directory_candidate, resolve_launch_working_directory,
 };
-#[cfg(debug_assertions)]
 use termy_terminal_ui::{
-    TerminalUiRenderMetricsSnapshot, terminal_ui_render_metrics_reset,
-    terminal_ui_render_metrics_snapshot,
+    TerminalUiRenderMetricsSnapshot, terminal_ui_render_metrics_snapshot,
 };
+#[cfg(debug_assertions)]
+use termy_terminal_ui::terminal_ui_render_metrics_reset;
 use termy_toast::ToastManager;
 
 mod benchmark;
@@ -902,6 +902,11 @@ struct DebugOverlayStats {
     terminal_event_drain_passes: u64,
     terminal_redraws: u64,
     alt_screen_fallback_redraws: u64,
+    span_damage_ms: f32,
+    span_rebuild_ms: f32,
+    span_shaping_ms: f32,
+    span_paint_ms: f32,
+    span_snapshot_base: TerminalUiRenderMetricsSnapshot,
     #[cfg(debug_assertions)]
     runtime_wakeup_base: u64,
     #[cfg(debug_assertions)]
@@ -929,6 +934,11 @@ impl DebugOverlayStats {
             terminal_event_drain_passes: 0,
             terminal_redraws: 0,
             alt_screen_fallback_redraws: 0,
+            span_damage_ms: 0.0,
+            span_rebuild_ms: 0.0,
+            span_shaping_ms: 0.0,
+            span_paint_ms: 0.0,
+            span_snapshot_base: terminal_ui_render_metrics_snapshot(),
             #[cfg(debug_assertions)]
             runtime_wakeup_base,
             #[cfg(debug_assertions)]
@@ -952,6 +962,11 @@ impl DebugOverlayStats {
         self.terminal_event_drain_passes = 0;
         self.terminal_redraws = 0;
         self.alt_screen_fallback_redraws = 0;
+        self.span_damage_ms = 0.0;
+        self.span_rebuild_ms = 0.0;
+        self.span_shaping_ms = 0.0;
+        self.span_paint_ms = 0.0;
+        self.span_snapshot_base = terminal_ui_render_metrics_snapshot();
         #[cfg(debug_assertions)]
         {
             self.runtime_wakeup_base = terminal_ui_render_metrics_snapshot().runtime_wakeup_count;
@@ -977,6 +992,7 @@ impl DebugOverlayStats {
             self.fps = self.frames_in_sample as f32 / elapsed_secs;
         }
         self.refresh_frame_percentiles();
+        self.refresh_span_timings();
         self.refresh_runtime_wakeups();
         self.sample_started_at = now;
         self.frames_in_sample = 0;
@@ -1030,6 +1046,17 @@ impl DebugOverlayStats {
         self.frame_p50_ms = percentile_millis(&sorted_samples, 50, 100);
         self.frame_p95_ms = percentile_millis(&sorted_samples, 95, 100);
         self.frame_p99_ms = percentile_millis(&sorted_samples, 99, 100);
+    }
+
+    fn refresh_span_timings(&mut self) {
+        let current = terminal_ui_render_metrics_snapshot();
+        let delta = current.saturating_sub(self.span_snapshot_base);
+        self.span_snapshot_base = current;
+        let frames = self.frames_in_sample.max(1) as f32;
+        self.span_damage_ms = delta.span_damage_compute_us as f32 / 1000.0 / frames;
+        self.span_rebuild_ms = delta.span_row_ops_rebuild_us as f32 / 1000.0 / frames;
+        self.span_shaping_ms = delta.span_text_shaping_us as f32 / 1000.0 / frames;
+        self.span_paint_ms = delta.span_grid_paint_us as f32 / 1000.0 / frames;
     }
 
     #[cfg(debug_assertions)]

--- a/src/terminal_view/render.rs
+++ b/src/terminal_view/render.rs
@@ -7,6 +7,8 @@ use alacritty_terminal::vte::ansi::{Color as AnsiColor, NamedColor};
 use gpui::prelude::FluentBuilder;
 use gpui::{ElementInputHandler, canvas};
 use std::sync::Arc;
+use std::time::Instant;
+use termy_terminal_ui::add_span_damage_compute_us;
 
 fn blend_rgb_only(base: gpui::Rgba, target: gpui::Rgba, factor: f32) -> gpui::Rgba {
     let factor = factor.clamp(0.0, 1.0);
@@ -143,23 +145,42 @@ fn finalized_cache_update_strategy(
     }
 }
 
+thread_local! {
+    static DIRTY_SPAN_RANGES: std::cell::RefCell<Vec<(usize, usize, usize)>> =
+        std::cell::RefCell::new(Vec::with_capacity(128));
+}
+
 fn paint_damage_from_dirty_spans(
     spans: &[TerminalDirtySpan],
     row_count: usize,
 ) -> TerminalGridPaintDamage {
-    let mut rows = Vec::with_capacity(spans.len());
-    for span in spans {
-        if span.row < row_count {
-            rows.push(span.row);
+    let t0 = Instant::now();
+    let result = DIRTY_SPAN_RANGES.with(|buf| {
+        let mut ranges = buf.borrow_mut();
+        ranges.clear();
+        for span in spans {
+            if span.row < row_count {
+                ranges.push((span.row, span.left_col, span.right_col));
+            }
         }
-    }
-    rows.sort_unstable();
-    rows.dedup();
-    if rows.is_empty() {
-        TerminalGridPaintDamage::None
-    } else {
-        TerminalGridPaintDamage::Rows(rows.into())
-    }
+        if ranges.is_empty() {
+            return TerminalGridPaintDamage::None;
+        }
+        // Sort by row so consecutive entries for the same row are adjacent
+        ranges.sort_unstable_by_key(|&(row, _, _)| row);
+        // Merge multiple spans on the same row into one union of column ranges
+        ranges.dedup_by(|b, a| {
+            if a.0 == b.0 {
+                a.2 = a.2.max(b.2); // expand right bound of `a` to cover `b`
+                true // remove `b`
+            } else {
+                false
+            }
+        });
+        TerminalGridPaintDamage::RowRanges(Arc::from(ranges.as_slice()))
+    });
+    add_span_damage_compute_us(t0.elapsed().as_micros() as u64);
+    result
 }
 
 #[derive(Clone, Copy)]
@@ -842,6 +863,7 @@ impl TerminalView {
         font_size: Pixels,
         cursor_style: TerminalCursorStyle,
         cursor_cell: Option<(usize, usize)>,
+        cursor_visible: bool,
         terminal_surface_bg: gpui::Rgba,
     ) -> TerminalGrid {
         let mut selection_bg = colors.cursor;
@@ -876,6 +898,7 @@ impl TerminalView {
             },
             hovered_link_range,
             cursor_cell,
+            cursor_visible,
             font_family,
             font_size,
             cursor_style,
@@ -1583,6 +1606,59 @@ impl TerminalView {
         )
     }
 
+    fn render_link_preview_overlay(&self) -> Option<AnyElement> {
+        let link = self.hovered_link.as_ref()?;
+        let overlay_style = self.overlay_style();
+
+        let url = &link.target;
+        // Convert file:/// URLs to a readable path, contracting ~ for home dir.
+        let display_url = if let Some(path) = url.strip_prefix("file:///") {
+            let path = format!("/{}", path);
+            // Percent-decode common sequences (spaces, etc.)
+            let path = path.replace("%20", " ");
+            // Contract home directory to ~
+            #[cfg(unix)]
+            let path = if let Some(home) = dirs::home_dir() {
+                let home_str = home.to_string_lossy();
+                if let Some(rel) = path.strip_prefix(home_str.as_ref()) {
+                    format!("~{}", rel)
+                } else {
+                    path
+                }
+            } else {
+                path
+            };
+            if path.len() > 80 {
+                format!("…{}", &path[path.len() - 79..])
+            } else {
+                path
+            }
+        } else if url.len() > 80 {
+            format!("{}…", &url[..79])
+        } else {
+            url.clone()
+        };
+
+        Some(
+            div()
+                .id("link-preview-overlay")
+                .absolute()
+                .bottom(px(6.0))
+                .left(px(6.0))
+                .max_w(px(600.0))
+                .px(px(8.0))
+                .py(px(3.0))
+                .rounded(px(TERMINAL_OVERLAY_GEOMETRY.panel_radius))
+                .bg(overlay_style.chrome_panel_background(0.88))
+                .border_1()
+                .border_color(overlay_style.chrome_panel_neutral(0.20))
+                .text_size(px(11.5))
+                .text_color(overlay_style.panel_foreground(0.85))
+                .child(display_url)
+                .into_any_element(),
+        )
+    }
+
     #[cfg(target_os = "linux")]
     fn clamped_context_menu_origin(
         &self,
@@ -1990,6 +2066,7 @@ impl TerminalView {
         let context_menu_overlay = self.render_terminal_context_menu_overlay(cx);
         let tab_context_menu_overlay = self.render_tab_context_menu_overlay(cx);
         let toast_overlay = self.render_toast_overlay(&colors, cx);
+        let link_preview_overlay = self.render_link_preview_overlay();
         let resize_overlay = self
             .resize_indicator_visible_until
             .zip(self.resize_indicator_dims)
@@ -2031,6 +2108,10 @@ impl TerminalView {
             let terminal_event_drain_passes = self.debug_overlay_stats.terminal_event_drain_passes;
             let terminal_redraws = self.debug_overlay_stats.terminal_redraws;
             let alt_screen_fallback_redraws = self.debug_overlay_stats.alt_screen_fallback_redraws;
+            let span_damage_ms = self.debug_overlay_stats.span_damage_ms;
+            let span_rebuild_ms = self.debug_overlay_stats.span_rebuild_ms;
+            let span_shaping_ms = self.debug_overlay_stats.span_shaping_ms;
+            let span_paint_ms = self.debug_overlay_stats.span_paint_ms;
             #[cfg(debug_assertions)]
             let view_wake_signals = self.debug_overlay_stats.view_wake_signals;
             #[cfg(debug_assertions)]
@@ -2069,6 +2150,9 @@ impl TerminalView {
                 .child(format!("Redraws: {terminal_redraws}"))
                 .child(format!(
                     "Alt fallback redraws: {alt_screen_fallback_redraws}"
+                ))
+                .child(format!(
+                    "Spans ms: dmg={span_damage_ms:.2} rebuild={span_rebuild_ms:.2} shape={span_shaping_ms:.2} paint={span_paint_ms:.2}"
                 ));
             #[cfg(debug_assertions)]
             let overlay = overlay.child(format!(
@@ -2119,6 +2203,7 @@ impl TerminalView {
             .children(resize_overlay)
             .children(debug_overlay)
             .children(toast_overlay)
+            .children(link_preview_overlay)
             .into_any_element()
     }
 }
@@ -2303,13 +2388,15 @@ impl Render for TerminalView {
                     cols,
                     rows,
                 );
-                let (cursor_cell, pane_cursor_style) = match pane_cursor_state {
-                    Some(cursor) => (
-                        cursor_visible.then_some((cursor.col, cursor.row)),
-                        cursor.style,
-                    ),
-                    None => (None, configured_cursor_style),
-                };
+                let (cursor_cell, cursor_paint_visible, pane_cursor_style) =
+                    match pane_cursor_state {
+                        Some(cursor) => (
+                            Some((cursor.col, cursor.row)),
+                            cursor_visible,
+                            cursor.style,
+                        ),
+                        None => (None, false, configured_cursor_style),
+                    };
 
                 let terminal_grid = self.build_terminal_grid_from_cache(
                     pane_cells,
@@ -2325,6 +2412,7 @@ impl Render for TerminalView {
                     pane_font_size,
                     pane_cursor_style,
                     cursor_cell,
+                    cursor_paint_visible,
                     terminal_surface_bg,
                 );
 
@@ -2434,6 +2522,7 @@ impl Render for TerminalView {
                     );
                 }
 
+                let link_hovered = is_active_pane && self.hovered_link.is_some();
                 pane_layers.push(
                     div()
                         .id(SharedString::from(format!("pane-{}", pane.id)))
@@ -2442,6 +2531,7 @@ impl Render for TerminalView {
                         .top(px(pane_top))
                         .w(px(pane_width))
                         .h(px(pane_height))
+                        .when(link_hovered, |el| el.cursor_pointer())
                         .child(terminal_grid)
                         .into_any_element(),
                 );


### PR DESCRIPTION
Add performance-focused changes: introduce PERF-PLAN.md and implement granular rendering improvements and metrics. Key changes:

- crates/terminal_ui/src/grid.rs: add TerminalGridPaintDamage::RowRanges, per-pass dirty_col_ranges, cursor_visible handling, a color_cache to avoid repeated HSLA ops, partial-shaped-line reuse for untouched column ranges, draw_op_col_range/col_ranges_overlap helpers, and microsecond timing around row-ops rebuild and text shaping. Adjusted APIs to thread-local and per-pass data and expanded tests for these behaviors.
- crates/terminal_ui/src/render_metrics.rs: add span counters (damage compute, row-ops rebuild, text shaping, grid paint), accessor/reset helpers, and functions to record microsecond spans.
- crates/terminal_ui/src/lib.rs: export a span metric helper.
- src/terminal_view/*: add debug overlay span timing aggregation and expose span snapshotting; move metric reset to debug-only build.
- src/terminal_view/render.rs: optimize paint_damage_from_dirty_spans with a thread-local buffer of (row,left,right) ranges and record damage-compute timing.

These changes enable column-granular damage tracking, reduce re-shaping work, cache background color resolution, and add end-to-end timing metrics to guide further optimizations and profiling.
