### PR TITLE
Fix native tab/pane exit cleanup on shell exit

### DIFF
--- a/src/terminal_view/mod.rs
+++ b/src/terminal_view/mod.rs
@@ -4554,8 +4554,13 @@ impl TerminalView {
         let mut reply_host = GpuiClipboardReplyHost::from_cx(cx);
         self.record_benchmark_terminal_event_drain_pass();
 
-        let mut pending_tab_closures: Vec<TabId> = Vec::new();
+        let mut pending_tab_closures: HashSet<TabId> = HashSet::new();
         let mut pending_pane_closures: Vec<(TabId, String)> = Vec::new();
+        let mut simulated_tab_count = self.tabs.len();
+        let mut simulated_pane_counts = HashMap::new();
+        for tab in &self.tabs {
+            simulated_pane_counts.insert(tab.id, tab.panes.len());
+        }
 
         for tab_index in 0..self.tabs.len() {
             let tab_id = self.tabs[tab_index].id;
@@ -4580,23 +4585,16 @@ impl TerminalView {
                             }
                         }
                         TerminalEvent::Exit => {
-                            if Self::native_exit_should_quit_app(
-                                self.tabs.len(),
-                                self.tabs[tab_index].panes.len(),
-                            ) {
+                            let exit_should_quit = Self::schedule_native_exit(
+                                tab_id,
+                                pane_id.as_str(),
+                                &mut simulated_tab_count,
+                                &mut simulated_pane_counts,
+                                &mut pending_tab_closures,
+                                &mut pending_pane_closures,
+                            );
+                            if exit_should_quit {
                                 should_quit = true;
-                            } else if !pending_tab_closures.contains(&tab_id) {
-                                if self.tabs[tab_index].panes.len() <= 1 {
-                                    pending_tab_closures.push(tab_id);
-                                } else if !pending_pane_closures
-                                    .iter()
-                                    .any(|(pending_tab, pending_pane)| {
-                                        *pending_tab == tab_id
-                                            && pending_pane.as_str() == pane_id.as_str()
-                                    })
-                                {
-                                    pending_pane_closures.push((tab_id, pane_id.clone()));
-                                }
                             }
                             if tab_index == active_tab {
                                 should_redraw = true;
@@ -4698,7 +4696,7 @@ impl TerminalView {
         if should_quit {
             pending_tab_closures.clear();
         }
-        for tab_id in pending_tab_closures.drain(..) {
+        for tab_id in pending_tab_closures.drain() {
             if let Some(tab_index) = self.tab_index_by_id(tab_id) {
                 self.close_tab(tab_index, cx);
                 should_redraw = true;
@@ -4732,6 +4730,40 @@ impl TerminalView {
         tab_count == 1 && pane_count == 1
     }
 
+    fn schedule_native_exit(
+        tab_id: TabId,
+        pane_id: &str,
+        simulated_tab_count: &mut usize,
+        simulated_pane_counts: &mut HashMap<TabId, usize>,
+        pending_tab_closures: &mut HashSet<TabId>,
+        pending_pane_closures: &mut Vec<(TabId, String)>,
+    ) -> bool {
+        let simulated_pane_count = simulated_pane_counts
+            .get(&tab_id)
+            .copied()
+            .unwrap_or(0);
+        if Self::native_exit_should_quit_app(*simulated_tab_count, simulated_pane_count) {
+            return true;
+        }
+        if pending_tab_closures.contains(&tab_id) {
+            return false;
+        }
+        if simulated_pane_count <= 1 {
+            pending_tab_closures.insert(tab_id);
+            *simulated_tab_count = simulated_tab_count.saturating_sub(1);
+            simulated_pane_counts.insert(tab_id, 0);
+            return false;
+        }
+        if pending_pane_closures.iter().any(|(pending_tab, pending_pane)| {
+            *pending_tab == tab_id && pending_pane.as_str() == pane_id
+        }) {
+            return false;
+        }
+        pending_pane_closures.push((tab_id, pane_id.to_string()));
+        simulated_pane_counts.insert(tab_id, simulated_pane_count.saturating_sub(1));
+        false
+    }
+
     fn clear_selection(&mut self) -> bool {
         let anchor_changed = self.selection_anchor.take().is_some();
         let head_changed = self.selection_head.take().is_some();
@@ -4759,6 +4791,7 @@ impl TerminalView {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::{HashMap, HashSet};
 
     #[test]
     fn terminal_overlay_geometry_defaults_to_square_edges() {
@@ -4790,6 +4823,68 @@ mod tests {
         assert!(!TerminalView::native_exit_should_quit_app(1, 2));
         assert!(!TerminalView::native_exit_should_quit_app(2, 1));
         assert!(!TerminalView::native_exit_should_quit_app(0, 0));
+    }
+
+    #[test]
+    fn native_exit_schedules_tab_close_after_two_panes_exit() {
+        let tab_id = 1;
+        let mut pending_tab_closures = HashSet::new();
+        let mut pending_pane_closures = Vec::new();
+        let mut simulated_tab_count = 2;
+        let mut simulated_pane_counts = HashMap::from([(tab_id, 2), (2, 1)]);
+
+        let should_quit = TerminalView::schedule_native_exit(
+            tab_id,
+            "%native-1",
+            &mut simulated_tab_count,
+            &mut simulated_pane_counts,
+            &mut pending_tab_closures,
+            &mut pending_pane_closures,
+        );
+        assert!(!should_quit);
+        assert_eq!(pending_pane_closures.len(), 1);
+
+        let should_quit = TerminalView::schedule_native_exit(
+            tab_id,
+            "%native-2",
+            &mut simulated_tab_count,
+            &mut simulated_pane_counts,
+            &mut pending_tab_closures,
+            &mut pending_pane_closures,
+        );
+        assert!(!should_quit);
+        assert!(pending_tab_closures.contains(&tab_id));
+        assert_eq!(simulated_tab_count, 1);
+    }
+
+    #[test]
+    fn native_exit_quits_after_two_single_pane_tabs_exit() {
+        let mut pending_tab_closures = HashSet::new();
+        let mut pending_pane_closures = Vec::new();
+        let mut simulated_tab_count = 2;
+        let mut simulated_pane_counts = HashMap::from([(1, 1), (2, 1)]);
+
+        let should_quit = TerminalView::schedule_native_exit(
+            1,
+            "%native-1",
+            &mut simulated_tab_count,
+            &mut simulated_pane_counts,
+            &mut pending_tab_closures,
+            &mut pending_pane_closures,
+        );
+        assert!(!should_quit);
+        assert!(pending_tab_closures.contains(&1));
+        assert_eq!(simulated_tab_count, 1);
+
+        let should_quit = TerminalView::schedule_native_exit(
+            2,
+            "%native-2",
+            &mut simulated_tab_count,
+            &mut simulated_pane_counts,
+            &mut pending_tab_closures,
+            &mut pending_pane_closures,
+        );
+        assert!(should_quit);
     }
 
     fn native_test_leaf(pane_id: &str) -> NativePaneLayoutNode {

--- a/src/terminal_view/mod.rs
+++ b/src/terminal_view/mod.rs
@@ -4554,13 +4554,17 @@ impl TerminalView {
         let mut reply_host = GpuiClipboardReplyHost::from_cx(cx);
         self.record_benchmark_terminal_event_drain_pass();
 
-        for index in 0..self.tabs.len() {
-            let active_pane_id = self.tabs[index].active_pane_id.clone();
+        let mut pending_tab_closures: Vec<TabId> = Vec::new();
+        let mut pending_pane_closures: Vec<(TabId, String)> = Vec::new();
 
-            for pane_index in 0..self.tabs[index].panes.len() {
-                let pane_is_active =
-                    self.tabs[index].panes[pane_index].id.as_str() == active_pane_id.as_str();
-                let (events, has_more) = self.tabs[index].panes[pane_index]
+        for tab_index in 0..self.tabs.len() {
+            let tab_id = self.tabs[tab_index].id;
+            let active_pane_id = self.tabs[tab_index].active_pane_id.clone();
+
+            for pane_index in 0..self.tabs[tab_index].panes.len() {
+                let pane_id = self.tabs[tab_index].panes[pane_index].id.clone();
+                let pane_is_active = pane_id.as_str() == active_pane_id.as_str();
+                let (events, has_more) = self.tabs[tab_index].panes[pane_index]
                     .terminal
                     .drain_events(&mut reply_host);
                 if has_more {
@@ -4571,33 +4575,47 @@ impl TerminalView {
                 for event in events {
                     match event {
                         TerminalEvent::Wakeup | TerminalEvent::Bell => {
-                            if index == active_tab {
+                            if tab_index == active_tab {
                                 should_redraw = true;
                             }
                         }
                         TerminalEvent::Exit => {
                             if Self::native_exit_should_quit_app(
                                 self.tabs.len(),
-                                self.tabs[index].panes.len(),
+                                self.tabs[tab_index].panes.len(),
                             ) {
                                 should_quit = true;
+                            } else if !pending_tab_closures.contains(&tab_id) {
+                                if self.tabs[tab_index].panes.len() <= 1 {
+                                    pending_tab_closures.push(tab_id);
+                                } else if !pending_pane_closures
+                                    .iter()
+                                    .any(|(pending_tab, pending_pane)| {
+                                        *pending_tab == tab_id
+                                            && pending_pane.as_str() == pane_id.as_str()
+                                    })
+                                {
+                                    pending_pane_closures.push((tab_id, pane_id.clone()));
+                                }
                             }
-                            if index == active_tab {
+                            if tab_index == active_tab {
                                 should_redraw = true;
                             }
                         }
                         TerminalEvent::Title(title) => {
-                            if pane_is_active && self.apply_terminal_title(index, &title, cx) {
+                            if pane_is_active
+                                && self.apply_terminal_title(tab_index, &title, cx)
+                            {
                                 should_redraw = true;
                             }
                         }
                         TerminalEvent::ResetTitle => {
-                            if pane_is_active && self.clear_terminal_titles(index) {
+                            if pane_is_active && self.clear_terminal_titles(tab_index) {
                                 should_redraw = true;
                             }
                         }
                         TerminalEvent::ClipboardStore(text) => {
-                            if index == active_tab && pane_is_active {
+                            if tab_index == active_tab && pane_is_active {
                                 self.pending_clipboard = Some(text);
                                 should_redraw = true;
                             }
@@ -4606,7 +4624,8 @@ impl TerminalView {
                         TerminalEvent::ShellPromptStart => {
                             if self.shell_integration_enabled {
                                 // Notify for long-running commands when prompt returns
-                                if let Some(duration) = self.tabs[index].command_lifecycle.elapsed()
+                                if let Some(duration) =
+                                    self.tabs[tab_index].command_lifecycle.elapsed()
                                 {
                                     if duration.as_secs_f32() >= self.notification_min_duration
                                         && self.notifications_enabled
@@ -4619,22 +4638,22 @@ impl TerminalView {
                                         );
                                     }
                                 }
-                                self.tabs[index].command_lifecycle.prompt_start();
+                                self.tabs[tab_index].command_lifecycle.prompt_start();
                             }
                         }
                         TerminalEvent::ShellCommandStart => {
                             if self.shell_integration_enabled {
-                                self.tabs[index].command_lifecycle.command_start();
+                                self.tabs[tab_index].command_lifecycle.command_start();
                             }
                         }
                         TerminalEvent::ShellCommandExecuting => {
                             if self.shell_integration_enabled {
-                                self.tabs[index].command_lifecycle.command_executing();
+                                self.tabs[tab_index].command_lifecycle.command_executing();
                             }
                         }
                         TerminalEvent::ShellCommandFinished(code) => {
                             if self.shell_integration_enabled {
-                                self.tabs[index].command_lifecycle.command_finished(code);
+                                self.tabs[tab_index].command_lifecycle.command_finished(code);
                             }
                         }
                         // Notification events (OSC 9, OSC 777)
@@ -4659,16 +4678,30 @@ impl TerminalView {
                         // Progress indicator (OSC 9;4)
                         TerminalEvent::Progress(state) => {
                             if self.progress_indicator_enabled {
-                                self.tabs[index].progress_state = state;
+                                self.tabs[tab_index].progress_state = state;
                                 should_redraw = true;
                             }
                         }
                         // Working directory (OSC 7)
                         TerminalEvent::WorkingDirectory(path) => {
-                            self.tabs[index].last_prompt_cwd = Some(path);
+                            self.tabs[tab_index].last_prompt_cwd = Some(path);
                         }
                     }
                 }
+            }
+        }
+
+        for (tab_id, pane_id) in pending_pane_closures.drain(..) {
+            let closed = self.close_native_pane_by_id(tab_id, pane_id.as_str(), cx);
+            should_redraw |= closed;
+        }
+        if should_quit {
+            pending_tab_closures.clear();
+        }
+        for tab_id in pending_tab_closures.drain(..) {
+            if let Some(tab_index) = self.tab_index_by_id(tab_id) {
+                self.close_tab(tab_index, cx);
+                should_redraw = true;
             }
         }
 

--- a/src/terminal_view/tabs/lifecycle.rs
+++ b/src/terminal_view/tabs/lifecycle.rs
@@ -584,6 +584,20 @@ impl TerminalView {
                 self.native_pane_layout_trees
                     .insert(tab_id, NativePaneLayoutTree { root: next_root });
                 let (cols, rows) = if let Some(tab) = self.tabs.get_mut(tab_index) {
+                    let prev_cols = tab
+                        .panes
+                        .iter()
+                        .map(|pane| pane.left.saturating_add(pane.width))
+                        .max()
+                        .unwrap_or(1)
+                        .max(1);
+                    let prev_rows = tab
+                        .panes
+                        .iter()
+                        .map(|pane| pane.top.saturating_add(pane.height))
+                        .max()
+                        .unwrap_or(1)
+                        .max(1);
                     tab.panes.retain(|pane| pane.id != pane_id);
                     if tab.active_pane_id == pane_id || !tab.has_active_pane() {
                         tab.active_pane_id = next_focus_id
@@ -596,21 +610,7 @@ impl TerminalView {
                         remaining_pane.pane_zoom_steps = 0;
                     }
                     tab.assert_active_pane_invariant();
-                    let cols = tab
-                        .panes
-                        .iter()
-                        .map(|pane| pane.left.saturating_add(pane.width))
-                        .max()
-                        .unwrap_or(1)
-                        .max(1);
-                    let rows = tab
-                        .panes
-                        .iter()
-                        .map(|pane| pane.top.saturating_add(pane.height))
-                        .max()
-                        .unwrap_or(1)
-                        .max(1);
-                    (cols, rows)
+                    (prev_cols, prev_rows)
                 } else {
                     return false;
                 };

--- a/src/terminal_view/tabs/lifecycle.rs
+++ b/src/terminal_view/tabs/lifecycle.rs
@@ -548,6 +548,117 @@ impl TerminalView {
         }
     }
 
+    pub(crate) fn close_native_pane_by_id(
+        &mut self,
+        tab_id: TabId,
+        pane_id: &str,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        if self.runtime_kind() != RuntimeKind::Native {
+            return false;
+        }
+        let Some(tab_index) = self.tab_index_by_id(tab_id) else {
+            return false;
+        };
+        let Some(tab) = self.tabs.get(tab_index) else {
+            return false;
+        };
+        if tab.panes.len() <= 1 {
+            return false;
+        }
+        if !tab.panes.iter().any(|pane| pane.id == pane_id) {
+            return false;
+        }
+
+        let pane_id = pane_id.to_string();
+        let _ = self
+            .release_forwarded_mouse_presses_for_panes(std::slice::from_ref(&pane_id));
+        self.clear_native_zoom_snapshot_for_tab_id(tab_id);
+
+        if self.ensure_native_layout_tree_for_tab_id(tab_id)
+            && let Some(tree) = self.native_pane_layout_trees.remove(&tab_id)
+        {
+            let (next_root, next_focus_id, removed) =
+                Self::native_remove_leaf_from_tree(tree.root, pane_id.as_str());
+            if removed && let Some(next_root) = next_root {
+                self.native_pane_layout_trees
+                    .insert(tab_id, NativePaneLayoutTree { root: next_root });
+                let (cols, rows) = if let Some(tab) = self.tabs.get_mut(tab_index) {
+                    tab.panes.retain(|pane| pane.id != pane_id);
+                    if tab.active_pane_id == pane_id || !tab.has_active_pane() {
+                        tab.active_pane_id = next_focus_id
+                            .or_else(|| tab.panes.first().map(|pane| pane.id.clone()))
+                            .unwrap_or_default();
+                    }
+                    if tab.panes.len() == 1
+                        && let Some(remaining_pane) = tab.panes.first_mut()
+                    {
+                        remaining_pane.pane_zoom_steps = 0;
+                    }
+                    tab.assert_active_pane_invariant();
+                    let cols = tab
+                        .panes
+                        .iter()
+                        .map(|pane| pane.left.saturating_add(pane.width))
+                        .max()
+                        .unwrap_or(1)
+                        .max(1);
+                    let rows = tab
+                        .panes
+                        .iter()
+                        .map(|pane| pane.top.saturating_add(pane.height))
+                        .max()
+                        .unwrap_or(1)
+                        .max(1);
+                    (cols, rows)
+                } else {
+                    return false;
+                };
+
+                self.apply_native_layout_tree_to_tab(tab_id, cols, rows);
+                if tab_index == self.active_tab {
+                    self.clear_selection();
+                    self.clear_hovered_link();
+                    self.clear_terminal_scrollbar_marker_cache();
+                }
+                self.schedule_persist_native_workspace();
+                cx.notify();
+                return true;
+            }
+        }
+
+        let Some(tab) = self.tabs.get_mut(tab_index) else {
+            return false;
+        };
+        let Some(removed_index) = tab.panes.iter().position(|pane| pane.id == pane_id) else {
+            return false;
+        };
+        let removed = tab.panes.remove(removed_index);
+        Self::native_close_expand_neighbors(&mut tab.panes, &removed);
+
+        if tab.active_pane_id == pane_id || !tab.has_active_pane() {
+            let next_index = removed_index.min(tab.panes.len().saturating_sub(1));
+            if let Some(next) = tab.panes.get(next_index) {
+                tab.active_pane_id = next.id.clone();
+            }
+        }
+        if tab.panes.len() == 1
+            && let Some(remaining_pane) = tab.panes.first_mut()
+        {
+            remaining_pane.pane_zoom_steps = 0;
+        }
+        tab.assert_active_pane_invariant();
+
+        if tab_index == self.active_tab {
+            self.clear_selection();
+            self.clear_hovered_link();
+            self.clear_terminal_scrollbar_marker_cache();
+        }
+        self.schedule_persist_native_workspace();
+        cx.notify();
+        true
+    }
+
     pub(crate) fn close_active_pane_or_tab(
         &mut self,
         window: &mut Window,
@@ -680,8 +791,12 @@ impl TerminalView {
 
     fn clear_native_zoom_snapshot_for_active_tab(&mut self) {
         if let Some(tab) = self.tabs.get(self.active_tab) {
-            self.native_pane_zoom_snapshots.remove(&tab.id);
+            self.clear_native_zoom_snapshot_for_tab_id(tab.id);
         }
+    }
+
+    fn clear_native_zoom_snapshot_for_tab_id(&mut self, tab_id: TabId) {
+        self.native_pane_zoom_snapshots.remove(&tab_id);
     }
 
     fn native_resize_active_pane(


### PR DESCRIPTION
# Pull Request
This Pull requests Ensures native terminal tabs/panes close when their shell exits, preventing stuck blank tabs while preserving app-quit behavior for the last pane.

## Screenshots/Videos

### Before

https://github.com/user-attachments/assets/f09e8846-a395-46ab-8d92-8c6bad717408

### After

https://github.com/user-attachments/assets/12137b2f-aad3-44c2-a756-b873d34b111c




## Related Issues

<!-- If this PR closes any issues, use the keyword 'closes' followed by the issue number -->

Closes #

## Checklist

- [x] I confirmed there is no existing open PR for the same or overlapping changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved event handling for terminal pane and tab closing operations
  * Enhanced shell integration and terminal lifecycle event processing
  * Better state management for terminal progress tracking and working directory updates

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/termy-org/termy/pull/307)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->