### PR TITLE
feat: render box-drawing characters as built-in geometry

### DIFF
--- a/crates/terminal_ui/src/grid.rs
+++ b/crates/terminal_ui/src/grid.rs
@@ -191,10 +191,15 @@ impl BlockElementGeometry {
     }
 
     fn push_rect(&mut self, rect: BlockRectSpec) {
-        assert!(
+        debug_assert!(
             self.rect_count < self.rects.len(),
             "box geometry exceeded rect capacity"
         );
+        if self.rect_count >= self.rects.len() {
+            // Preserve release stability if a future mapping regression exceeds
+            // the fixed connector rect budget.
+            return;
+        }
         self.rects[self.rect_count] = rect;
         self.rect_count += 1;
     }
@@ -1200,6 +1205,7 @@ fn rounded_corner_path_spec(
     glyph: char,
     stroke_width: Pixels,
 ) -> Option<RoundedCornerPathSpec> {
+    let cell_bounds = snapped_quad_bounds(cell_bounds)?;
     let origin = cell_bounds.origin;
     let width = cell_bounds.size.width;
     let height = cell_bounds.size.height;
@@ -1284,6 +1290,7 @@ fn diagonal_path_specs(
     glyph: char,
     stroke_width: Pixels,
 ) -> Option<(DiagonalPathSpec, Option<DiagonalPathSpec>)> {
+    let cell_bounds = snapped_quad_bounds(cell_bounds)?;
     let origin = cell_bounds.origin;
     let width = cell_bounds.size.width;
     let height = cell_bounds.size.height;
@@ -2156,78 +2163,9 @@ impl TerminalGrid {
     #[cfg(test)]
     fn collect_draw_ops(&self, cursor_fg: Hsla, highlight_fg: Hsla) -> Vec<TextDrawOp> {
         let mut ops = Vec::with_capacity(self.cell_count());
-        let mut current: Option<TextBatch> = None;
-        let cell_w: f32 = self.cell_size.width.into();
-        let cell_h: f32 = self.cell_size.height.into();
-        let font_sz: f32 = self.font_size.into();
-
-        for cell in self.cells.iter().flat_map(|row| row.iter()) {
-            if !Self::cell_is_drawable_text(cell) {
-                Self::push_pending_text_batch(&mut current, &mut ops);
-                continue;
-            }
-
-            let fg = self.cell_fg_color(cell, cursor_fg, highlight_fg);
-            if rounded_corner_char(cell.char) {
-                Self::push_pending_text_batch(&mut current, &mut ops);
-                ops.push(TextDrawOp::RoundedCorner(RoundedCornerDraw {
-                    row: cell.row,
-                    col: cell.col,
-                    glyph: cell.char,
-                    fg,
-                }));
-                continue;
-            }
-
-            if diagonal_char(cell.char) {
-                Self::push_pending_text_batch(&mut current, &mut ops);
-                ops.push(TextDrawOp::Diagonal(DiagonalDraw {
-                    row: cell.row,
-                    col: cell.col,
-                    glyph: cell.char,
-                    fg,
-                }));
-                continue;
-            }
-
-            if let Some(geometry) = block_element_geometry(cell.char)
-                .or_else(|| box_draw_geometry_for_char(cell.char, cell_w, cell_h, font_sz))
-            {
-                Self::push_pending_text_batch(&mut current, &mut ops);
-                ops.push(TextDrawOp::Block(BlockDraw {
-                    row: cell.row,
-                    col: cell.col,
-                    geometry,
-                    fg,
-                }));
-                continue;
-            }
-
-            let underline = self.cell_underline(cell.row, cell.col, fg);
-            let key = TextBatchKey {
-                bold: cell.bold,
-                fg,
-            };
-
-            let should_append = current.as_ref().is_some_and(|batch| {
-                batch.can_append(cell.col, cell.row, key, &underline)
-            });
-
-            if should_append {
-                if let Some(batch) = current.as_mut() {
-                    batch.append_char(cell.char);
-                }
-                continue;
-            }
-
-            Self::push_pending_text_batch(&mut current, &mut ops);
-            current = Some(TextBatch::new(
-                cell.col, cell.row, cell.char, key, underline,
-            ));
+        for row_cells in self.cells.iter() {
+            ops.extend(self.collect_row_draw_ops(row_cells.as_ref(), cursor_fg, highlight_fg));
         }
-
-        Self::push_pending_text_batch(&mut current, &mut ops);
-
         ops
     }
 }


### PR DESCRIPTION
# Built-in box-drawing character rendering

This uses the same strategy that Ghostty uses to overcome the problem of line/box/etc. characters when line height is greater than `1.0`.

## Problem

Font glyphs for Unicode box-drawing characters (U+2500..U+257F) are sized to the font's natural cell height, not the terminal's actual cell height. When `line_height > 1.0`, this leaves visible gaps between vertically adjacent box-drawing rows. Even at `line_height = 1.0`, glyph anti-aliasing produces inconsistent stroke widths across different fonts, the same problem that already motivated built-in rendering of block elements (U+2580..U+259F).

| Before | After |
|---|---|
| <img width="1552" height="1012" alt="SCR-20260324-lpxf" src="https://github.com/user-attachments/assets/fb448d3f-5cec-4bb2-8df5-25b6984b1661" /> | <img width="1508" height="968" alt="SCR-20260324-lpxx" src="https://github.com/user-attachments/assets/c6ff6902-2057-4bf4-ac4d-26c9dcb04486" /> |

## Mental model

The terminal grid renderer now intercepts the entire box-drawing range before it reaches the text shaper, the same way it already intercepts block elements. Each box-drawing codepoint is classified into one of three rendering strategies:

1. **Rectangular connectors** (U+2500-U+256C, U+2574-U+257F) — decomposed into a set of axis-aligned rectangles placed relative to the cell, then painted as pixel-snapped quads. A `BoxDrawSegments` descriptor declares which of the four cardinal arms (up/down/left/right) are present and whether each is light, heavy, or double. The `box_draw_geometry` function converts this into `BlockElementGeometry` rects using Ghostty's `linesChar` edge-placement algorithm, then merges overlapping collinear rectangles.

2. **Rounded corners** (U+256D-U+2570) — rendered as stroked cubic Bézier paths. A straight stub extends from each cell edge to the arc start, then a single cubic curve connects the two arms. This preserves true curves while matching the built-in stroke width.

3. **Diagonals** (U+2571-U+2573) — rendered as stroked straight lines with slope-dependent overshoot past the cell boundary to prevent pixel gaps at adjacent-cell seams.

All three strategies share the stroke width formula `ceil(font_size * 0.0675).max(1.0)`, matching Ghostty's unconditional sprite-rendering policy.

## Non-goals

- Dashed/dotted box-drawing variants (U+2504, U+2505, etc.) are intentionally rendered as solid lines, consistent with Ghostty's approach. True dash patterns are deferred.
- This change does not touch the block-element rendering path except to widen `BlockElementGeometry`'s internal capacity from 4 to 8 rects.

## Tradeoffs

- **Fixed-capacity geometry array (8 rects)**: Avoids heap allocation on the hot paint path. The most complex glyph (double-cross U+256C) produces exactly 8 rects before merge. If future glyphs exceed this, the `push_rect` assert will fire at development time rather than silently truncating.
- **Collinear merge pass**: The O(n^2) merge in `merge_collinear_overlaps` is bounded by n <= 8. For simple glyphs it eliminates redundant overlapping quads from the independent-arm composition, keeping the painted rect count low.
- **Emoji isolation**: Characters in U+2600..U+27BF and U+1F000..U+1FAFF are now excluded from text-batch coalescing. This prevents variable-width emoji from shifting the pixel alignment of subsequent ASCII characters in the same `ShapedLine`, at the cost of more (smaller) text batches.

## Architecture

All new code lives in `crates/terminal_ui/src/grid.rs`. The dispatch order in `collect_row_draw_ops` / `collect_draw_ops` is:

```
char_requires_isolated_batch? → skip (emoji)
rounded_corner_char?          → TextDrawOp::RoundedCorner
diagonal_char?                → TextDrawOp::Diagonal
block_element_geometry?       → TextDrawOp::Block
box_draw_geometry_for_char?   → TextDrawOp::Block  (reuses existing quad painter)
otherwise                     → TextDrawOp::Batch  (text shaper)
```

New types:
- `BoxLineStyle` — None / Light / Heavy / Double
- `BoxDrawSegments` — four-arm style descriptor
- `RoundedCornerDraw`, `DiagonalDraw` — deferred paint ops
- `RoundedCornerPathSpec`, `DiagonalPathSpec` — resolved path geometry

New free functions:
- `box_draw_segments(char) → Option<BoxDrawSegments>` — codepoint lookup table
- `box_draw_geometry(segments, cell_w, cell_h, font_size) → BlockElementGeometry`
- `rounded_corner_path_spec`, `diagonal_path_specs` — path construction
- `paint_rounded_corner_path`, `paint_diagonal_path` — GPUI paint calls
- `draw_op_col_range`, `col_ranges_overlap` — column-range helpers

## Observability

- `render_metrics` counters (`increment_grid_paint_count`, cache hit/miss) are unchanged and continue to track shaped-line caching. Box-drawing glyphs now bypass shaping entirely, so cache-miss rates should drop for box-drawing-heavy screens.
- The `push_rect` assertion (`box geometry exceeded rect capacity`) will panic in debug builds if a codepoint generates more than 8 rects, providing early detection if the table is extended incorrectly.

## Tests

- `box_draw_segments_covers_expected_range` — ensures every codepoint in U+2500..U+257F is handled by at least one of the three strategies.
- Geometry tests verify exact rect fractions for light horizontal, light cross, double cross, light-to-heavy connector, and light-to-double connector.
- `box_draw_lines_extend_to_cell_edges` — invariant: straight lines span 0.0 to 1.0 in their primary axis.
- Path-spec tests verify cubic control points for rounded corners and overshoot coordinates for diagonals.
- Batch-splitting tests confirm that box-drawing, rounded-corner, diagonal, and emoji characters correctly flush the preceding text batch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced rendering of Unicode box-drawing characters for crisper, pixel-aligned connectors, with smoother rounded corners and cleaner diagonals; improved merging of adjacent connector segments to reduce seams and produce continuous lines. Emoji behavior in normal text flow unaffected.

* **Tests**
  * Expanded test coverage for box-drawing rendering, connector merging, rounded-corner/diagonal accuracy, and draw-order/batching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->