### PR TITLE
Avoid auto-submitting deeplink commands

### DIFF
--- a/crates/desktop_app/src/terminal_view/interaction/actions.rs
+++ b/crates/desktop_app/src/terminal_view/interaction/actions.rs
@@ -771,12 +771,9 @@ fn is_safe_deeplink_terminal_input(value: &str) -> bool {
 }
 
 fn deeplink_command_terminal_input(value: &str) -> Option<String> {
-    let mut input = value.trim().to_string();
+    let input = value.trim().to_string();
     if !is_safe_deeplink_terminal_input(&input) {
         return None;
-    }
-    if !input.ends_with('\n') {
-        input.push('\n');
     }
     Some(input)
 }
@@ -845,10 +842,10 @@ mod tests {
     }
 
     #[test]
-    fn deeplink_command_input_appends_newline() {
+    fn deeplink_command_input_does_not_append_newline() {
         assert_eq!(
             deeplink_command_terminal_input("git status").as_deref(),
-            Some("git status\n")
+            Some("git status")
         );
     }
 


### PR DESCRIPTION
### Motivation
- Prevent untrusted external `termy://new?cmd=...` deeplinks from automatically submitting shell commands in a newly opened terminal by stopping automatic newline append behavior.

### Description
- Remove the automatic newline append in `deeplink_command_terminal_input` so validated deeplink text is placed into the terminal but not executed, and update the corresponding unit test in `crates/desktop_app/src/terminal_view/interaction/actions.rs` to assert no newline is appended.

### Testing
- Ran `cargo fmt --check` and `git diff --check`, both succeeded, and ran `cargo test -p termy deeplink_command_input` which could not complete in this environment due to missing system libraries (`-lxkbcommon` and `-lxkbcommon-x11`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3485a7e568832a92afde742429dc8d)