### PR TITLE
Nix: add package and dev flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776877367,
+        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,102 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachSystem [ "x86_64-linux" ] (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+
+        nativeBuildInputs = with pkgs; [
+          cargo
+          clang
+          cmake
+          git
+          makeWrapper
+          pkg-config
+          rustc
+        ];
+
+        buildInputs = with pkgs; [
+          alsa-lib
+          fontconfig
+          freetype
+          libgit2
+          openssl
+          sqlite
+          vulkan-loader
+          wayland
+          libx11
+          libxcb
+          libxkbcommon
+          zstd
+        ];
+
+        termy = pkgs.rustPlatform.buildRustPackage {
+          name = "termy";
+          src = self;
+
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+            allowBuiltinFetchGit = true;
+          };
+
+          inherit nativeBuildInputs buildInputs;
+
+          doCheck = false;
+          env = {
+            LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
+          };
+
+          postInstall = ''
+            wrapProgram $out/bin/termy \
+              --prefix LD_LIBRARY_PATH : ${pkgs.lib.makeLibraryPath buildInputs}
+          '';
+
+          meta = {
+            description = "A fast, minimal terminal emulator built with GPUI and alacritty_terminal";
+            homepage = "https://github.com/lassejlv/termy";
+            license = pkgs.lib.licenses.mit;
+            mainProgram = "termy";
+            platforms = [ "x86_64-linux" ];
+          };
+        };
+      in
+      {
+        packages = {
+          default = termy;
+          termy = termy;
+        };
+
+        apps = {
+          default = flake-utils.lib.mkApp { drv = termy; };
+          termy = flake-utils.lib.mkApp { drv = termy; };
+        };
+
+        devShells.default = pkgs.mkShell {
+          packages =
+            with pkgs;
+            [
+              cargo-watch
+              just
+              rust-analyzer
+            ]
+            ++ nativeBuildInputs
+            ++ buildInputs;
+
+          env = {
+            LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
+            LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath buildInputs;
+          };
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
       nixpkgs,
       flake-utils,
     }:
-    flake-utils.lib.eachSystem [ "x86_64-linux" ] (
+    flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux"] (
       system:
       let
         pkgs = import nixpkgs { inherit system; };
@@ -66,7 +66,7 @@
             homepage = "https://github.com/termy-org/termy";
             license = pkgs.lib.licenses.mit;
             mainProgram = "termy";
-            platforms = [ "x86_64-linux" ];
+            platforms = [ "x86_64-linux" "aarch64-linux"];
           };
         };
       in

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
       nixpkgs,
       flake-utils,
     }:
-    flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux"] (
+    flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" ] (
       system:
       let
         pkgs = import nixpkgs { inherit system; };
@@ -42,7 +42,7 @@
 
         termy = pkgs.rustPlatform.buildRustPackage {
           name = "termy";
-          src = self;
+          src = pkgs.lib.cleanSource self;
 
           cargoLock = {
             lockFile = ./Cargo.lock;
@@ -66,7 +66,10 @@
             homepage = "https://github.com/termy-org/termy";
             license = pkgs.lib.licenses.mit;
             mainProgram = "termy";
-            platforms = [ "x86_64-linux" "aarch64-linux"];
+            platforms = [
+              "x86_64-linux"
+              "aarch64-linux"
+            ];
           };
         };
       in

--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,8 @@
         ];
 
         termy = pkgs.rustPlatform.buildRustPackage {
-          name = "termy";
+          pname = "termy";
+          version = "latest";
           src = pkgs.lib.cleanSource self;
 
           cargoLock = {

--- a/flake.nix
+++ b/flake.nix
@@ -63,7 +63,7 @@
 
           meta = {
             description = "A fast, minimal terminal emulator built with GPUI and alacritty_terminal";
-            homepage = "https://github.com/lassejlv/termy";
+            homepage = "https://github.com/termy-org/termy";
             license = pkgs.lib.licenses.mit;
             mainProgram = "termy";
             platforms = [ "x86_64-linux" ];


### PR DESCRIPTION
# Pull Request

Adds a Nix flake with a devshell for contributors and a package build for users' flake config.
Only builds for `x86_64-linux` since I don't have a macos system to test out the darwin build.
## Description

- add `flake.nix`
- add `flake.lock`

## Related Issues
Closes #302 

## Checklist

- [x] I confirmed there is no existing open PR for the same or overlapping changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Nix flake configuration enabling users to build and develop the termy application with a pre-configured development environment and all required dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->