### PR TITLE
Add native settings window and macOS terminal fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5814,6 +5814,8 @@ dependencies = [
 name = "termy_ffi"
 version = "0.1.0"
 dependencies = [
+ "serde_json",
+ "termy_config_core",
  "termy_core",
 ]
 

--- a/crates/core/src/frame.rs
+++ b/crates/core/src/frame.rs
@@ -139,6 +139,11 @@ pub(crate) fn snapshot_from_term<T: EventListener>(
         if cell.flags.contains(Flags::INVERSE) {
             std::mem::swap(&mut fg, &mut bg);
         }
+        // Compute default-bg *after* the inverse swap: a reverse-video cell
+        // (e.g. Ink/Claude Code's cursor) paints with the default *foreground*
+        // color, so it is no longer the terminal's default background and must
+        // be drawn rather than skipped/made transparent.
+        let uses_terminal_default_bg = matches!(bg, AnsiColor::Named(NamedColor::Background));
         if cell.flags.contains(Flags::BOLD) {
             fg = bold_foreground_color(fg);
         }
@@ -160,7 +165,7 @@ pub(crate) fn snapshot_from_term<T: EventListener>(
             char: cell.c,
             fg,
             bg: color_to_rgba(bg, live_colors, query_colors),
-            uses_terminal_default_bg: matches!(cell.bg, AnsiColor::Named(NamedColor::Background)),
+            uses_terminal_default_bg,
             bold: cell.flags.contains(Flags::BOLD),
             render_text: !cell.flags.intersects(
                 Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER | Flags::HIDDEN,
@@ -230,6 +235,34 @@ mod tests {
             }
         );
         assert!(frame.cells[0].bold);
+    }
+
+    #[test]
+    fn snapshot_inverse_default_cell_paints_background() {
+        // Ink/Claude Code render the cursor as a reverse-video cell with the
+        // terminal's default colors. After the inverse swap its background is
+        // the default foreground, so it must NOT be flagged as default-bg or
+        // the renderer skips it and the cursor disappears.
+        let size = TerminalSize {
+            cols: 2,
+            rows: 1,
+            cell_width: 9.0,
+            cell_height: 18.0,
+        };
+        let mut term = Term::new(TermConfig::default(), &size, VoidListener);
+        let mut parser: ansi::Processor = ansi::Processor::new();
+        parser.advance(&mut term, b"\x1b[7mX");
+
+        let frame = snapshot_from_term(&term, size, TerminalQueryColors::default());
+
+        assert!(!frame.cells[0].uses_terminal_default_bg);
+        // Inverse swaps fg/bg, so the cell background is the default foreground.
+        let default_fg = color_to_rgba(
+            AnsiColor::Named(NamedColor::Foreground),
+            term.colors(),
+            TerminalQueryColors::default(),
+        );
+        assert_eq!(frame.cells[0].bg, default_fg);
     }
 
     #[test]

--- a/crates/core/src/runtime.rs
+++ b/crates/core/src/runtime.rs
@@ -1459,6 +1459,17 @@ impl Terminal {
         true
     }
 
+    /// Purge scrollback history and snap the viewport back to live output.
+    /// Returns true if there was any history or scroll offset to clear.
+    pub fn clear_scrollback(&self) -> bool {
+        let mut term = self.term.lock();
+        if term.grid().history_size() == 0 && term.grid().display_offset() == 0 {
+            return false;
+        }
+        term.grid_mut().clear_history();
+        true
+    }
+
     /// Return `(display_offset, history_size)` for viewport scrollbar rendering.
     pub fn scroll_state(&self) -> (usize, usize) {
         let term = self.term.lock();

--- a/crates/ffi/Cargo.toml
+++ b/crates/ffi/Cargo.toml
@@ -12,3 +12,5 @@ workspace = true
 
 [dependencies]
 termy_core = { path = "../core" }
+termy_config_core = { path = "../config_core" }
+serde_json = "1.0"

--- a/crates/ffi/include/termy.h
+++ b/crates/ffi/include/termy.h
@@ -15,6 +15,8 @@ typedef enum {
   TERMY_FFI_INVALID_UTF8 = 2,
   TERMY_FFI_SPAWN_FAILED = 3,
   TERMY_FFI_CONFIG_LOAD_FAILED = 4,
+  TERMY_FFI_UNKNOWN_KEY = 5,
+  TERMY_FFI_WRITE_FAILED = 6,
 } TermyFfiStatus;
 
 typedef enum {
@@ -240,6 +242,26 @@ TermyFfiStatus termy_config_render_config(
     const TermyFfiConfig *config,
     TermyFfiRenderConfig *out_render_config);
 TermyFfiStatus termy_render_config_free(TermyFfiRenderConfig *render_config);
+TermyFfiStatus termy_settings_schema_json(
+    const TermyFfiConfig *config,
+    TermyFfiBytes *out_bytes);
+TermyFfiStatus termy_settings_set_root(
+    const uint8_t *key_ptr,
+    size_t key_len,
+    const uint8_t *value_ptr,
+    size_t value_len);
+TermyFfiStatus termy_settings_reset_root(
+    const uint8_t *key_ptr,
+    size_t key_len);
+TermyFfiStatus termy_settings_set_color(
+    const uint8_t *key_ptr,
+    size_t key_len,
+    const uint8_t *hex_ptr,
+    size_t hex_len);
+TermyFfiStatus termy_settings_set_keybinds(
+    const uint8_t *text_ptr,
+    size_t text_len);
+TermyFfiStatus termy_terminal_reload_default_config_colors(TermyFfiTerminal *terminal);
 TermyFfiStatus termy_terminal_free(TermyFfiTerminal *terminal);
 TermyFfiStatus termy_terminal_write(
     TermyFfiTerminal *terminal,
@@ -258,6 +280,9 @@ TermyFfiStatus termy_terminal_scroll_display(
     int32_t delta_lines,
     bool *out_changed);
 TermyFfiStatus termy_terminal_scroll_to_bottom(
+    TermyFfiTerminal *terminal,
+    bool *out_changed);
+TermyFfiStatus termy_terminal_clear_scrollback(
     TermyFfiTerminal *terminal,
     bool *out_changed);
 TermyFfiStatus termy_terminal_snapshot(

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -19,6 +19,8 @@ pub enum TermyFfiStatus {
     InvalidUtf8 = 2,
     SpawnFailed = 3,
     ConfigLoadFailed = 4,
+    UnknownKey = 5,
+    WriteFailed = 6,
 }
 
 #[repr(C)]
@@ -848,6 +850,290 @@ pub unsafe extern "C" fn termy_render_config_free(
     TermyFfiStatus::Ok
 }
 
+// ---------------------------------------------------------------------------
+// Settings (native settings window <-> config.txt bridge)
+// ---------------------------------------------------------------------------
+
+use termy_config_core as cfg;
+
+fn settings_read_contents() -> String {
+    match cfg::config_path().and_then(|path| std::fs::read_to_string(path).ok()) {
+        Some(contents) if !contents.trim().is_empty() => contents,
+        _ => cfg::DEFAULT_CONFIG_TEMPLATE.to_string(),
+    }
+}
+
+fn settings_write_contents(contents: &str) -> Result<(), TermyFfiStatus> {
+    let path = cfg::config_path().ok_or(TermyFfiStatus::WriteFailed)?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|_| TermyFfiStatus::WriteFailed)?;
+    }
+    std::fs::write(&path, contents).map_err(|_| TermyFfiStatus::WriteFailed)
+}
+
+fn settings_color_hex(app: &cfg::AppConfig, id: cfg::ColorSettingId) -> Option<String> {
+    use cfg::ColorSettingId::*;
+    let rgb = match id {
+        Foreground => app.colors.foreground,
+        Background => app.colors.background,
+        Cursor => app.colors.cursor,
+        Black => app.colors.ansi[0],
+        Red => app.colors.ansi[1],
+        Green => app.colors.ansi[2],
+        Yellow => app.colors.ansi[3],
+        Blue => app.colors.ansi[4],
+        Magenta => app.colors.ansi[5],
+        Cyan => app.colors.ansi[6],
+        White => app.colors.ansi[7],
+        BrightBlack => app.colors.ansi[8],
+        BrightRed => app.colors.ansi[9],
+        BrightGreen => app.colors.ansi[10],
+        BrightYellow => app.colors.ansi[11],
+        BrightBlue => app.colors.ansi[12],
+        BrightMagenta => app.colors.ansi[13],
+        BrightCyan => app.colors.ansi[14],
+        BrightWhite => app.colors.ansi[15],
+    };
+    rgb.map(|c| format!("#{:02x}{:02x}{:02x}", c.r, c.g, c.b))
+}
+
+fn settings_schema_json(loaded: &LoadedTermyConfig) -> String {
+    use serde_json::{Value, json};
+
+    let app = &loaded.app_config;
+    let sections_meta = [
+        (cfg::SettingsSection::Appearance, "appearance", "Appearance", "paintbrush"),
+        (cfg::SettingsSection::Terminal, "terminal", "Terminal", "terminal"),
+        (cfg::SettingsSection::Tabs, "tabs", "Tabs", "square.on.square"),
+        (cfg::SettingsSection::Advanced, "advanced", "Advanced", "gearshape.2"),
+        (cfg::SettingsSection::Colors, "colors", "Colors", "paintpalette"),
+        (cfg::SettingsSection::Keybindings, "keybindings", "Keybindings", "keyboard"),
+    ];
+
+    let mut sections = Vec::new();
+    for (section, id, label, icon) in sections_meta {
+        let mut obj = json!({ "id": id, "label": label, "systemImage": icon });
+
+        match section {
+            cfg::SettingsSection::Colors => {
+                let colors: Vec<Value> = cfg::COLOR_SETTING_SPECS
+                    .iter()
+                    .map(|spec| {
+                        json!({
+                            "key": spec.key,
+                            "title": spec.title,
+                            "description": spec.description,
+                            "hex": settings_color_hex(app, spec.id),
+                        })
+                    })
+                    .collect();
+                obj["colors"] = json!(colors);
+            }
+            cfg::SettingsSection::Keybindings => {
+                let lines: Vec<&str> =
+                    app.keybind_lines.iter().map(|line| line.value.as_str()).collect();
+                obj["keybinds"] = json!(lines);
+            }
+            _ => {
+                let mut groups: Vec<(&str, Vec<Value>)> = Vec::new();
+                for spec in cfg::ROOT_SETTING_SPECS {
+                    if spec.section != section
+                        || matches!(spec.id, cfg::RootSettingId::Keybind)
+                    {
+                        continue;
+                    }
+
+                    let kind = match spec.value_kind {
+                        cfg::RootSettingValueKind::Text => "text",
+                        cfg::RootSettingValueKind::Numeric => "numeric",
+                        cfg::RootSettingValueKind::Boolean => "boolean",
+                        cfg::RootSettingValueKind::Enum => "enum",
+                        cfg::RootSettingValueKind::Special => "special",
+                    };
+
+                    let mut setting = json!({
+                        "key": spec.key,
+                        "title": spec.title,
+                        "description": spec.description,
+                        "kind": kind,
+                        "value": cfg::root_setting_default_value(app, spec.id),
+                    });
+
+                    if let Some(choices) = cfg::root_setting_enum_choices(spec.id) {
+                        let choices: Vec<Value> = choices
+                            .iter()
+                            .map(|choice| json!({ "value": choice.value, "label": choice.label }))
+                            .collect();
+                        setting["choices"] = json!(choices);
+                    }
+
+                    match groups.iter_mut().find(|(group, _)| *group == spec.group) {
+                        Some((_, settings)) => settings.push(setting),
+                        None => groups.push((spec.group, vec![setting])),
+                    }
+                }
+
+                let groups: Vec<Value> = groups
+                    .into_iter()
+                    .map(|(group, settings)| json!({ "label": group, "settings": settings }))
+                    .collect();
+                obj["groups"] = json!(groups);
+            }
+        }
+
+        sections.push(obj);
+    }
+
+    json!({
+        "configPath": loaded.path.as_ref().map(|path| path.to_string_lossy().into_owned()),
+        "loadedFromDisk": loaded.loaded_from_disk,
+        "sections": sections,
+    })
+    .to_string()
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn termy_settings_schema_json(
+    config: *const TermyFfiConfig,
+    out_bytes: *mut TermyFfiBytes,
+) -> TermyFfiStatus {
+    if config.is_null() || out_bytes.is_null() {
+        return TermyFfiStatus::Null;
+    }
+
+    let loaded = unsafe { &(*config).loaded };
+    let json = settings_schema_json(loaded);
+    unsafe {
+        *out_bytes = ffi_bytes_from_string(json);
+    }
+    TermyFfiStatus::Ok
+}
+
+unsafe fn settings_set_root_inner(
+    key_ptr: *const u8,
+    key_len: usize,
+    value_ptr: *const u8,
+    value_len: usize,
+) -> Result<(), TermyFfiStatus> {
+    let key = unsafe { required_utf8(key_ptr, key_len) }?;
+    let value = unsafe { optional_utf8(value_ptr, value_len) }?.unwrap_or("");
+    let id = cfg::root_setting_from_key(key).ok_or(TermyFfiStatus::UnknownKey)?;
+    let updated = cfg::upsert_root_setting(&settings_read_contents(), id, value.trim());
+    settings_write_contents(&updated)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn termy_settings_set_root(
+    key_ptr: *const u8,
+    key_len: usize,
+    value_ptr: *const u8,
+    value_len: usize,
+) -> TermyFfiStatus {
+    match unsafe { settings_set_root_inner(key_ptr, key_len, value_ptr, value_len) } {
+        Ok(()) => TermyFfiStatus::Ok,
+        Err(status) => status,
+    }
+}
+
+unsafe fn settings_reset_root_inner(
+    key_ptr: *const u8,
+    key_len: usize,
+) -> Result<(), TermyFfiStatus> {
+    let key = unsafe { required_utf8(key_ptr, key_len) }?;
+    let id = cfg::root_setting_from_key(key).ok_or(TermyFfiStatus::UnknownKey)?;
+    let updated = cfg::remove_root_setting(&settings_read_contents(), id);
+    settings_write_contents(&updated)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn termy_settings_reset_root(
+    key_ptr: *const u8,
+    key_len: usize,
+) -> TermyFfiStatus {
+    match unsafe { settings_reset_root_inner(key_ptr, key_len) } {
+        Ok(()) => TermyFfiStatus::Ok,
+        Err(status) => status,
+    }
+}
+
+unsafe fn settings_set_color_inner(
+    key_ptr: *const u8,
+    key_len: usize,
+    hex_ptr: *const u8,
+    hex_len: usize,
+) -> Result<(), TermyFfiStatus> {
+    let key = unsafe { required_utf8(key_ptr, key_len) }?;
+    let id = cfg::color_setting_from_key(key).ok_or(TermyFfiStatus::UnknownKey)?;
+    let value = unsafe { optional_utf8(hex_ptr, hex_len) }?.map(|hex| hex.trim().to_string());
+    let updated = cfg::apply_color_updates(
+        &settings_read_contents(),
+        &[cfg::ColorSettingUpdate { id, value }],
+    );
+    settings_write_contents(&updated)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn termy_settings_set_color(
+    key_ptr: *const u8,
+    key_len: usize,
+    hex_ptr: *const u8,
+    hex_len: usize,
+) -> TermyFfiStatus {
+    match unsafe { settings_set_color_inner(key_ptr, key_len, hex_ptr, hex_len) } {
+        Ok(()) => TermyFfiStatus::Ok,
+        Err(status) => status,
+    }
+}
+
+unsafe fn settings_set_keybinds_inner(
+    text_ptr: *const u8,
+    text_len: usize,
+) -> Result<(), TermyFfiStatus> {
+    let text = unsafe { optional_utf8(text_ptr, text_len) }?.unwrap_or("");
+    let lines: Vec<String> = text
+        .lines()
+        .map(|line| line.trim().to_string())
+        .filter(|line| !line.is_empty())
+        .collect();
+    let updated = cfg::replace_keybind_lines(&settings_read_contents(), &lines);
+    settings_write_contents(&updated)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn termy_settings_set_keybinds(
+    text_ptr: *const u8,
+    text_len: usize,
+) -> TermyFfiStatus {
+    match unsafe { settings_set_keybinds_inner(text_ptr, text_len) } {
+        Ok(()) => TermyFfiStatus::Ok,
+        Err(status) => status,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn termy_terminal_reload_default_config_colors(
+    terminal: *mut TermyFfiTerminal,
+) -> TermyFfiStatus {
+    if terminal.is_null() {
+        return TermyFfiStatus::Null;
+    }
+
+    let Ok(loaded) = load_config_from_default_path() else {
+        return TermyFfiStatus::ConfigLoadFailed;
+    };
+    let query_colors = termy_core::terminal_query_colors_from_resolved_theme(
+        &termy_core::resolve_theme_colors_from_app_config(
+            &loaded.app_config,
+            loaded.path.as_deref(),
+            termy_core::SystemAppearance::Dark,
+        ),
+    );
+    unsafe {
+        (*terminal).terminal.set_query_colors(query_colors);
+    }
+    TermyFfiStatus::Ok
+}
+
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn termy_terminal_free(terminal: *mut TermyFfiTerminal) -> TermyFfiStatus {
     if terminal.is_null() {
@@ -984,6 +1270,21 @@ pub unsafe extern "C" fn termy_terminal_scroll_to_bottom(
 
     unsafe {
         *out_changed = (*terminal).terminal.scroll_to_bottom();
+    }
+    TermyFfiStatus::Ok
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn termy_terminal_clear_scrollback(
+    terminal: *mut TermyFfiTerminal,
+    out_changed: *mut bool,
+) -> TermyFfiStatus {
+    if terminal.is_null() || out_changed.is_null() {
+        return TermyFfiStatus::Null;
+    }
+
+    unsafe {
+        *out_changed = (*terminal).terminal.clear_scrollback();
     }
     TermyFfiStatus::Ok
 }
@@ -1287,6 +1588,67 @@ mod tests {
         assert!(size.rows > 0);
         assert!(size.cell_width > 0.0);
         assert!(size.cell_height > 0.0);
+    }
+
+    #[test]
+    fn settings_schema_json_covers_sections_and_values() {
+        let contents =
+            b"font_size = 18\ncursor_style = line\n[colors]\nforeground = #abcdef\n";
+        let mut config = ptr::null_mut();
+        assert_eq!(
+            unsafe { termy_config_from_contents(contents.as_ptr(), contents.len(), &mut config) },
+            TermyFfiStatus::Ok
+        );
+
+        let mut bytes = TermyFfiBytes::default();
+        assert_eq!(
+            unsafe { termy_settings_schema_json(config, &mut bytes) },
+            TermyFfiStatus::Ok
+        );
+        let json = unsafe {
+            str::from_utf8(slice::from_raw_parts(bytes.ptr, bytes.len)).expect("schema utf8")
+        };
+        let value: serde_json::Value = serde_json::from_str(json).expect("valid json");
+
+        let sections = value["sections"].as_array().expect("sections array");
+        let ids: Vec<&str> = sections
+            .iter()
+            .map(|section| section["id"].as_str().unwrap())
+            .collect();
+        assert_eq!(
+            ids,
+            vec![
+                "appearance",
+                "terminal",
+                "tabs",
+                "advanced",
+                "colors",
+                "keybindings"
+            ]
+        );
+
+        // Appearance carries the edited font size value.
+        let appearance = &sections[0];
+        let font_size = appearance["groups"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .flat_map(|group| group["settings"].as_array().unwrap())
+            .find(|setting| setting["key"] == "font_size")
+            .expect("font_size setting");
+        assert_eq!(font_size["value"], "18");
+        assert_eq!(font_size["kind"], "numeric");
+
+        // Colors section reflects the override hex.
+        let colors = &sections[4]["colors"].as_array().unwrap();
+        let foreground = colors
+            .iter()
+            .find(|color| color["key"] == "foreground")
+            .expect("foreground color");
+        assert_eq!(foreground["hex"], "#abcdef");
+
+        assert_eq!(unsafe { termy_buffer_free(bytes) }, TermyFfiStatus::Ok);
+        assert_eq!(unsafe { termy_config_free(config) }, TermyFfiStatus::Ok);
     }
 
     #[test]

--- a/macos/Sources/TermySwift/App/TermySwiftApp.swift
+++ b/macos/Sources/TermySwift/App/TermySwiftApp.swift
@@ -13,6 +13,10 @@ struct TermySwiftApp: App {
                 .background(WindowConfigurator())
         }
         .commands {
+            CommandGroup(replacing: .appSettings) {
+                OpenSettingsButton()
+            }
+
             CommandGroup(replacing: .newItem) {
                 Button("New Tab") {
                     NativeTabWindowManager.shared.openNativeTab()
@@ -68,16 +72,37 @@ struct TermySwiftApp: App {
                 .disabled(terminalCommands == nil)
             }
         }
+
+        Window("Termy Settings", id: Self.settingsWindowID) {
+            SettingsRootView()
+        }
+        .defaultSize(width: 860, height: 600)
+        .windowResizability(.contentMinSize)
+    }
+
+    static let settingsWindowID = "termy-settings"
+}
+
+/// Opens settings in a dedicated window while preserving the standard shortcut.
+private struct OpenSettingsButton: View {
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some View {
+        Button("Settings…") {
+            openWindow(id: TermySwiftApp.settingsWindowID)
+            NSApp.activate(ignoringOtherApps: true)
+        }
+        .keyboardShortcut(",", modifiers: .command)
     }
 }
 
 final class AppDelegate: NSObject, NSApplicationDelegate {
-    private var closePaneEventMonitor: Any?
+    private var closePaneEventMonitor: LocalEventMonitor?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.regular)
         NSWindow.allowsAutomaticWindowTabbing = true
-        closePaneEventMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+        if let monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: { event in
             guard event.modifierFlags.contains(.command),
                   !event.modifierFlags.contains(.shift),
                   event.charactersIgnoringModifiers?.lowercased() == "w"
@@ -86,14 +111,33 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
 
             return TerminalCommandRouter.shared.closeFocusedPaneIfSplit() ? nil : event
+        }) {
+            closePaneEventMonitor = LocalEventMonitor(monitor)
         }
         NSApp.activate(ignoringOtherApps: true)
     }
 
     func applicationWillTerminate(_ notification: Notification) {
-        if let closePaneEventMonitor {
-            NSEvent.removeMonitor(closePaneEventMonitor)
+        closePaneEventMonitor?.invalidate()
+    }
+}
+
+private final class LocalEventMonitor {
+    private var invalidateHandler: (() -> Void)?
+
+    init<Token>(_ token: Token) {
+        invalidateHandler = {
+            NSEvent.removeMonitor(token)
         }
+    }
+
+    func invalidate() {
+        invalidateHandler?()
+        invalidateHandler = nil
+    }
+
+    deinit {
+        invalidate()
     }
 }
 

--- a/macos/Sources/TermySwift/Models/SettingsSchema.swift
+++ b/macos/Sources/TermySwift/Models/SettingsSchema.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Decoded representation of the JSON returned by `termy_settings_schema_json`.
+struct SettingsSchema: Decodable {
+    var sections: [SettingsSectionModel]
+}
+
+struct SettingsSectionModel: Decodable, Identifiable {
+    var id: String
+    var label: String
+    var systemImage: String
+    var groups: [SettingsGroup]?
+    var colors: [ColorSetting]?
+    var keybinds: [String]?
+}
+
+struct SettingsGroup: Decodable, Identifiable {
+    var label: String
+    var settings: [Setting]
+
+    var id: String { label }
+}
+
+enum SettingKind: String, Decodable {
+    case text
+    case numeric
+    case boolean
+    case enumeration = "enum"
+    case special
+}
+
+struct Setting: Decodable, Identifiable {
+    var key: String
+    var title: String
+    var description: String
+    var kind: SettingKind
+    var value: String?
+    var choices: [SettingEnumChoice]?
+
+    var id: String { key }
+}
+
+struct SettingEnumChoice: Decodable, Identifiable, Hashable {
+    var value: String
+    var label: String
+
+    var id: String { value }
+}
+
+struct ColorSetting: Decodable, Identifiable {
+    var key: String
+    var title: String
+    var description: String
+    var hex: String?
+
+    var id: String { key }
+}

--- a/macos/Sources/TermySwift/Models/TerminalFrame.swift
+++ b/macos/Sources/TermySwift/Models/TerminalFrame.swift
@@ -43,7 +43,7 @@ struct TerminalRenderConfig: Equatable {
     var backgroundOpacity: Double
     var backgroundOpacityCells: Bool
     var cursorBlink: Bool
-    var cursorStyle: UInt32
+    var cursorStyle: TerminalCursorStyle
     var measuredCellWidth: CGFloat
     var measuredCellHeight: CGFloat
 
@@ -60,7 +60,7 @@ struct TerminalRenderConfig: Equatable {
         backgroundOpacity: 1.0,
         backgroundOpacityCells: false,
         cursorBlink: true,
-        cursorStyle: 2,
+        cursorStyle: .block,
         measuredCellWidth: 9.0,
         measuredCellHeight: 19.6
     )
@@ -78,7 +78,7 @@ struct TerminalRenderConfig: Equatable {
         backgroundOpacity: Double,
         backgroundOpacityCells: Bool,
         cursorBlink: Bool,
-        cursorStyle: UInt32,
+        cursorStyle: TerminalCursorStyle,
         measuredCellWidth: CGFloat,
         measuredCellHeight: CGFloat
     ) {
@@ -101,8 +101,8 @@ struct TerminalRenderConfig: Equatable {
 
     init(_ ffiConfig: TermyFfiRenderConfig) {
         self.init(
-            fontFamily: Self.string(from: ffiConfig.font_family) ?? Self.default.fontFamily,
-            activeTheme: Self.string(from: ffiConfig.active_theme) ?? Self.default.activeTheme,
+            fontFamily: TermyFfiBridge.string(from: ffiConfig.font_family) ?? Self.default.fontFamily,
+            activeTheme: TermyFfiBridge.string(from: ffiConfig.active_theme) ?? Self.default.activeTheme,
             foreground: TerminalRGBA(ffiConfig.foreground),
             background: TerminalRGBA(ffiConfig.background),
             cursor: TerminalRGBA(ffiConfig.cursor),
@@ -113,7 +113,7 @@ struct TerminalRenderConfig: Equatable {
             backgroundOpacity: Double(ffiConfig.background_opacity),
             backgroundOpacityCells: ffiConfig.background_opacity_cells,
             cursorBlink: ffiConfig.cursor_blink,
-            cursorStyle: ffiConfig.cursor_style,
+            cursorStyle: TerminalCursorStyle(ffiRawValue: ffiConfig.cursor_style),
             measuredCellWidth: CGFloat(ffiConfig.cell_width),
             measuredCellHeight: CGFloat(ffiConfig.cell_height)
         )
@@ -126,13 +126,14 @@ struct TerminalRenderConfig: Equatable {
     var cellHeight: CGFloat {
         measuredCellHeight
     }
+}
 
-    private static func string(from bytes: TermyFfiBytes) -> String? {
-        guard let ptr = bytes.ptr, bytes.len > 0 else {
-            return nil
-        }
-        let buffer = UnsafeBufferPointer(start: ptr, count: Int(bytes.len))
-        return String(decoding: buffer, as: UTF8.self)
+enum TerminalCursorStyle: UInt32 {
+    case line = 1
+    case block = 2
+
+    init(ffiRawValue: UInt32) {
+        self = TerminalCursorStyle(rawValue: ffiRawValue) ?? .block
     }
 }
 
@@ -204,7 +205,7 @@ struct TerminalCell: Identifiable, Equatable {
 struct TerminalCursor: Equatable {
     var col: Int
     var row: Int
-    var style: UInt32
+    var style: TerminalCursorStyle
 }
 
 struct TerminalFrame: Equatable {

--- a/macos/Sources/TermySwift/Models/TerminalInput.swift
+++ b/macos/Sources/TermySwift/Models/TerminalInput.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+struct TerminalKeyInput: Equatable {
+    var key: String
+    var keyChar: String?
+    var control: Bool
+    var alt: Bool
+    var shift: Bool
+    var platform: Bool
+    var function: Bool
+    var eventKind: TerminalKeyEventKind
+
+    init(
+        key: String,
+        keyChar: String? = nil,
+        control: Bool = false,
+        alt: Bool = false,
+        shift: Bool = false,
+        platform: Bool = false,
+        function: Bool = false,
+        eventKind: TerminalKeyEventKind = .press
+    ) {
+        self.key = key
+        self.keyChar = keyChar
+        self.control = control
+        self.alt = alt
+        self.shift = shift
+        self.platform = platform
+        self.function = function
+        self.eventKind = eventKind
+    }
+}
+
+enum TerminalKeyEventKind: UInt32 {
+    case press = 1
+    case `repeat` = 2
+    case release = 3
+}

--- a/macos/Sources/TermySwift/Models/TerminalPane.swift
+++ b/macos/Sources/TermySwift/Models/TerminalPane.swift
@@ -194,24 +194,3 @@ final class TerminalWorkspaceStore: ObservableObject {
         return .split(axis: .horizontal, first: first, second: second)
     }
 }
-
-@MainActor
-final class TerminalCommandRouter {
-    static let shared = TerminalCommandRouter()
-
-    weak var activeStore: TerminalWorkspaceStore?
-
-    func closeFocusedPaneIfSplit() -> Bool {
-        activeStore?.closeFocusedPaneIfSplit() ?? false
-    }
-}
-
-struct TerminalCommandSet {
-    var splitRight: () -> Void
-    var splitDown: () -> Void
-    var closePane: () -> Void
-    var focusNextPane: () -> Void
-    var showSearch: () -> Void
-    var hideSearch: () -> Void
-    var sendInterrupt: () -> Void
-}

--- a/macos/Sources/TermySwift/Models/TerminalRuntimeEvent.swift
+++ b/macos/Sources/TermySwift/Models/TerminalRuntimeEvent.swift
@@ -1,24 +1,59 @@
 import CTermy
 import Foundation
 
+enum TerminalRuntimeEventKind: UInt32 {
+    case wakeup = 1
+    case title = 2
+    case resetTitle = 3
+    case bell = 4
+    case exit = 5
+    case clipboardStore = 6
+    case shellPromptStart = 7
+    case shellCommandStart = 8
+    case shellCommandExecuting = 9
+    case shellCommandFinished = 10
+    case progress = 11
+    case workingDirectory = 12
+}
+
+enum TerminalProgressKind: UInt8 {
+    case clear = 0
+    case inProgress = 1
+    case error = 2
+    case indeterminate = 3
+    case warning = 4
+}
+
+struct TerminalProgressPercent: Equatable {
+    var value: UInt8
+
+    init(_ value: UInt8) {
+        self.value = min(value, 100)
+    }
+
+    var fraction: Double {
+        Double(value) / 100.0
+    }
+}
+
 enum TerminalProgress: Equatable {
     case clear
-    case inProgress(UInt8)
-    case error(UInt8)
+    case inProgress(TerminalProgressPercent)
+    case error(TerminalProgressPercent)
     case indeterminate
-    case warning(UInt8)
+    case warning(TerminalProgressPercent)
 
     init(state: UInt8, value: UInt8) {
-        switch state {
-        case UInt8(TERMY_FFI_PROGRESS_IN_PROGRESS.rawValue):
-            self = .inProgress(value)
-        case UInt8(TERMY_FFI_PROGRESS_ERROR.rawValue):
-            self = .error(value)
-        case UInt8(TERMY_FFI_PROGRESS_INDETERMINATE.rawValue):
+        switch TerminalProgressKind(rawValue: state) {
+        case .inProgress:
+            self = .inProgress(TerminalProgressPercent(value))
+        case .error:
+            self = .error(TerminalProgressPercent(value))
+        case .indeterminate:
             self = .indeterminate
-        case UInt8(TERMY_FFI_PROGRESS_WARNING.rawValue):
-            self = .warning(value)
-        default:
+        case .warning:
+            self = .warning(TerminalProgressPercent(value))
+        case .clear, nil:
             self = .clear
         }
     }
@@ -30,7 +65,7 @@ enum TerminalProgress: Equatable {
     var fraction: Double? {
         switch self {
         case let .inProgress(value), let .error(value), let .warning(value):
-            return Double(value) / 100.0
+            return value.fraction
         case .clear, .indeterminate:
             return nil
         }
@@ -60,36 +95,4 @@ struct TerminalSearchMatch: Identifiable, Equatable {
     var row: Int
     var startCol: Int
     var endCol: Int
-    var line: String
-}
-
-struct TerminalKeyInput: Equatable {
-    var key: String
-    var keyChar: String?
-    var control: Bool
-    var alt: Bool
-    var shift: Bool
-    var platform: Bool
-    var function: Bool
-    var eventKind: UInt32
-
-    init(
-        key: String,
-        keyChar: String? = nil,
-        control: Bool = false,
-        alt: Bool = false,
-        shift: Bool = false,
-        platform: Bool = false,
-        function: Bool = false,
-        eventKind: UInt32 = 1
-    ) {
-        self.key = key
-        self.keyChar = keyChar
-        self.control = control
-        self.alt = alt
-        self.shift = shift
-        self.platform = platform
-        self.function = function
-        self.eventKind = eventKind
-    }
 }

--- a/macos/Sources/TermySwift/Services/LibTermyTerminal.swift
+++ b/macos/Sources/TermySwift/Services/LibTermyTerminal.swift
@@ -2,14 +2,11 @@ import CTermy
 import Foundation
 
 enum LibTermyError: Error, CustomStringConvertible {
-    case ffi(String, TermyFfiStatus)
     case missingTerminal
     case missingCells
 
     var description: String {
         switch self {
-        case let .ffi(operation, status):
-            return "\(operation) failed with status \(status.rawValue)"
         case .missingTerminal:
             return "libtermy did not return a terminal handle"
         case .missingCells:
@@ -22,38 +19,32 @@ final class LibTermyTerminal {
     private var handle: OpaquePointer?
     private var configHandle: OpaquePointer?
 
-    let configSummary: String
     let renderConfig: TerminalRenderConfig
 
     init(cols: UInt16 = 96, rows: UInt16 = 28, loadUserConfig: Bool = true) throws {
         var size = termy_size_default()
         size.cols = cols
         size.rows = rows
-        let startupCommand = Self.startupCommand()
         let config = try loadUserConfig ? Self.loadDefaultConfig() : nil
         configHandle = config
-        configSummary = Self.configSummary(for: config)
         renderConfig = try Self.renderConfig(for: config)
         let workingDirectory = try Self.workingDirectory(for: config)
 
         var terminal: OpaquePointer?
-        let startupCommandBytes = startupCommand ?? []
         let workingDirectoryBytes = workingDirectory.map { Array($0.utf8) } ?? []
-        let status = startupCommandBytes.withUnsafeBufferPointer { startupBuffer in
-            workingDirectoryBytes.withUnsafeBufferPointer { workingDirectoryBuffer in
-                var options = TermyFfiTerminalOptions(
-                    config: config,
-                    working_directory_ptr: workingDirectoryBuffer.baseAddress,
-                    working_directory_len: workingDirectoryBuffer.count,
-                    startup_command_ptr: startupBuffer.baseAddress,
-                    startup_command_len: startupBuffer.count,
-                    env_vars_ptr: nil,
-                    env_vars_len: 0
-                )
-                return termy_terminal_new_with_options(size, &options, &terminal)
-            }
+        let status = workingDirectoryBytes.withUnsafeBufferPointer { workingDirectoryBuffer in
+            var options = TermyFfiTerminalOptions(
+                config: config,
+                working_directory_ptr: workingDirectoryBuffer.baseAddress,
+                working_directory_len: workingDirectoryBuffer.count,
+                startup_command_ptr: nil,
+                startup_command_len: 0,
+                env_vars_ptr: nil,
+                env_vars_len: 0
+            )
+            return termy_terminal_new_with_options(size, &options, &terminal)
         }
-        try Self.requireOK("termy_terminal_new_with_options", status)
+        try TermyFfiBridge.requireOK("termy_terminal_new_with_options", status)
 
         guard let terminal else {
             throw LibTermyError.missingTerminal
@@ -71,19 +62,15 @@ final class LibTermyTerminal {
     }
 
     func write(_ bytes: [UInt8]) throws {
-        guard let handle else {
-            throw LibTermyError.missingTerminal
-        }
+        let handle = try terminalHandle()
         let status = bytes.withUnsafeBufferPointer { buffer in
             termy_terminal_write(handle, buffer.baseAddress, buffer.count)
         }
-        try Self.requireOK("termy_terminal_write", status)
+        try TermyFfiBridge.requireOK("termy_terminal_write", status)
     }
 
     func encodeKey(_ keyInput: TerminalKeyInput) throws -> [UInt8]? {
-        guard let handle else {
-            throw LibTermyError.missingTerminal
-        }
+        let handle = try terminalHandle()
 
         let keyBytes = Array(keyInput.key.utf8)
         let keyCharBytes = keyInput.keyChar.map { Array($0.utf8) } ?? []
@@ -101,12 +88,12 @@ final class LibTermyTerminal {
                     key_len: keyBuffer.count,
                     key_char_ptr: keyCharBuffer.baseAddress,
                     key_char_len: keyCharBuffer.count,
-                    event_kind: keyInput.eventKind
+                    event_kind: keyInput.eventKind.rawValue
                 )
                 return termy_terminal_encode_key(handle, &ffiKeystroke, &outBytes)
             }
         }
-        try Self.requireOK("termy_terminal_encode_key", status)
+        try TermyFfiBridge.requireOK("termy_terminal_encode_key", status)
         defer {
             if outBytes.ptr != nil {
                 _ = termy_buffer_free(outBytes)
@@ -120,49 +107,59 @@ final class LibTermyTerminal {
     }
 
     func resize(cols: UInt16, rows: UInt16, cellWidth: Float, cellHeight: Float) throws {
-        guard let handle else {
-            throw LibTermyError.missingTerminal
-        }
+        let handle = try terminalHandle()
         var size = termy_size_default()
         size.cols = cols
         size.rows = rows
         size.cell_width = cellWidth
         size.cell_height = cellHeight
-        try Self.requireOK("termy_terminal_resize", termy_terminal_resize(handle, size))
+        try TermyFfiBridge.requireOK("termy_terminal_resize", termy_terminal_resize(handle, size))
     }
 
     func scrollDisplay(deltaLines: Int32) throws -> Bool {
-        guard let handle else {
-            throw LibTermyError.missingTerminal
+        try changedBy("termy_terminal_scroll_display") { handle, changed in
+            termy_terminal_scroll_display(handle, deltaLines, changed)
         }
-
-        var changed = false
-        try Self.requireOK(
-            "termy_terminal_scroll_display",
-            termy_terminal_scroll_display(handle, deltaLines, &changed)
-        )
-        return changed
     }
 
     func scrollToBottom() throws -> Bool {
-        guard let handle else {
-            throw LibTermyError.missingTerminal
+        try changedBy("termy_terminal_scroll_to_bottom") { handle, changed in
+            termy_terminal_scroll_to_bottom(handle, changed)
         }
+    }
 
-        var changed = false
-        try Self.requireOK(
-            "termy_terminal_scroll_to_bottom",
-            termy_terminal_scroll_to_bottom(handle, &changed)
+    /// Reload the terminal's theme palette from the on-disk config so existing
+    /// cells recolor on the next snapshot.
+    func reloadColors() throws {
+        let handle = try terminalHandle()
+        try TermyFfiBridge.requireOK(
+            "termy_terminal_reload_default_config_colors",
+            termy_terminal_reload_default_config_colors(handle)
         )
-        return changed
+    }
+
+    /// Load a fresh render config (font, metrics, colors, padding) from the
+    /// on-disk config without touching any running terminal.
+    static func loadRenderConfig() throws -> TerminalRenderConfig {
+        let config = try loadDefaultConfig()
+        defer {
+            if let config {
+                _ = termy_config_free(config)
+            }
+        }
+        return try renderConfig(for: config)
+    }
+
+    func clearScrollback() throws -> Bool {
+        try changedBy("termy_terminal_clear_scrollback") { handle, changed in
+            termy_terminal_clear_scrollback(handle, changed)
+        }
     }
 
     func drainEvents() throws -> [TerminalRuntimeEvent] {
-        guard let handle else {
-            throw LibTermyError.missingTerminal
-        }
+        let handle = try terminalHandle()
         var batch = TermyFfiEventBatch()
-        try Self.requireOK(
+        try TermyFfiBridge.requireOK(
             "termy_terminal_drain_events",
             termy_terminal_drain_events(handle, &batch)
         )
@@ -178,12 +175,10 @@ final class LibTermyTerminal {
     }
 
     func takeDamage() throws -> Bool {
-        guard let handle else {
-            throw LibTermyError.missingTerminal
-        }
+        let handle = try terminalHandle()
 
         var damage = TermyFfiDamage()
-        try Self.requireOK(
+        try TermyFfiBridge.requireOK(
             "termy_terminal_take_damage",
             termy_terminal_take_damage(handle, &damage)
         )
@@ -193,12 +188,10 @@ final class LibTermyTerminal {
     }
 
     func snapshot() throws -> TerminalFrame {
-        guard let handle else {
-            throw LibTermyError.missingTerminal
-        }
+        let handle = try terminalHandle()
 
         var frame = TermyFfiFrame()
-        try Self.requireOK("termy_terminal_snapshot", termy_terminal_snapshot(handle, &frame))
+        try TermyFfiBridge.requireOK("termy_terminal_snapshot", termy_terminal_snapshot(handle, &frame))
         defer {
             _ = termy_frame_free(&frame)
         }
@@ -213,7 +206,7 @@ final class LibTermyTerminal {
             ? TerminalCursor(
                 col: Int(frame.cursor.col),
                 row: Int(frame.cursor.row),
-                style: frame.cursor.style
+                style: TerminalCursorStyle(ffiRawValue: frame.cursor.style)
             )
             : nil
 
@@ -228,15 +221,13 @@ final class LibTermyTerminal {
     }
 
     func search(_ query: String) throws -> [TerminalSearchMatch] {
-        guard let handle else {
-            throw LibTermyError.missingTerminal
-        }
+        let handle = try terminalHandle()
 
         var batch = TermyFfiSearchBatch()
         let status = Array(query.utf8).withUnsafeBufferPointer { buffer in
             termy_terminal_search(handle, buffer.baseAddress, buffer.count, &batch)
         }
-        try Self.requireOK("termy_terminal_search", status)
+        try TermyFfiBridge.requireOK("termy_terminal_search", status)
         defer {
             _ = termy_search_batch_free(&batch)
         }
@@ -249,42 +240,32 @@ final class LibTermyTerminal {
                 TerminalSearchMatch(
                     row: Int(match.row),
                     startCol: Int(match.start_col),
-                    endCol: Int(match.end_col),
-                    line: Self.string(from: match.line) ?? ""
+                    endCol: Int(match.end_col)
                 )
             }
     }
 
-    private static func requireOK(_ operation: String, _ status: TermyFfiStatus) throws {
-        guard status == TERMY_FFI_OK else {
-            throw LibTermyError.ffi(operation, status)
+    private func terminalHandle() throws -> OpaquePointer {
+        guard let handle else {
+            throw LibTermyError.missingTerminal
         }
+        return handle
+    }
+
+    private func changedBy(
+        _ operation: String,
+        _ call: (OpaquePointer, UnsafeMutablePointer<Bool>) -> TermyFfiStatus
+    ) throws -> Bool {
+        let handle = try terminalHandle()
+        var changed = false
+        try TermyFfiBridge.requireOK(operation, call(handle, &changed))
+        return changed
     }
 
     private static func loadDefaultConfig() throws -> OpaquePointer? {
         var config: OpaquePointer?
-        try requireOK("termy_config_load_default", termy_config_load_default(&config))
+        try TermyFfiBridge.requireOK("termy_config_load_default", termy_config_load_default(&config))
         return config
-    }
-
-    private static func startupCommand() -> [UInt8]? {
-        if ProcessInfo.processInfo.environment["TERMY_SWIFT_EXAMPLE_EXIT_AFTER_RENDER"] == "1" {
-            return Array("printf 'libtermy SwiftUI smoke\\n'".utf8)
-        }
-        return nil
-    }
-
-    private static func configSummary(for config: OpaquePointer?) -> String {
-        guard let config else {
-            return "config: off"
-        }
-
-        let diagnostics = Int(termy_config_diagnostic_count(config))
-        let suffix = diagnostics == 0 ? "" : " (\(diagnostics) diagnostics)"
-        if termy_config_loaded_from_disk(config) {
-            return "config: loaded\(suffix)"
-        }
-        return "config: defaults\(suffix)"
     }
 
     private static func renderConfig(for config: OpaquePointer?) throws -> TerminalRenderConfig {
@@ -293,7 +274,7 @@ final class LibTermyTerminal {
         }
 
         var renderConfig = TermyFfiRenderConfig()
-        try requireOK(
+        try TermyFfiBridge.requireOK(
             "termy_config_render_config",
             termy_config_render_config(config, &renderConfig)
         )
@@ -309,7 +290,7 @@ final class LibTermyTerminal {
         }
 
         var bytes = TermyFfiBytes()
-        try requireOK(
+        try TermyFfiBridge.requireOK(
             "termy_config_working_directory",
             termy_config_working_directory(config, &bytes)
         )
@@ -319,46 +300,46 @@ final class LibTermyTerminal {
             }
         }
 
-        guard let ptr = bytes.ptr, bytes.len > 0 else {
+        guard bytes.ptr != nil, bytes.len > 0 else {
             return nil
         }
-        let buffer = UnsafeBufferPointer(start: ptr, count: Int(bytes.len))
-        let value = String(decoding: buffer, as: UTF8.self)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let value = TermyFfiBridge.string(from: bytes, trimmingWhitespaceAndNewlines: true) ?? ""
         return value.isEmpty ? nil : value
     }
 
     private static func event(from event: TermyFfiEvent) -> TerminalRuntimeEvent? {
-        switch event.kind {
-        case UInt32(TERMY_FFI_EVENT_WAKEUP.rawValue):
+        guard let eventKind = TerminalRuntimeEventKind(rawValue: event.kind) else {
+            return nil
+        }
+
+        switch eventKind {
+        case .wakeup:
             return .wakeup
-        case UInt32(TERMY_FFI_EVENT_TITLE.rawValue):
-            return .title(string(from: event.payload) ?? "")
-        case UInt32(TERMY_FFI_EVENT_RESET_TITLE.rawValue):
+        case .title:
+            return .title(TermyFfiBridge.string(from: event.payload) ?? "")
+        case .resetTitle:
             return .resetTitle
-        case UInt32(TERMY_FFI_EVENT_BELL.rawValue):
+        case .bell:
             return .bell
-        case UInt32(TERMY_FFI_EVENT_EXIT.rawValue):
+        case .exit:
             return .exit
-        case UInt32(TERMY_FFI_EVENT_CLIPBOARD_STORE.rawValue):
-            return .clipboardStore(string(from: event.payload) ?? "")
-        case UInt32(TERMY_FFI_EVENT_SHELL_PROMPT_START.rawValue):
+        case .clipboardStore:
+            return .clipboardStore(TermyFfiBridge.string(from: event.payload) ?? "")
+        case .shellPromptStart:
             return .shellPromptStart
-        case UInt32(TERMY_FFI_EVENT_SHELL_COMMAND_START.rawValue):
+        case .shellCommandStart:
             return .shellCommandStart
-        case UInt32(TERMY_FFI_EVENT_SHELL_COMMAND_EXECUTING.rawValue):
+        case .shellCommandExecuting:
             return .shellCommandExecuting
-        case UInt32(TERMY_FFI_EVENT_SHELL_COMMAND_FINISHED.rawValue):
+        case .shellCommandFinished:
             return .shellCommandFinished(event.exit_code >= 0 ? event.exit_code : nil)
-        case UInt32(TERMY_FFI_EVENT_PROGRESS.rawValue):
+        case .progress:
             return .progress(TerminalProgress(
                 state: event.progress_state,
                 value: event.progress_value
             ))
-        case UInt32(TERMY_FFI_EVENT_WORKING_DIRECTORY.rawValue):
-            return .workingDirectory(string(from: event.payload) ?? "")
-        default:
-            return nil
+        case .workingDirectory:
+            return .workingDirectory(TermyFfiBridge.string(from: event.payload) ?? "")
         }
     }
 
@@ -379,11 +360,4 @@ final class LibTermyTerminal {
         UnicodeScalar(codepoint).map(Character.init) ?? " "
     }
 
-    private static func string(from bytes: TermyFfiBytes) -> String? {
-        guard let ptr = bytes.ptr, bytes.len > 0 else {
-            return nil
-        }
-        let buffer = UnsafeBufferPointer(start: ptr, count: Int(bytes.len))
-        return String(decoding: buffer, as: UTF8.self)
-    }
 }

--- a/macos/Sources/TermySwift/Services/SettingsBridge.swift
+++ b/macos/Sources/TermySwift/Services/SettingsBridge.swift
@@ -1,0 +1,83 @@
+import CTermy
+import Foundation
+
+/// Thin wrapper over the libtermy settings C functions. All writes target the
+/// shared config file at `~/.config/termy/config.txt` and preserve comments and
+/// formatting (the Rust side does surgical edits).
+enum SettingsBridge {
+    enum BridgeError: Error, CustomStringConvertible {
+        case decode(String)
+
+        var description: String {
+            switch self {
+            case let .decode(message):
+                return message
+            }
+        }
+    }
+
+    static func loadSchema() throws -> SettingsSchema {
+        var config: OpaquePointer?
+        try TermyFfiBridge.requireOK("termy_config_load_default", termy_config_load_default(&config))
+        defer {
+            if let config {
+                _ = termy_config_free(config)
+            }
+        }
+
+        var bytes = TermyFfiBytes()
+        try TermyFfiBridge.requireOK("termy_settings_schema_json", termy_settings_schema_json(config, &bytes))
+        defer {
+            if bytes.ptr != nil {
+                _ = termy_buffer_free(bytes)
+            }
+        }
+
+        guard let ptr = bytes.ptr, bytes.len > 0 else {
+            throw BridgeError.decode("settings schema was empty")
+        }
+        let data = Data(bytes: ptr, count: Int(bytes.len))
+        return try JSONDecoder().decode(SettingsSchema.self, from: data)
+    }
+
+    static func setRoot(key: String, value: String) throws {
+        let keyBytes = Array(key.utf8)
+        let valueBytes = Array(value.utf8)
+        let status = keyBytes.withUnsafeBufferPointer { keyBuffer in
+            valueBytes.withUnsafeBufferPointer { valueBuffer in
+                termy_settings_set_root(
+                    keyBuffer.baseAddress,
+                    keyBuffer.count,
+                    valueBuffer.baseAddress,
+                    valueBuffer.count
+                )
+            }
+        }
+        try TermyFfiBridge.requireOK("termy_settings_set_root", status)
+    }
+
+    /// Pass `hex == nil` to clear the override and inherit the theme color.
+    static func setColor(key: String, hex: String?) throws {
+        let keyBytes = Array(key.utf8)
+        let hexBytes = hex.map { Array($0.utf8) } ?? []
+        let status = keyBytes.withUnsafeBufferPointer { keyBuffer in
+            hexBytes.withUnsafeBufferPointer { hexBuffer in
+                termy_settings_set_color(
+                    keyBuffer.baseAddress,
+                    keyBuffer.count,
+                    hex == nil ? nil : hexBuffer.baseAddress,
+                    hex == nil ? 0 : hexBuffer.count
+                )
+            }
+        }
+        try TermyFfiBridge.requireOK("termy_settings_set_color", status)
+    }
+
+    static func setKeybinds(_ text: String) throws {
+        let textBytes = Array(text.utf8)
+        let status = textBytes.withUnsafeBufferPointer { textBuffer in
+            termy_settings_set_keybinds(textBuffer.baseAddress, textBuffer.count)
+        }
+        try TermyFfiBridge.requireOK("termy_settings_set_keybinds", status)
+    }
+}

--- a/macos/Sources/TermySwift/Services/SettingsStore.swift
+++ b/macos/Sources/TermySwift/Services/SettingsStore.swift
@@ -1,0 +1,107 @@
+import SwiftUI
+
+@MainActor
+final class SettingsStore: ObservableObject {
+    @Published private(set) var schema: SettingsSchema?
+    @Published var errorMessage: String?
+
+    /// Canonical current values, keyed by setting key. Edited optimistically and
+    /// written straight through to the config file via `SettingsBridge`.
+    @Published private(set) var values: [String: String] = [:]
+    /// Color overrides keyed by color key. Empty string means "inherit theme".
+    @Published private(set) var colors: [String: String] = [:]
+    @Published var keybindsText: String = ""
+
+    func load() {
+        do {
+            let schema = try SettingsBridge.loadSchema()
+            var values: [String: String] = [:]
+            var colors: [String: String] = [:]
+            for section in schema.sections {
+                for group in section.groups ?? [] {
+                    for setting in group.settings {
+                        values[setting.key] = setting.value ?? ""
+                    }
+                }
+                for color in section.colors ?? [] {
+                    colors[color.key] = color.hex ?? ""
+                }
+                if let keybinds = section.keybinds {
+                    keybindsText = keybinds.joined(separator: "\n")
+                }
+            }
+            self.values = values
+            self.colors = colors
+            self.schema = schema
+            errorMessage = nil
+        } catch {
+            report(error)
+        }
+    }
+
+    func section(id: String?) -> SettingsSectionModel? {
+        guard let id else {
+            return nil
+        }
+        return schema?.sections.first { $0.id == id }
+    }
+
+    func value(for key: String) -> String {
+        values[key] ?? ""
+    }
+
+    func commitRoot(key: String, value: String) {
+        values[key] = value
+        commit {
+            try SettingsBridge.setRoot(key: key, value: value)
+        }
+    }
+
+    func boolBinding(_ key: String) -> Binding<Bool> {
+        Binding(
+            get: { self.values[key] == "true" },
+            set: { self.commitRoot(key: key, value: $0 ? "true" : "false") }
+        )
+    }
+
+    func enumBinding(_ key: String) -> Binding<String> {
+        Binding(
+            get: { self.values[key] ?? "" },
+            set: { self.commitRoot(key: key, value: $0) }
+        )
+    }
+
+    func colorHex(for key: String) -> String {
+        colors[key] ?? ""
+    }
+
+    func commitColor(key: String, hex: String?) {
+        colors[key] = hex ?? ""
+        commit {
+            try SettingsBridge.setColor(key: key, hex: hex)
+        }
+    }
+
+    func commitKeybinds() {
+        commit {
+            try SettingsBridge.setKeybinds(keybindsText)
+        }
+    }
+
+    private func commit(_ write: () throws -> Void) {
+        do {
+            try write()
+            notifyChanged()
+        } catch {
+            report(error)
+        }
+    }
+
+    private func notifyChanged() {
+        NotificationCenter.default.post(name: .termySettingsChanged, object: nil)
+    }
+
+    private func report(_ error: Error) {
+        errorMessage = String(describing: error)
+    }
+}

--- a/macos/Sources/TermySwift/Services/TerminalViewModel.swift
+++ b/macos/Sources/TermySwift/Services/TerminalViewModel.swift
@@ -5,13 +5,10 @@ import Foundation
 final class TerminalViewModel: ObservableObject {
     @Published private(set) var frame: TerminalFrame = .empty
     @Published private(set) var errorMessage: String?
-    @Published private(set) var configSummary = "config: loading"
     @Published private(set) var renderConfig = TerminalRenderConfig.default
     @Published private(set) var title = "Shell"
     @Published private(set) var progress = TerminalProgress.clear
-    @Published private(set) var workingDirectory: String?
     @Published private(set) var isExited = false
-    @Published private(set) var lastEvents: [TerminalRuntimeEvent] = []
     @Published private(set) var searchMatches: [TerminalSearchMatch] = []
     @Published private(set) var activeSearchMatchIndex = 0
     @Published var selection: TerminalSelection?
@@ -19,9 +16,7 @@ final class TerminalViewModel: ObservableObject {
     private var terminal: LibTermyTerminal?
     private var timer: Timer?
     private var lastResize: TerminalResize?
-    private var shouldExitAfterFirstRender: Bool {
-        ProcessInfo.processInfo.environment["TERMY_SWIFT_EXAMPLE_EXIT_AFTER_RENDER"] == "1"
-    }
+    private var settingsObserver: NSObjectProtocol?
 
     func start() {
         guard terminal == nil else {
@@ -31,7 +26,6 @@ final class TerminalViewModel: ObservableObject {
         do {
             let terminal = try LibTermyTerminal()
             self.terminal = terminal
-            configSummary = terminal.configSummary
             renderConfig = terminal.renderConfig
             isExited = false
             refresh(force: true)
@@ -41,17 +35,43 @@ final class TerminalViewModel: ObservableObject {
                     self?.refresh()
                 }
             }
+            settingsObserver = NotificationCenter.default.addObserver(
+                forName: .termySettingsChanged,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor in
+                    self?.reloadAppearance()
+                }
+            }
         } catch {
-            errorMessage = String(describing: error)
+            report(error)
         }
     }
 
     func stop() {
         timer?.invalidate()
         timer = nil
+        if let settingsObserver {
+            NotificationCenter.default.removeObserver(settingsObserver)
+            self.settingsObserver = nil
+        }
         terminal = nil
         isExited = true
         progress = .clear
+    }
+
+    /// Re-read appearance settings from the config file and apply them to this
+    /// live terminal: refreshed render config (font/metrics/padding/opacity) and
+    /// reloaded theme palette so existing cells recolor.
+    private func reloadAppearance() {
+        do {
+            renderConfig = try LibTermyTerminal.loadRenderConfig()
+            try terminal?.reloadColors()
+            refresh(force: true)
+        } catch {
+            report(error)
+        }
     }
 
     func sendControlC() {
@@ -65,7 +85,7 @@ final class TerminalViewModel: ObservableObject {
             }
             send(bytes: bytes)
         } catch {
-            errorMessage = String(describing: error)
+            report(error)
         }
     }
 
@@ -82,7 +102,7 @@ final class TerminalViewModel: ObservableObject {
             try terminal?.write(bytes)
             refresh(force: true)
         } catch {
-            errorMessage = String(describing: error)
+            report(error)
         }
     }
 
@@ -92,28 +112,30 @@ final class TerminalViewModel: ObservableObject {
         }
 
         let clampedDelta = max(Int(Int32.min), min(Int(Int32.max), deltaLines))
-        do {
-            if try terminal?.scrollDisplay(deltaLines: Int32(clampedDelta)) == true {
-                refresh(force: true)
-            }
-        } catch {
-            errorMessage = String(describing: error)
+        refreshIfChanged {
+            try terminal?.scrollDisplay(deltaLines: Int32(clampedDelta)) == true
         }
     }
 
     func scrollToBottom() {
-        do {
-            if try terminal?.scrollToBottom() == true {
-                refresh(force: true)
-            }
-        } catch {
-            errorMessage = String(describing: error)
+        refreshIfChanged {
+            try terminal?.scrollToBottom() == true
         }
     }
 
     func scrollToDisplayOffset(_ offset: Int) {
         let targetOffset = max(0, min(offset, frame.historySize))
         scrollDisplay(deltaLines: targetOffset - frame.displayOffset)
+    }
+
+    func scrollToTop() {
+        scrollToDisplayOffset(frame.historySize)
+    }
+
+    func clearScrollback() {
+        refreshIfChanged {
+            try terminal?.clearScrollback() == true
+        }
     }
 
     func updateSelection(_ selection: TerminalSelection?) {
@@ -134,7 +156,7 @@ final class TerminalViewModel: ObservableObject {
         do {
             return try terminal?.search(query) ?? []
         } catch {
-            errorMessage = String(describing: error)
+            report(error)
             return []
         }
     }
@@ -189,7 +211,7 @@ final class TerminalViewModel: ObservableObject {
             )
             refresh(force: true)
         } catch {
-            errorMessage = String(describing: error)
+            report(error)
         }
     }
 
@@ -206,11 +228,24 @@ final class TerminalViewModel: ObservableObject {
             if let nextFrame = try terminal?.snapshot() {
                 frame = nextFrame
                 errorMessage = nil
-                terminateForSmokeTestIfNeeded(nextFrame)
             }
         } catch {
-            errorMessage = String(describing: error)
+            report(error)
         }
+    }
+
+    private func refreshIfChanged(_ operation: () throws -> Bool) {
+        do {
+            if try operation() {
+                refresh(force: true)
+            }
+        } catch {
+            report(error)
+        }
+    }
+
+    private func report(_ error: Error) {
+        errorMessage = String(describing: error)
     }
 
     private func handle(_ events: [TerminalRuntimeEvent]) {
@@ -218,7 +253,6 @@ final class TerminalViewModel: ObservableObject {
             return
         }
 
-        lastEvents = events
         for event in events {
             switch event {
             case .title(let title):
@@ -232,33 +266,19 @@ final class TerminalViewModel: ObservableObject {
                 progress = .clear
             case .progress(let progress):
                 self.progress = progress
-            case .workingDirectory(let path):
-                workingDirectory = path.isEmpty ? nil : path
             case .wakeup,
                  .bell,
                  .clipboardStore(_),
                  .shellPromptStart,
                  .shellCommandStart,
                  .shellCommandExecuting,
-                 .shellCommandFinished(_):
+                 .shellCommandFinished(_),
+                 .workingDirectory(_):
                 break
             }
         }
     }
 
-    private func terminateForSmokeTestIfNeeded(_ frame: TerminalFrame) {
-        guard shouldExitAfterFirstRender else {
-            return
-        }
-        let hasText = frame.cells.contains { $0.renderText && $0.character != " " }
-        guard hasText else {
-            return
-        }
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-            NSApp.terminate(nil)
-        }
-    }
 }
 
 private struct TerminalResize: Equatable {

--- a/macos/Sources/TermySwift/Services/TermyAppConfiguration.swift
+++ b/macos/Sources/TermySwift/Services/TermyAppConfiguration.swift
@@ -2,60 +2,73 @@ import CTermy
 import CoreGraphics
 import Foundation
 
+enum TermyAppConfigurationError: Error, CustomStringConvertible {
+    case missingConfig
+
+    var description: String {
+        switch self {
+        case .missingConfig:
+            return "libtermy did not return a config handle"
+        }
+    }
+}
+
 struct TermyAppConfiguration {
     var windowWidth: CGFloat
     var windowHeight: CGFloat
-    var workingDirectory: String?
 
     var windowSize: CGSize {
         CGSize(width: windowWidth, height: windowHeight)
     }
 
-    static let current = load()
-
-    static let fallback = TermyAppConfiguration(
+    private static let defaultConfiguration = TermyAppConfiguration(
         windowWidth: 1280,
-        windowHeight: 820,
-        workingDirectory: nil
+        windowHeight: 820
     )
 
-    private static func load() -> TermyAppConfiguration {
+    private static let loadedConfiguration = Result {
+        try load()
+    }
+
+    static let current: TermyAppConfiguration = {
+        switch loadedConfiguration {
+        case .success(let configuration):
+            return configuration
+        case .failure:
+            return defaultConfiguration
+        }
+    }()
+
+    static let loadErrorMessage: String? = {
+        switch loadedConfiguration {
+        case .success:
+            return nil
+        case .failure(let error):
+            return String(describing: error)
+        }
+    }()
+
+    private static func load() throws -> TermyAppConfiguration {
         var config: OpaquePointer?
-        guard termy_config_load_default(&config) == TERMY_FFI_OK, let config else {
-            return .fallback
+        try TermyFfiBridge.requireOK("termy_config_load_default", termy_config_load_default(&config))
+        guard let config else {
+            throw TermyAppConfigurationError.missingConfig
         }
         defer {
             _ = termy_config_free(config)
         }
 
-        var width: Float = Float(fallback.windowWidth)
-        var height: Float = Float(fallback.windowHeight)
-        _ = termy_config_window_size(config, &width, &height)
+        var width: Float = Float(defaultConfiguration.windowWidth)
+        var height: Float = Float(defaultConfiguration.windowHeight)
+        try TermyFfiBridge.requireOK(
+            "termy_config_window_size",
+            termy_config_window_size(config, &width, &height)
+        )
 
         return TermyAppConfiguration(
             windowWidth: CGFloat(max(320, width)),
-            windowHeight: CGFloat(max(240, height)),
-            workingDirectory: workingDirectory(from: config)
+            windowHeight: CGFloat(max(240, height))
         )
     }
 
-    private static func workingDirectory(from config: OpaquePointer) -> String? {
-        var bytes = TermyFfiBytes()
-        guard termy_config_working_directory(config, &bytes) == TERMY_FFI_OK else {
-            return nil
-        }
-        defer {
-            if bytes.ptr != nil {
-                _ = termy_buffer_free(bytes)
-            }
-        }
-
-        guard let ptr = bytes.ptr, bytes.len > 0 else {
-            return nil
-        }
-        let buffer = UnsafeBufferPointer(start: ptr, count: Int(bytes.len))
-        let value = String(decoding: buffer, as: UTF8.self)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
-    }
 }

--- a/macos/Sources/TermySwift/Support/TerminalCommandRouting.swift
+++ b/macos/Sources/TermySwift/Support/TerminalCommandRouting.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+@MainActor
+final class TerminalCommandRouter {
+    static let shared = TerminalCommandRouter()
+
+    weak var activeStore: TerminalWorkspaceStore?
+
+    func closeFocusedPaneIfSplit() -> Bool {
+        activeStore?.closeFocusedPaneIfSplit() ?? false
+    }
+}
+
+struct TerminalCommandSet {
+    var splitRight: () -> Void
+    var splitDown: () -> Void
+    var closePane: () -> Void
+    var focusNextPane: () -> Void
+    var showSearch: () -> Void
+    var hideSearch: () -> Void
+    var sendInterrupt: () -> Void
+}

--- a/macos/Sources/TermySwift/Support/TermyFfiBridge.swift
+++ b/macos/Sources/TermySwift/Support/TermyFfiBridge.swift
@@ -1,0 +1,34 @@
+import CTermy
+import Foundation
+
+enum TermyFfiError: Error, CustomStringConvertible {
+    case ffi(String, TermyFfiStatus)
+
+    var description: String {
+        switch self {
+        case let .ffi(operation, status):
+            return "\(operation) failed with status \(status.rawValue)"
+        }
+    }
+}
+
+enum TermyFfiBridge {
+    static func requireOK(_ operation: String, _ status: TermyFfiStatus) throws {
+        guard status == TERMY_FFI_OK else {
+            throw TermyFfiError.ffi(operation, status)
+        }
+    }
+
+    static func string(
+        from bytes: TermyFfiBytes,
+        trimmingWhitespaceAndNewlines shouldTrim: Bool = false
+    ) -> String? {
+        guard let ptr = bytes.ptr, bytes.len > 0 else {
+            return nil
+        }
+
+        let buffer = UnsafeBufferPointer(start: ptr, count: Int(bytes.len))
+        let value = String(decoding: buffer, as: UTF8.self)
+        return shouldTrim ? value.trimmingCharacters(in: .whitespacesAndNewlines) : value
+    }
+}

--- a/macos/Sources/TermySwift/Support/TermyNotifications.swift
+++ b/macos/Sources/TermySwift/Support/TermyNotifications.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+/// Posted whenever a setting is written to disk so open terminals can live-apply
+/// appearance changes.
+extension Notification.Name {
+    static let termySettingsChanged = Notification.Name("TermySettingsChanged")
+}

--- a/macos/Sources/TermySwift/Views/Settings/SettingsRootView.swift
+++ b/macos/Sources/TermySwift/Views/Settings/SettingsRootView.swift
@@ -1,0 +1,372 @@
+import AppKit
+import SwiftUI
+
+struct SettingsRootView: View {
+    @StateObject private var store = SettingsStore()
+    @State private var selection: String?
+
+    var body: some View {
+        NavigationSplitView {
+            List(selection: $selection) {
+                ForEach(store.schema?.sections ?? []) { section in
+                    Label(section.label, systemImage: section.systemImage)
+                        .tag(section.id as String?)
+                }
+            }
+            .navigationSplitViewColumnWidth(min: 200, ideal: 214, max: 260)
+            .listStyle(.sidebar)
+            .safeAreaInset(edge: .bottom) {
+                HStack(alignment: .top, spacing: 6) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.yellow)
+                    Text("Some settings may require a new terminal or app restart to take effect.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .padding(10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(.bar)
+            }
+        } detail: {
+            Group {
+                if let section = store.section(id: selection) {
+                    SettingsSectionView(section: section, store: store)
+                } else {
+                    ContentUnavailableView(
+                        "Settings",
+                        systemImage: "gearshape",
+                        description: Text("Select a category.")
+                    )
+                }
+            }
+            .frame(minWidth: 480, maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .frame(minWidth: 760, minHeight: 520)
+        .onAppear {
+            store.load()
+            if selection == nil {
+                selection = store.schema?.sections.first?.id
+            }
+        }
+        .alert(
+            "Settings Error",
+            isPresented: Binding(
+                get: { store.errorMessage != nil },
+                set: { if !$0 { store.errorMessage = nil } }
+            )
+        ) {
+            Button("OK", role: .cancel) { store.errorMessage = nil }
+        } message: {
+            Text(store.errorMessage ?? "")
+        }
+    }
+}
+
+private struct SettingsSectionView: View {
+    let section: SettingsSectionModel
+    @ObservedObject var store: SettingsStore
+
+    var body: some View {
+        Form {
+            if let colors = section.colors {
+                ColorSettingsContent(colors: colors, store: store)
+            } else if section.keybinds != nil {
+                KeybindSettingsContent(store: store)
+            } else {
+                ForEach(section.groups ?? []) { group in
+                    Section(group.label) {
+                        ForEach(group.settings) { setting in
+                            SettingRow(setting: setting, store: store)
+                        }
+                    }
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .navigationTitle(section.label)
+    }
+}
+
+// MARK: - Generic root setting row
+
+private struct SettingRow: View {
+    let setting: Setting
+    @ObservedObject var store: SettingsStore
+
+    var body: some View {
+        switch setting.kind {
+        case .boolean:
+            Toggle(isOn: store.boolBinding(setting.key)) {
+                SettingLabelView(setting: setting)
+            }
+        case .enumeration:
+            Picker(selection: store.enumBinding(setting.key)) {
+                ForEach(setting.choices ?? []) { choice in
+                    Text(choice.label).tag(choice.value)
+                }
+            } label: {
+                SettingLabelView(setting: setting)
+            }
+        case .numeric:
+            NumericSettingRow(setting: setting, store: store)
+        case .text, .special:
+            CommittingTextFieldRow(setting: setting, store: store, maxWidth: 240)
+        }
+    }
+}
+
+private struct SettingLabelView: View {
+    let title: String
+    let description: String
+
+    init(setting: Setting) {
+        title = setting.title
+        description = setting.description
+    }
+
+    init(color: ColorSetting) {
+        title = color.title
+        description = color.description
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+            Text(description)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+private struct NumericSettingRow: View {
+    let setting: Setting
+    @ObservedObject var store: SettingsStore
+
+    var body: some View {
+        if let range = Self.sliderRange(for: setting.key) {
+            LabeledContent {
+                HStack(spacing: 10) {
+                    Slider(
+                        value: Binding(
+                            get: { Double(store.value(for: setting.key)) ?? range.lowerBound },
+                            set: { store.commitRoot(key: setting.key, value: Self.format($0)) }
+                        ),
+                        in: range,
+                        step: Self.step(for: setting.key)
+                    )
+                    .frame(width: 180)
+                    Text(store.value(for: setting.key))
+                        .font(.system(.body, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 48, alignment: .trailing)
+                }
+            } label: {
+                SettingLabelView(setting: setting)
+            }
+        } else {
+            CommittingTextFieldRow(setting: setting, store: store, maxWidth: 120)
+        }
+    }
+
+    private static func sliderRange(for key: String) -> ClosedRange<Double>? {
+        switch key {
+        case "background_opacity":
+            return 0...1
+        case "pane_focus_strength":
+            return 0...2
+        case "line_height":
+            return 0.8...2.5
+        case "mouse_scroll_multiplier":
+            return 0.1...10
+        default:
+            return nil
+        }
+    }
+
+    private static func step(for key: String) -> Double {
+        key == "mouse_scroll_multiplier" ? 0.1 : 0.05
+    }
+
+    private static func format(_ value: Double) -> String {
+        String(format: "%.2f", value)
+    }
+}
+
+private struct CommittingTextFieldRow: View {
+    let setting: Setting
+    @ObservedObject var store: SettingsStore
+    let maxWidth: CGFloat
+
+    @State private var text: String = ""
+    @FocusState private var focused: Bool
+
+    var body: some View {
+        LabeledContent {
+            TextField(setting.title, text: $text)
+                .textFieldStyle(.roundedBorder)
+                .frame(maxWidth: maxWidth)
+                .focused($focused)
+                .onSubmit(commit)
+                .onChange(of: focused) { _, isFocused in
+                    if !isFocused {
+                        commit()
+                    }
+                }
+        } label: {
+            SettingLabelView(setting: setting)
+        }
+        .onAppear {
+            text = store.value(for: setting.key)
+        }
+        .onChange(of: store.value(for: setting.key)) { _, newValue in
+            if !focused {
+                text = newValue
+            }
+        }
+    }
+
+    private func commit() {
+        store.commitRoot(key: setting.key, value: text)
+    }
+}
+
+// MARK: - Colors
+
+private struct ColorSettingsContent: View {
+    let colors: [ColorSetting]
+    @ObservedObject var store: SettingsStore
+
+    var body: some View {
+        Section("Base") {
+            ForEach(colors.prefix(3)) { color in
+                ColorRow(color: color, store: store)
+            }
+        }
+        Section("ANSI Palette") {
+            ForEach(colors.dropFirst(3)) { color in
+                ColorRow(color: color, store: store)
+            }
+        }
+    }
+}
+
+private struct ColorRow: View {
+    let color: ColorSetting
+    @ObservedObject var store: SettingsStore
+
+    var body: some View {
+        LabeledContent {
+            HStack(spacing: 10) {
+                ColorPicker("", selection: pickerBinding, supportsOpacity: false)
+                    .labelsHidden()
+                if !store.colorHex(for: color.key).isEmpty {
+                    Button("Reset") {
+                        store.commitColor(key: color.key, hex: nil)
+                    }
+                    .buttonStyle(.borderless)
+                    .font(.caption)
+                } else {
+                    Text("theme")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        } label: {
+            SettingLabelView(color: color)
+        }
+    }
+
+    private var pickerBinding: Binding<Color> {
+        Binding(
+            get: { Color(hex: store.colorHex(for: color.key)) ?? Color(white: 0.5) },
+            set: { newColor in
+                if let hex = newColor.hexString {
+                    store.commitColor(key: color.key, hex: hex)
+                }
+            }
+        )
+    }
+}
+
+// MARK: - Keybindings
+
+private struct KeybindSettingsContent: View {
+    @ObservedObject var store: SettingsStore
+
+    var body: some View {
+        Section("Keybind Directives") {
+            Text("One directive per line, e.g. `cmd-k=clear_buffer`. These are written verbatim as `keybind = …` lines.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            TextEditor(text: $store.keybindsText)
+                .font(.system(.body, design: .monospaced))
+                .frame(minHeight: 220)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(Color.secondary.opacity(0.25), lineWidth: 1)
+                )
+
+            HStack {
+                Spacer()
+                Button("Apply Keybinds") {
+                    store.commitKeybinds()
+                }
+                .keyboardShortcut("s", modifiers: [.command])
+            }
+        }
+    }
+}
+
+// MARK: - Color hex helpers
+
+extension Color {
+    init?(hex: String) {
+        guard let rgb = RGBHexColor(hex: hex) else {
+            return nil
+        }
+        self = Color(
+            red: rgb.red,
+            green: rgb.green,
+            blue: rgb.blue
+        )
+    }
+
+    var hexString: String? {
+        guard let srgb = NSColor(self).usingColorSpace(.sRGB) else {
+            return nil
+        }
+        let r = Int((srgb.redComponent * 255).rounded())
+        let g = Int((srgb.greenComponent * 255).rounded())
+        let b = Int((srgb.blueComponent * 255).rounded())
+        return String(format: "#%02x%02x%02x", r, g, b)
+    }
+}
+
+private struct RGBHexColor {
+    var red: Double
+    var green: Double
+    var blue: Double
+
+    init?(hex: String) {
+        var value = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else {
+            return nil
+        }
+        if value.hasPrefix("#") {
+            value.removeFirst()
+        }
+        guard value.count == 6, let packed = Int(value, radix: 16) else {
+            return nil
+        }
+        red = Self.component(packed >> 16)
+        green = Self.component(packed >> 8)
+        blue = Self.component(packed)
+    }
+
+    private static func component(_ packedComponent: Int) -> Double {
+        Double(packedComponent & 0xff) / 255.0
+    }
+}

--- a/macos/Sources/TermySwift/Views/TerminalGridView.swift
+++ b/macos/Sources/TermySwift/Views/TerminalGridView.swift
@@ -8,31 +8,38 @@ struct TerminalGridView: View {
     let activeSearchMatch: TerminalSearchMatch?
 
     var body: some View {
-        ZStack(alignment: .topLeading) {
-            backgroundOverlay
-            searchOverlay
-            selectionOverlay
-            cursorOverlay
-
-            textOverlay
+        Canvas(opaque: false, rendersAsynchronously: false) { context, _ in
+            draw(in: &context)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .clipped()
     }
 
-    private var backgroundOverlay: some View {
-        ZStack(alignment: .topLeading) {
-            ForEach(frame.cells.filter(shouldPaintBackground)) { cell in
-                Rectangle()
-                    .fill(cell.background.swiftUIColor.opacity(backgroundOpacity(for: cell)))
-                    .frame(width: renderConfig.cellWidth, height: renderConfig.cellHeight)
-                    .offset(
-                        x: renderConfig.paddingX + CGFloat(cell.col) * renderConfig.cellWidth,
-                        y: renderConfig.paddingY + CGFloat(cell.row) * renderConfig.cellHeight
-                    )
-            }
+    private func draw(in context: inout GraphicsContext) {
+        drawBackgrounds(in: &context)
+        drawSearch(in: &context)
+        drawSelection(in: &context)
+        drawCursor(in: &context)
+        drawText(in: &context)
+    }
+
+    private func cellRect(col: Int, row: Int, cols: Int = 1) -> CGRect {
+        CGRect(
+            x: renderConfig.paddingX + CGFloat(col) * renderConfig.cellWidth,
+            y: renderConfig.paddingY + CGFloat(row) * renderConfig.cellHeight,
+            width: CGFloat(cols) * renderConfig.cellWidth,
+            height: renderConfig.cellHeight
+        )
+    }
+
+    private func drawBackgrounds(in context: inout GraphicsContext) {
+        for cell in frame.cells where shouldPaintBackground(cell) {
+            let rect = cellRect(col: cell.col, row: cell.row)
+            context.fill(
+                Path(rect),
+                with: .color(cell.background.swiftUIColor.opacity(backgroundOpacity(for: cell)))
+            )
         }
-        .allowsHitTesting(false)
     }
 
     private func shouldPaintBackground(_ cell: TerminalCell) -> Bool {
@@ -43,42 +50,30 @@ struct TerminalGridView: View {
         cell.usesTerminalDefaultBackground ? renderConfig.backgroundOpacity : 1.0
     }
 
-    private var selectionOverlay: some View {
-        ZStack(alignment: .topLeading) {
-            ForEach(selection?.rowRanges(cols: frame.cols, rows: frame.rows) ?? []) { range in
-                Rectangle()
-                    .fill(Color.accentColor.opacity(0.35))
-                    .frame(
-                        width: CGFloat(range.endCol - range.startCol + 1)
-                            * renderConfig.cellWidth,
-                        height: renderConfig.cellHeight
-                    )
-                    .offset(
-                        x: renderConfig.paddingX + CGFloat(range.startCol) * renderConfig.cellWidth,
-                        y: renderConfig.paddingY + CGFloat(range.row) * renderConfig.cellHeight
-                    )
-            }
+    private func drawSelection(in context: inout GraphicsContext) {
+        guard let ranges = selection?.rowRanges(cols: frame.cols, rows: frame.rows) else {
+            return
         }
-        .allowsHitTesting(false)
+        let fill = GraphicsContext.Shading.color(Color.accentColor.opacity(0.35))
+        for range in ranges {
+            let rect = cellRect(
+                col: range.startCol,
+                row: range.row,
+                cols: range.endCol - range.startCol + 1
+            )
+            context.fill(Path(rect), with: fill)
+        }
     }
 
-    private var searchOverlay: some View {
-        ZStack(alignment: .topLeading) {
-            ForEach(searchMatches) { match in
-                Rectangle()
-                    .fill(searchColor(for: match))
-                    .frame(
-                        width: CGFloat(max(1, match.endCol - match.startCol + 1))
-                            * renderConfig.cellWidth,
-                        height: renderConfig.cellHeight
-                    )
-                    .offset(
-                        x: renderConfig.paddingX + CGFloat(match.startCol) * renderConfig.cellWidth,
-                        y: renderConfig.paddingY + CGFloat(match.row) * renderConfig.cellHeight
-                    )
-            }
+    private func drawSearch(in context: inout GraphicsContext) {
+        for match in searchMatches {
+            let rect = cellRect(
+                col: match.startCol,
+                row: match.row,
+                cols: max(1, match.endCol - match.startCol + 1)
+            )
+            context.fill(Path(rect), with: .color(searchColor(for: match)))
         }
-        .allowsHitTesting(false)
     }
 
     private func searchColor(for match: TerminalSearchMatch) -> Color {
@@ -88,40 +83,28 @@ struct TerminalGridView: View {
         return .yellow.opacity(0.28)
     }
 
-    private var cursorOverlay: some View {
-        Group {
-            if let cursor = frame.cursor, frame.displayOffset == 0 {
-                Rectangle()
-                    .fill(renderConfig.cursor.swiftUIColor)
-                    .frame(width: renderConfig.cellWidth, height: renderConfig.cellHeight)
-                    .offset(
-                        x: renderConfig.paddingX + CGFloat(cursor.col) * renderConfig.cellWidth,
-                        y: renderConfig.paddingY + CGFloat(cursor.row) * renderConfig.cellHeight
-                    )
-            }
+    private func drawCursor(in context: inout GraphicsContext) {
+        guard let cursor = frame.cursor, frame.displayOffset == 0 else {
+            return
         }
-        .allowsHitTesting(false)
+        let rect = cellRect(col: cursor.col, row: cursor.row)
+        context.fill(Path(rect), with: .color(renderConfig.cursor.swiftUIColor))
     }
 
-    private var textOverlay: some View {
-        ZStack(alignment: .topLeading) {
-            ForEach(textSegments) { segment in
-                Text(verbatim: segment.text)
-                    .font(terminalFont(weight: segment.bold ? .semibold : .regular))
-                    .foregroundStyle(segment.foreground.swiftUIColor)
-                    .lineLimit(1)
-                    .frame(
-                        width: CGFloat(segment.text.count) * renderConfig.cellWidth,
-                        height: renderConfig.cellHeight,
-                        alignment: .leading
-                    )
-                    .offset(
-                        x: renderConfig.paddingX + CGFloat(segment.startCol) * renderConfig.cellWidth,
-                        y: renderConfig.paddingY + CGFloat(segment.row) * renderConfig.cellHeight
-                    )
-            }
+    private func drawText(in context: inout GraphicsContext) {
+        let centerY = renderConfig.cellHeight / 2
+        for segment in textSegments {
+            var text = Text(verbatim: segment.text)
+                .font(terminalFont(weight: segment.bold ? .semibold : .regular))
+            text = text.foregroundColor(segment.foreground.swiftUIColor)
+
+            let resolved = context.resolve(text)
+            let origin = CGPoint(
+                x: renderConfig.paddingX + CGFloat(segment.startCol) * renderConfig.cellWidth,
+                y: renderConfig.paddingY + CGFloat(segment.row) * renderConfig.cellHeight + centerY
+            )
+            context.draw(resolved, at: origin, anchor: .leading)
         }
-        .allowsHitTesting(false)
     }
 
     private var textSegments: [TerminalTextSegment] {
@@ -181,14 +164,10 @@ struct TerminalGridView: View {
     }
 }
 
-private struct TerminalTextSegment: Identifiable {
+private struct TerminalTextSegment {
     var row: Int
     var startCol: Int
     var text: String
     var foreground: TerminalRGBA
     var bold: Bool
-
-    var id: String {
-        "\(row):\(startCol):\(text.count):\(foreground.red):\(foreground.green):\(foreground.blue):\(bold)"
-    }
 }

--- a/macos/Sources/TermySwift/Views/TerminalKeyboardInputView.swift
+++ b/macos/Sources/TermySwift/Views/TerminalKeyboardInputView.swift
@@ -11,9 +11,13 @@ struct TerminalKeyboardInputView: NSViewRepresentable {
     var onBytes: ([UInt8]) -> Void
     var onKeyInput: (TerminalKeyInput) -> Void
     var onScrollLines: (Int) -> Void
+    var onScrollToTop: () -> Void
+    var onScrollToBottom: () -> Void
+    var onClearBuffer: () -> Void
     var onSplitRight: () -> Void
     var onSplitDown: () -> Void
     var onClosePane: () -> Void
+    var onClosePaneIfSplit: () -> Bool
     var onFocusNextPane: () -> Void
     var onShowSearch: () -> Void
     var onSelectionChanged: (TerminalSelection?) -> Void
@@ -21,44 +25,14 @@ struct TerminalKeyboardInputView: NSViewRepresentable {
 
     func makeNSView(context: Context) -> KeyboardCaptureView {
         let view = KeyboardCaptureView()
-        view.cols = cols
-        view.rows = rows
-        view.renderConfig = renderConfig
-        view.isTerminalFocused = isFocused
-        view.isInputEnabled = isInputEnabled
-        view.onFocus = onFocus
-        view.onBytes = onBytes
-        view.onKeyInput = onKeyInput
-        view.onScrollLines = onScrollLines
-        view.onSplitRight = onSplitRight
-        view.onSplitDown = onSplitDown
-        view.onClosePane = onClosePane
-        view.onFocusNextPane = onFocusNextPane
-        view.onShowSearch = onShowSearch
-        view.onSelectionChanged = onSelectionChanged
-        view.onCopy = onCopy
+        view.apply(configuration: self)
         view.wantsLayer = true
         view.layer?.backgroundColor = NSColor.clear.cgColor
         return view
     }
 
     func updateNSView(_ view: KeyboardCaptureView, context: Context) {
-        view.cols = cols
-        view.rows = rows
-        view.renderConfig = renderConfig
-        view.isTerminalFocused = isFocused
-        view.isInputEnabled = isInputEnabled
-        view.onFocus = onFocus
-        view.onBytes = onBytes
-        view.onKeyInput = onKeyInput
-        view.onScrollLines = onScrollLines
-        view.onSplitRight = onSplitRight
-        view.onSplitDown = onSplitDown
-        view.onClosePane = onClosePane
-        view.onFocusNextPane = onFocusNextPane
-        view.onShowSearch = onShowSearch
-        view.onSelectionChanged = onSelectionChanged
-        view.onCopy = onCopy
+        view.apply(configuration: self)
         if isFocused, isInputEnabled {
             view.focus()
         }
@@ -75,9 +49,13 @@ final class KeyboardCaptureView: NSView {
     var onBytes: ([UInt8]) -> Void = { _ in }
     var onKeyInput: (TerminalKeyInput) -> Void = { _ in }
     var onScrollLines: (Int) -> Void = { _ in }
+    var onScrollToTop: () -> Void = {}
+    var onScrollToBottom: () -> Void = {}
+    var onClearBuffer: () -> Void = {}
     var onSplitRight: () -> Void = {}
     var onSplitDown: () -> Void = {}
     var onClosePane: () -> Void = {}
+    var onClosePaneIfSplit: () -> Bool = { false }
     var onFocusNextPane: () -> Void = {}
     var onShowSearch: () -> Void = {}
     var onSelectionChanged: (TerminalSelection?) -> Void = { _ in }
@@ -175,6 +153,19 @@ final class KeyboardCaptureView: NSView {
         }
 
         if event.modifierFlags.contains(.command) {
+            // cmd+up/down scroll the viewport to the history extremes.
+            if handleCommandScroll(event) {
+                return
+            }
+            // Forward macOS line-editing shortcuts (cmd+arrows/backspace/delete);
+            // the core maps these to ^A/^E/^U/^K. Everything else falls through
+            // to the menu/responder chain.
+            if let keyCode = MacKeyCode(rawValue: event.keyCode),
+               isLineEditingKeyCode(keyCode),
+               let keyInput = terminalKeyInput(for: event) {
+                onKeyInput(keyInput)
+                return
+            }
             super.keyDown(with: event)
             return
         }
@@ -185,6 +176,32 @@ final class KeyboardCaptureView: NSView {
         }
 
         super.keyDown(with: event)
+    }
+
+    private func isLineEditingKeyCode(_ keyCode: MacKeyCode) -> Bool {
+        switch keyCode {
+        case .deleteBackward, .forwardDelete, .leftArrow, .rightArrow, .home, .end:
+            return true
+        default:
+            return false
+        }
+    }
+
+    private func handleCommandScroll(_ event: NSEvent) -> Bool {
+        guard let keyCode = MacKeyCode(rawValue: event.keyCode) else {
+            return false
+        }
+
+        switch keyCode {
+        case .upArrow:
+            onScrollToTop()
+            return true
+        case .downArrow:
+            onScrollToBottom()
+            return true
+        default:
+            return false
+        }
     }
 
     override func scrollWheel(with event: NSEvent) {
@@ -256,7 +273,7 @@ final class KeyboardCaptureView: NSView {
             onClosePane()
             return true
         case ("w", false):
-            if TerminalCommandRouter.shared.closeFocusedPaneIfSplit() {
+            if onClosePaneIfSplit() {
                 return true
             }
             return false
@@ -266,69 +283,76 @@ final class KeyboardCaptureView: NSView {
         case ("f", _):
             onShowSearch()
             return true
+        case ("k", false):
+            onClearBuffer()
+            return true
         default:
             return false
         }
     }
 
     private func terminalKeyInput(for event: NSEvent) -> TerminalKeyInput? {
-        switch event.keyCode {
-        case 36, 76:
-            return keyInput("enter", event: event)
-        case 48:
-            return keyInput("tab", event: event)
-        case 51:
-            return keyInput("backspace", event: event)
-        case 53:
-            return keyInput("escape", event: event)
-        case 115:
-            return keyInput("home", event: event)
-        case 119:
-            return keyInput("end", event: event)
-        case 116:
-            return keyInput("pageup", event: event)
-        case 121:
-            return keyInput("pagedown", event: event)
-        case 117:
-            return keyInput("delete", event: event)
-        case 123:
-            return keyInput("left", event: event)
-        case 124:
-            return keyInput("right", event: event)
-        case 125:
-            return keyInput("down", event: event)
-        case 126:
-            return keyInput("up", event: event)
-        case 122:
-            return keyInput("f1", event: event, function: true)
-        case 120:
-            return keyInput("f2", event: event, function: true)
-        case 99:
-            return keyInput("f3", event: event, function: true)
-        case 118:
-            return keyInput("f4", event: event, function: true)
-        case 96:
-            return keyInput("f5", event: event, function: true)
-        case 97:
-            return keyInput("f6", event: event, function: true)
-        case 98:
-            return keyInput("f7", event: event, function: true)
-        case 100:
-            return keyInput("f8", event: event, function: true)
-        case 101:
-            return keyInput("f9", event: event, function: true)
-        case 109:
-            return keyInput("f10", event: event, function: true)
-        case 103:
-            return keyInput("f11", event: event, function: true)
-        case 111:
-            return keyInput("f12", event: event, function: true)
-        case 49:
-            return keyInput("space", event: event, keyChar: event.characters)
-        default:
-            break
+        guard let keyCode = MacKeyCode(rawValue: event.keyCode) else {
+            return characterKeyInput(for: event)
         }
 
+        switch keyCode {
+        case .returnKey, .keypadEnter:
+            return keyInput("enter", event: event)
+        case .tab:
+            return keyInput("tab", event: event)
+        case .deleteBackward:
+            return keyInput("backspace", event: event)
+        case .escape:
+            return keyInput("escape", event: event)
+        case .home:
+            return keyInput("home", event: event)
+        case .end:
+            return keyInput("end", event: event)
+        case .pageUp:
+            return keyInput("pageup", event: event)
+        case .pageDown:
+            return keyInput("pagedown", event: event)
+        case .forwardDelete:
+            return keyInput("delete", event: event)
+        case .leftArrow:
+            return keyInput("left", event: event)
+        case .rightArrow:
+            return keyInput("right", event: event)
+        case .downArrow:
+            return keyInput("down", event: event)
+        case .upArrow:
+            return keyInput("up", event: event)
+        case .f1:
+            return keyInput("f1", event: event, function: true)
+        case .f2:
+            return keyInput("f2", event: event, function: true)
+        case .f3:
+            return keyInput("f3", event: event, function: true)
+        case .f4:
+            return keyInput("f4", event: event, function: true)
+        case .f5:
+            return keyInput("f5", event: event, function: true)
+        case .f6:
+            return keyInput("f6", event: event, function: true)
+        case .f7:
+            return keyInput("f7", event: event, function: true)
+        case .f8:
+            return keyInput("f8", event: event, function: true)
+        case .f9:
+            return keyInput("f9", event: event, function: true)
+        case .f10:
+            return keyInput("f10", event: event, function: true)
+        case .f11:
+            return keyInput("f11", event: event, function: true)
+        case .f12:
+            return keyInput("f12", event: event, function: true)
+        case .space:
+            return keyInput("space", event: event, keyChar: event.characters)
+        }
+    }
+
+    private func characterKeyInput(for event: NSEvent) -> TerminalKeyInput? {
         guard let key = event.charactersIgnoringModifiers, !key.isEmpty else {
             return nil
         }
@@ -354,7 +378,7 @@ final class KeyboardCaptureView: NSView {
             shift: flags.contains(.shift),
             platform: flags.contains(.command),
             function: flags.contains(.function) || function,
-            eventKind: event.isARepeat ? 2 : 1
+            eventKind: event.isARepeat ? .repeat : .press
         )
     }
 
@@ -369,4 +393,59 @@ final class KeyboardCaptureView: NSView {
         return TerminalGridPosition(col: col, row: row)
     }
 
+}
+
+private enum MacKeyCode: UInt16 {
+    case returnKey = 36
+    case keypadEnter = 76
+    case tab = 48
+    case deleteBackward = 51
+    case escape = 53
+    case home = 115
+    case end = 119
+    case pageUp = 116
+    case pageDown = 121
+    case forwardDelete = 117
+    case leftArrow = 123
+    case rightArrow = 124
+    case downArrow = 125
+    case upArrow = 126
+    case f1 = 122
+    case f2 = 120
+    case f3 = 99
+    case f4 = 118
+    case f5 = 96
+    case f6 = 97
+    case f7 = 98
+    case f8 = 100
+    case f9 = 101
+    case f10 = 109
+    case f11 = 103
+    case f12 = 111
+    case space = 49
+}
+
+private extension KeyboardCaptureView {
+    func apply(configuration: TerminalKeyboardInputView) {
+        cols = configuration.cols
+        rows = configuration.rows
+        renderConfig = configuration.renderConfig
+        isTerminalFocused = configuration.isFocused
+        isInputEnabled = configuration.isInputEnabled
+        onFocus = configuration.onFocus
+        onBytes = configuration.onBytes
+        onKeyInput = configuration.onKeyInput
+        onScrollLines = configuration.onScrollLines
+        onScrollToTop = configuration.onScrollToTop
+        onScrollToBottom = configuration.onScrollToBottom
+        onClearBuffer = configuration.onClearBuffer
+        onSplitRight = configuration.onSplitRight
+        onSplitDown = configuration.onSplitDown
+        onClosePane = configuration.onClosePane
+        onClosePaneIfSplit = configuration.onClosePaneIfSplit
+        onFocusNextPane = configuration.onFocusNextPane
+        onShowSearch = configuration.onShowSearch
+        onSelectionChanged = configuration.onSelectionChanged
+        onCopy = configuration.onCopy
+    }
 }

--- a/macos/Sources/TermySwift/Views/TerminalSurfaceView.swift
+++ b/macos/Sources/TermySwift/Views/TerminalSurfaceView.swift
@@ -4,13 +4,16 @@ struct TerminalSurfaceView: View {
     @ObservedObject var terminal: TerminalViewModel
     @State private var isScrollBarVisible = false
     @State private var scrollBarHideTask: Task<Void, Never>?
+    @State private var lastSize: CGSize = .zero
 
     let isFocused: Bool
+    let showsFocusBorder: Bool
     let isInputEnabled: Bool
     let onFocus: () -> Void
     let onSplitRight: () -> Void
     let onSplitDown: () -> Void
     let onClosePane: () -> Void
+    let onClosePaneIfSplit: () -> Bool
     let onFocusNextPane: () -> Void
     let onShowSearch: () -> Void
 
@@ -43,9 +46,21 @@ struct TerminalSurfaceView: View {
                         revealScrollBar()
                         terminal.scrollDisplay(deltaLines: lines)
                     },
+                    onScrollToTop: {
+                        revealScrollBar()
+                        terminal.scrollToTop()
+                    },
+                    onScrollToBottom: {
+                        revealScrollBar()
+                        terminal.scrollToBottom()
+                    },
+                    onClearBuffer: {
+                        terminal.clearScrollback()
+                    },
                     onSplitRight: onSplitRight,
                     onSplitDown: onSplitDown,
                     onClosePane: onClosePane,
+                    onClosePaneIfSplit: onClosePaneIfSplit,
                     onFocusNextPane: onFocusNextPane,
                     onShowSearch: onShowSearch,
                     onSelectionChanged: { selection in
@@ -70,7 +85,7 @@ struct TerminalSurfaceView: View {
                 }
             }
             .overlay {
-                if isFocused {
+                if isFocused && showsFocusBorder {
                     Rectangle()
                         .stroke(Color.accentColor.opacity(0.6), lineWidth: 1)
                         .allowsHitTesting(false)
@@ -102,10 +117,17 @@ struct TerminalSurfaceView: View {
             }
             .onAppear {
                 terminal.start()
+                lastSize = proxy.size
                 resizeTerminal(to: proxy.size)
             }
             .onChange(of: proxy.size) { _, size in
+                lastSize = size
                 resizeTerminal(to: size)
+            }
+            .onChange(of: terminal.renderConfig) { _, _ in
+                // Font/padding changes alter cell metrics, so recompute the grid
+                // for the current pixel size when settings live-apply.
+                resizeTerminal(to: lastSize)
             }
             .onChange(of: terminal.frame.displayOffset) { oldValue, newValue in
                 if oldValue != newValue {

--- a/macos/Sources/TermySwift/Views/TerminalWorkspaceView.swift
+++ b/macos/Sources/TermySwift/Views/TerminalWorkspaceView.swift
@@ -3,10 +3,30 @@ import SwiftUI
 
 struct TerminalWorkspaceView: View {
     @StateObject private var store = TerminalWorkspaceStore()
+    @State private var appConfigurationError = TermyAppConfiguration.loadErrorMessage
 
     var body: some View {
         ZStack(alignment: .topTrailing) {
             TerminalPaneNodeView(node: store.root, store: store)
+
+            if let appConfigurationError {
+                HStack(spacing: 8) {
+                    Text(appConfigurationError)
+                        .font(.system(size: 12, design: .monospaced))
+                        .foregroundStyle(.red)
+                    Button {
+                        self.appConfigurationError = nil
+                    } label: {
+                        Image(systemName: "xmark")
+                    }
+                    .buttonStyle(.borderless)
+                }
+                .padding(8)
+                .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
+                .padding(10)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                .zIndex(11)
+            }
 
             if store.isSearchVisible, let terminal = store.focusedTerminal {
                 TerminalSearchPanel(
@@ -160,6 +180,7 @@ private struct TerminalPaneLeafView: View {
         TerminalSurfaceView(
             terminal: pane.terminal,
             isFocused: store.focusedPaneID == pane.id,
+            showsFocusBorder: store.paneCount > 1,
             isInputEnabled: !store.isSearchVisible,
             onFocus: {
                 store.focus(pane)
@@ -175,6 +196,10 @@ private struct TerminalPaneLeafView: View {
             onClosePane: {
                 store.focus(pane)
                 store.closeFocusedPane()
+            },
+            onClosePaneIfSplit: {
+                store.focus(pane)
+                return store.closeFocusedPaneIfSplit()
             },
             onFocusNextPane: store.focusNextPane,
             onShowSearch: store.showSearch

--- a/macos/script/build_and_run.sh
+++ b/macos/script/build_and_run.sh
@@ -16,7 +16,7 @@ APP_MACOS="$APP_CONTENTS/MacOS"
 APP_RESOURCES="$APP_CONTENTS/Resources"
 APP_BINARY="$APP_MACOS/$APP_NAME"
 INFO_PLIST="$APP_CONTENTS/Info.plist"
-ICON_SOURCE="$ROOT_DIR/assets/termy_old_icon.png"
+ICON_SOURCE="$ROOT_DIR/assets/TermyIcon.png"
 ICON_NAME="TermyIcon"
 
 pkill -x "$APP_NAME" >/dev/null 2>&1 || true


### PR DESCRIPTION
Settings:
- Native System Settings-style window (NavigationSplitView sidebar) driven by the config_core schema, editing ~/.config/termy/config.txt with format-preserving writes. Live-applies appearance changes to open panes.
- FFI: termy_settings_schema_json + set_root/reset_root/set_color/set_keybinds and termy_terminal_reload_default_config_colors.

Terminal:
- Rewrite TerminalGridView onto a single Canvas, fixing scroll/resize lag.
- Fix missing cursor in reverse-video TUIs (Claude Code): compute uses_terminal_default_bg after the INVERSE swap.
- Add cmd+backspace/delete/left/right line editing, cmd+up/down scroll, and cmd+k clear-scrollback; gate the focus border to multi-pane.

# Pull Request

<!-- A clear and concise description of what this PR does and why it's needed. -->

## Description

<!-- Describe the changes made in the PR. -->

- 
-
-
-

## Screenshots/Videos

<!-- If applicable, add screenshots or screen recordings to help explain your changes. -->


## Related Issues

<!-- If this PR closes any issues, use the keyword 'closes' followed by the issue number -->

Closes #

## Checklist

- [ ] I confirmed there is no existing open PR for the same or overlapping changes.
