### PR TITLE
E1 tranche 1: extract terminal_view window_appearance

### DIFF
--- a/crates/desktop_app/src/terminal_view/mod.rs
+++ b/crates/desktop_app/src/terminal_view/mod.rs
@@ -76,6 +76,9 @@ pub(crate) mod tab_strip;
 mod tabs;
 mod titles;
 mod update_toasts;
+mod window_appearance;
+
+pub(crate) use window_appearance::initial_window_background_appearance;
 
 use self::benchmark::{BENCHMARK_SAMPLE_INTERVAL, BenchmarkConfig, BenchmarkSession};
 use command_palette::{CommandPaletteMode, CommandPaletteState, TmuxSessionIntent};
@@ -87,6 +90,7 @@ use overlay_view::TerminalOverlayView;
 use runtime::{RuntimeKind, RuntimeState, TmuxRuntime};
 pub(crate) use tab_strip::constants::*;
 use tab_strip::state::TabStripState;
+use window_appearance::BackgroundSupportContext;
 
 type TabId = u64;
 
@@ -1184,105 +1188,6 @@ struct HoveredLink {
     target: String,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[allow(dead_code)]
-enum BackgroundPlatform {
-    MacOs,
-    Windows,
-    Linux,
-    Other,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct BackgroundSupportContext {
-    platform: BackgroundPlatform,
-    linux_wayland_session: bool,
-}
-
-impl BackgroundSupportContext {
-    fn current() -> Self {
-        #[cfg(target_os = "macos")]
-        let platform = BackgroundPlatform::MacOs;
-        #[cfg(target_os = "windows")]
-        let platform = BackgroundPlatform::Windows;
-        #[cfg(target_os = "linux")]
-        let platform = BackgroundPlatform::Linux;
-        #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
-        let platform = BackgroundPlatform::Other;
-
-        #[cfg(target_os = "linux")]
-        let linux_wayland_session = std::env::var("XDG_SESSION_TYPE")
-            .ok()
-            .is_some_and(|session_type| session_type.eq_ignore_ascii_case("wayland"))
-            || std::env::var_os("WAYLAND_DISPLAY").is_some();
-        #[cfg(not(target_os = "linux"))]
-        let linux_wayland_session = false;
-
-        Self {
-            platform,
-            linux_wayland_session,
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum BlurFallbackReason {
-    None,
-    KnownUnsupported,
-    UnknownSupport,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-struct ResolvedBackgroundAppearance {
-    appearance: WindowBackgroundAppearance,
-    blur_fallback: BlurFallbackReason,
-}
-
-fn resolve_background_appearance(
-    background_opacity: f32,
-    background_blur: bool,
-    context: BackgroundSupportContext,
-) -> ResolvedBackgroundAppearance {
-    let opacity = background_opacity.clamp(0.0, 1.0);
-    if opacity >= 1.0 {
-        return ResolvedBackgroundAppearance {
-            appearance: WindowBackgroundAppearance::Opaque,
-            blur_fallback: BlurFallbackReason::None,
-        };
-    }
-
-    if !background_blur {
-        return ResolvedBackgroundAppearance {
-            appearance: WindowBackgroundAppearance::Transparent,
-            blur_fallback: BlurFallbackReason::None,
-        };
-    }
-
-    match context.platform {
-        BackgroundPlatform::MacOs | BackgroundPlatform::Windows => ResolvedBackgroundAppearance {
-            appearance: WindowBackgroundAppearance::Blurred,
-            blur_fallback: BlurFallbackReason::None,
-        },
-        BackgroundPlatform::Linux => {
-            if context.linux_wayland_session {
-                ResolvedBackgroundAppearance {
-                    appearance: WindowBackgroundAppearance::Blurred,
-                    blur_fallback: BlurFallbackReason::UnknownSupport,
-                }
-            } else {
-                ResolvedBackgroundAppearance {
-                    appearance: WindowBackgroundAppearance::Transparent,
-                    blur_fallback: BlurFallbackReason::KnownUnsupported,
-                }
-            }
-        }
-        BackgroundPlatform::Other => ResolvedBackgroundAppearance {
-            appearance: WindowBackgroundAppearance::Blurred,
-            blur_fallback: BlurFallbackReason::UnknownSupport,
-        },
-    }
-}
-
 fn background_opacity_factor(background_opacity: f32) -> f32 {
     background_opacity.clamp(0.0, 1.0)
 }
@@ -1455,17 +1360,6 @@ impl<'a> OverlayStyleBuilder<'a> {
         color.a = alpha.clamp(0.0, 1.0);
         color
     }
-}
-
-pub(crate) fn initial_window_background_appearance(
-    config: &AppConfig,
-) -> WindowBackgroundAppearance {
-    resolve_background_appearance(
-        config.background_opacity,
-        config.background_blur,
-        BackgroundSupportContext::current(),
-    )
-    .appearance
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -3627,29 +3521,6 @@ impl TerminalView {
         .detach();
     }
 
-    fn sync_window_background_appearance(&mut self, window: &mut Window) {
-        let resolved = resolve_background_appearance(
-            self.effective_background_opacity(),
-            self.background_blur,
-            self.background_support_context,
-        );
-
-        if self.last_window_background_appearance != Some(resolved.appearance) {
-            window.set_background_appearance(resolved.appearance);
-            self.last_window_background_appearance = Some(resolved.appearance);
-        }
-
-        if self.background_blur
-            && resolved.blur_fallback == BlurFallbackReason::KnownUnsupported
-            && !self.warned_blur_unsupported_once
-        {
-            self.warned_blur_unsupported_once = true;
-            termy_toast::warning(
-                "Background blur is unsupported in this session; using transparency",
-            );
-        }
-    }
-
     pub fn new(window: &mut Window, cx: &mut Context<Self>, config: AppConfig) -> Self {
         let focus_handle = cx.focus_handle();
         let blur_focus_handle = focus_handle.clone();
@@ -4155,21 +4026,6 @@ impl TerminalView {
                 view.handle_window_appearance_change(window.appearance(), cx);
             }));
         view
-    }
-
-    fn handle_window_appearance_change(
-        &mut self,
-        appearance: gpui::WindowAppearance,
-        cx: &mut Context<Self>,
-    ) {
-        let next = system_appearance_from_window(appearance);
-        if self.system_appearance == next {
-            return;
-        }
-        self.system_appearance = next;
-        if self.theme_mode != config::AppearanceMode::Manual {
-            self.reapply_theme(cx);
-        }
     }
 
     fn reapply_theme(&mut self, cx: &mut Context<Self>) {
@@ -5245,76 +5101,6 @@ mod tests {
     }
 
     #[test]
-    fn resolve_background_appearance_is_opaque_when_opacity_is_full() {
-        let resolved = resolve_background_appearance(
-            1.0,
-            true,
-            BackgroundSupportContext {
-                platform: BackgroundPlatform::MacOs,
-                linux_wayland_session: false,
-            },
-        );
-        assert_eq!(resolved.appearance, WindowBackgroundAppearance::Opaque);
-        assert_eq!(resolved.blur_fallback, BlurFallbackReason::None);
-    }
-
-    #[test]
-    fn resolve_background_appearance_is_transparent_without_blur() {
-        let resolved = resolve_background_appearance(
-            0.85,
-            false,
-            BackgroundSupportContext {
-                platform: BackgroundPlatform::Windows,
-                linux_wayland_session: false,
-            },
-        );
-        assert_eq!(resolved.appearance, WindowBackgroundAppearance::Transparent);
-        assert_eq!(resolved.blur_fallback, BlurFallbackReason::None);
-    }
-
-    #[test]
-    fn resolve_background_appearance_blur_is_known_unsupported_on_linux_non_wayland() {
-        let resolved = resolve_background_appearance(
-            0.9,
-            true,
-            BackgroundSupportContext {
-                platform: BackgroundPlatform::Linux,
-                linux_wayland_session: false,
-            },
-        );
-        assert_eq!(resolved.appearance, WindowBackgroundAppearance::Transparent);
-        assert_eq!(resolved.blur_fallback, BlurFallbackReason::KnownUnsupported);
-    }
-
-    #[test]
-    fn resolve_background_appearance_blur_is_unknown_on_linux_wayland() {
-        let resolved = resolve_background_appearance(
-            0.9,
-            true,
-            BackgroundSupportContext {
-                platform: BackgroundPlatform::Linux,
-                linux_wayland_session: true,
-            },
-        );
-        assert_eq!(resolved.appearance, WindowBackgroundAppearance::Blurred);
-        assert_eq!(resolved.blur_fallback, BlurFallbackReason::UnknownSupport);
-    }
-
-    #[test]
-    fn resolve_background_appearance_blur_is_enabled_on_macos() {
-        let resolved = resolve_background_appearance(
-            0.9,
-            true,
-            BackgroundSupportContext {
-                platform: BackgroundPlatform::MacOs,
-                linux_wayland_session: false,
-            },
-        );
-        assert_eq!(resolved.appearance, WindowBackgroundAppearance::Blurred);
-        assert_eq!(resolved.blur_fallback, BlurFallbackReason::None);
-    }
-
-    #[test]
     fn chrome_alpha_scales_without_floor() {
         let base = 0.92;
         let alpha = scaled_chrome_alpha_for_opacity(base, 0.1);
@@ -5551,27 +5337,6 @@ mod tests {
                 opacity: 0.5,
             })
         );
-    }
-
-    #[test]
-    fn resolve_background_appearance_uses_preview_opacity_during_drag() {
-        let effective_opacity = config::effective_background_opacity(
-            1.0,
-            Some(config::BackgroundOpacityPreview {
-                owner_id: 1,
-                opacity: 0.4,
-            }),
-        );
-        let resolved = resolve_background_appearance(
-            effective_opacity,
-            false,
-            BackgroundSupportContext {
-                platform: BackgroundPlatform::MacOs,
-                linux_wayland_session: false,
-            },
-        );
-
-        assert_eq!(resolved.appearance, WindowBackgroundAppearance::Transparent);
     }
 
     #[test]

--- a/crates/desktop_app/src/terminal_view/window_appearance.rs
+++ b/crates/desktop_app/src/terminal_view/window_appearance.rs
@@ -1,0 +1,255 @@
+//! Window background appearance and system theme reactions for `TerminalView`.
+//!
+//! E1 tranche 1 — extracted from `mod.rs` per `docs/engineering/terminal-view-decomposition.md`.
+
+use crate::config::{self, AppConfig};
+use gpui::{Context, Window, WindowAppearance, WindowBackgroundAppearance};
+
+use super::TerminalView;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[allow(dead_code)]
+pub(super) enum BackgroundPlatform {
+    MacOs,
+    Windows,
+    Linux,
+    Other,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct BackgroundSupportContext {
+    pub(super) platform: BackgroundPlatform,
+    pub(super) linux_wayland_session: bool,
+}
+
+impl BackgroundSupportContext {
+    pub(super) fn current() -> Self {
+        #[cfg(target_os = "macos")]
+        let platform = BackgroundPlatform::MacOs;
+        #[cfg(target_os = "windows")]
+        let platform = BackgroundPlatform::Windows;
+        #[cfg(target_os = "linux")]
+        let platform = BackgroundPlatform::Linux;
+        #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+        let platform = BackgroundPlatform::Other;
+
+        #[cfg(target_os = "linux")]
+        let linux_wayland_session = std::env::var("XDG_SESSION_TYPE")
+            .ok()
+            .is_some_and(|session_type| session_type.eq_ignore_ascii_case("wayland"))
+            || std::env::var_os("WAYLAND_DISPLAY").is_some();
+        #[cfg(not(target_os = "linux"))]
+        let linux_wayland_session = false;
+
+        Self {
+            platform,
+            linux_wayland_session,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum BlurFallbackReason {
+    None,
+    KnownUnsupported,
+    UnknownSupport,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(super) struct ResolvedBackgroundAppearance {
+    pub(super) appearance: WindowBackgroundAppearance,
+    pub(super) blur_fallback: BlurFallbackReason,
+}
+
+pub(super) fn resolve_background_appearance(
+    background_opacity: f32,
+    background_blur: bool,
+    context: BackgroundSupportContext,
+) -> ResolvedBackgroundAppearance {
+    let opacity = background_opacity.clamp(0.0, 1.0);
+    if opacity >= 1.0 {
+        return ResolvedBackgroundAppearance {
+            appearance: WindowBackgroundAppearance::Opaque,
+            blur_fallback: BlurFallbackReason::None,
+        };
+    }
+
+    if !background_blur {
+        return ResolvedBackgroundAppearance {
+            appearance: WindowBackgroundAppearance::Transparent,
+            blur_fallback: BlurFallbackReason::None,
+        };
+    }
+
+    match context.platform {
+        BackgroundPlatform::MacOs | BackgroundPlatform::Windows => ResolvedBackgroundAppearance {
+            appearance: WindowBackgroundAppearance::Blurred,
+            blur_fallback: BlurFallbackReason::None,
+        },
+        BackgroundPlatform::Linux => {
+            if context.linux_wayland_session {
+                ResolvedBackgroundAppearance {
+                    appearance: WindowBackgroundAppearance::Blurred,
+                    blur_fallback: BlurFallbackReason::UnknownSupport,
+                }
+            } else {
+                ResolvedBackgroundAppearance {
+                    appearance: WindowBackgroundAppearance::Transparent,
+                    blur_fallback: BlurFallbackReason::KnownUnsupported,
+                }
+            }
+        }
+        BackgroundPlatform::Other => ResolvedBackgroundAppearance {
+            appearance: WindowBackgroundAppearance::Blurred,
+            blur_fallback: BlurFallbackReason::UnknownSupport,
+        },
+    }
+}
+
+pub(crate) fn initial_window_background_appearance(
+    config: &AppConfig,
+) -> WindowBackgroundAppearance {
+    resolve_background_appearance(
+        config.background_opacity,
+        config.background_blur,
+        BackgroundSupportContext::current(),
+    )
+    .appearance
+}
+
+impl TerminalView {
+    pub(super) fn sync_window_background_appearance(&mut self, window: &mut Window) {
+        let resolved = resolve_background_appearance(
+            self.effective_background_opacity(),
+            self.background_blur,
+            self.background_support_context,
+        );
+
+        if self.last_window_background_appearance != Some(resolved.appearance) {
+            window.set_background_appearance(resolved.appearance);
+            self.last_window_background_appearance = Some(resolved.appearance);
+        }
+
+        if self.background_blur
+            && resolved.blur_fallback == BlurFallbackReason::KnownUnsupported
+            && !self.warned_blur_unsupported_once
+        {
+            self.warned_blur_unsupported_once = true;
+            termy_toast::warning(
+                "Background blur is unsupported in this session; using transparency",
+            );
+        }
+    }
+
+    pub(super) fn handle_window_appearance_change(
+        &mut self,
+        appearance: WindowAppearance,
+        cx: &mut Context<Self>,
+    ) {
+        let next = config::system_appearance_from_window(appearance);
+        if self.system_appearance == next {
+            return;
+        }
+        self.system_appearance = next;
+        if self.theme_mode != config::AppearanceMode::Manual {
+            self.reapply_theme(cx);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config;
+
+    #[test]
+    fn resolve_background_appearance_is_opaque_when_opacity_is_full() {
+        let resolved = resolve_background_appearance(
+            1.0,
+            true,
+            BackgroundSupportContext {
+                platform: BackgroundPlatform::MacOs,
+                linux_wayland_session: false,
+            },
+        );
+        assert_eq!(resolved.appearance, WindowBackgroundAppearance::Opaque);
+        assert_eq!(resolved.blur_fallback, BlurFallbackReason::None);
+    }
+
+    #[test]
+    fn resolve_background_appearance_is_transparent_without_blur() {
+        let resolved = resolve_background_appearance(
+            0.85,
+            false,
+            BackgroundSupportContext {
+                platform: BackgroundPlatform::Windows,
+                linux_wayland_session: false,
+            },
+        );
+        assert_eq!(resolved.appearance, WindowBackgroundAppearance::Transparent);
+        assert_eq!(resolved.blur_fallback, BlurFallbackReason::None);
+    }
+
+    #[test]
+    fn resolve_background_appearance_blur_is_known_unsupported_on_linux_non_wayland() {
+        let resolved = resolve_background_appearance(
+            0.9,
+            true,
+            BackgroundSupportContext {
+                platform: BackgroundPlatform::Linux,
+                linux_wayland_session: false,
+            },
+        );
+        assert_eq!(resolved.appearance, WindowBackgroundAppearance::Transparent);
+        assert_eq!(resolved.blur_fallback, BlurFallbackReason::KnownUnsupported);
+    }
+
+    #[test]
+    fn resolve_background_appearance_blur_is_unknown_on_linux_wayland() {
+        let resolved = resolve_background_appearance(
+            0.9,
+            true,
+            BackgroundSupportContext {
+                platform: BackgroundPlatform::Linux,
+                linux_wayland_session: true,
+            },
+        );
+        assert_eq!(resolved.appearance, WindowBackgroundAppearance::Blurred);
+        assert_eq!(resolved.blur_fallback, BlurFallbackReason::UnknownSupport);
+    }
+
+    #[test]
+    fn resolve_background_appearance_blur_is_enabled_on_macos() {
+        let resolved = resolve_background_appearance(
+            0.9,
+            true,
+            BackgroundSupportContext {
+                platform: BackgroundPlatform::MacOs,
+                linux_wayland_session: false,
+            },
+        );
+        assert_eq!(resolved.appearance, WindowBackgroundAppearance::Blurred);
+        assert_eq!(resolved.blur_fallback, BlurFallbackReason::None);
+    }
+
+    #[test]
+    fn resolve_background_appearance_uses_preview_opacity_during_drag() {
+        let effective_opacity = config::effective_background_opacity(
+            1.0,
+            Some(config::BackgroundOpacityPreview {
+                owner_id: 1,
+                opacity: 0.4,
+            }),
+        );
+        let resolved = resolve_background_appearance(
+            effective_opacity,
+            false,
+            BackgroundSupportContext {
+                platform: BackgroundPlatform::MacOs,
+                linux_wayland_session: false,
+            },
+        );
+
+        assert_eq!(resolved.appearance, WindowBackgroundAppearance::Transparent);
+    }
+}

--- a/docs/engineering/terminal-view-decomposition.md
+++ b/docs/engineering/terminal-view-decomposition.md
@@ -31,8 +31,9 @@ Execute **one tranche per release** (or per month), each ≤500 lines moved, wit
 
 ### Tranche 1 — Session & window glue (E1 Q2)
 
-- Move window-scoped session wiring out of `mod.rs` → `session_window.rs` or extend `runtime/mod.rs`.
+- Move window-scoped session wiring out of `mod.rs` → `window_appearance.rs` (started in #319).
 - **Exit:** `mod.rs` −300 lines; no behavior change; tests unchanged count.
+- **Progress:** `window_appearance.rs` holds background blur/opacity + system appearance handlers (~196 lines removed from `mod.rs`).
 
 ### Tranche 2 — Tab lifecycle boundary (E1 Q2–Q3)
 


### PR DESCRIPTION
## Summary

Engineering roadmap **E1 tranche 1** — extract window background and system theme glue from `terminal_view/mod.rs` into `window_appearance.rs`.

- ~196 lines removed from `mod.rs` (5574 → 5378)
- 6 background-appearance tests moved with the code
- Public `initial_window_background_appearance` re-export unchanged for `main.rs` / settings

## Depends on

None (orthogonal to #318 native tab removal). Merge order flexible.

## Test plan

- [x] `cargo test -p termy --release` (600 tests)
- [x] `cargo test -p termy window_appearance --release`

## Roadmap

Next: tranche 2 (tab lifecycle boundary), continue shrinking allowlist in `check-file-sizes.sh`.