### PR TITLE
Add Vercel deployment config for website

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -5,3 +5,28 @@ Run development server:
 ```bash
 bun run dev
 ```
+
+Build:
+
+```bash
+bun run build
+```
+
+The build uses the Nitro `bun` preset by default (see `vite.config.ts`), which
+the `Dockerfile` serves via `bun run start`.
+
+## Deploying to Vercel
+
+Deployment is configured in `vercel.json`. It sets `NITRO_PRESET=vercel` at
+build time, so the build emits Vercel's Build Output API artifacts to
+`.vercel/output`, which Vercel detects automatically.
+
+When importing the repo into Vercel, set the project **Root Directory** to
+`website`. No other configuration is required — `vercel.json` provides the
+install and build commands.
+
+To reproduce the Vercel build locally:
+
+```bash
+NITRO_PRESET=vercel bun run build
+```

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": null,
+  "installCommand": "bun install --frozen-lockfile",
+  "buildCommand": "bun run build",
+  "build": {
+    "env": {
+      "NITRO_PRESET": "vercel"
+    }
+  }
+}

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -5,6 +5,11 @@ import tailwindcss from "@tailwindcss/vite";
 import mdx from "fumadocs-mdx/vite";
 import { nitro } from "nitro/vite";
 
+// Default to the `bun` preset for local dev and the Docker image. Deployment
+// targets (e.g. Vercel) override this via the NITRO_PRESET env var at build
+// time — see vercel.json.
+const preset = process.env.NITRO_PRESET ?? "bun";
+
 export default defineConfig({
   server: {
     port: 3000,
@@ -19,7 +24,7 @@ export default defineConfig({
     }),
     react(),
     nitro({
-      preset: "bun",
+      preset,
       traceDeps: ["tslib*"],
     }),
   ],


### PR DESCRIPTION
Enables deploying the website to Vercel without breaking the existing Docker/bun workflow.

## Changes
- **`vite.config.ts`** — Nitro preset is now env-driven (`process.env.NITRO_PRESET ?? "bun"`). Local dev and the Docker image keep using the `bun` preset; deployment targets override it.
- **`vercel.json`** (new) — sets install/build commands and `NITRO_PRESET=vercel` at build time, so the build emits Build Output API v3 artifacts to `.vercel/output` that Vercel auto-detects.
- **`README.md`** — documents the Vercel flow.

## Manual step
When importing into Vercel, set the project **Root Directory** to `website`. Everything else comes from `vercel.json`.

## Verification
Ran `NITRO_PRESET=vercel bun run build` locally — produced a valid `.vercel/output` (`config.json` v3, `__server` function, prerendered static pages).