### PR TITLE
Disable command execution from deeplinks

### DIFF
--- a/crates/desktop_app/src/deeplink.rs
+++ b/crates/desktop_app/src/deeplink.rs
@@ -1,6 +1,5 @@
 use url::Url;
 
-const MAX_DEEPLINK_COMMAND_LEN: usize = 4096;
 const MAX_DEEPLINK_DIR_LEN: usize = 4096;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -55,9 +54,9 @@ impl DeepLinkRoute {
         match segments.as_slice() {
             [] => Ok((Self::Activate, None)),
             ["new"] => {
-                let command = parse_query_value(&url, "cmd")
-                    .map(|value| validate_deeplink_text(value, "cmd", MAX_DEEPLINK_COMMAND_LEN))
-                    .transpose()?;
+                // Do not honor ?cmd= from external URL protocol launches. Writing
+                // deeplink-controlled bytes into a PTY can execute commands.
+                let command = None;
                 let dir = parse_query_value(&url, "dir")
                     .map(|value| validate_deeplink_text(value, "dir", MAX_DEEPLINK_DIR_LEN))
                     .transpose()?;
@@ -139,20 +138,14 @@ mod tests {
         assert_eq!(DeepLinkRoute::parse("termy://new"), Ok((NewTab, None)));
         assert_eq!(
             DeepLinkRoute::parse("termy://new?cmd=git%20status"),
-            Ok((
-                NewTab,
-                Some(DeepLinkArgument::NewTab(NewTabDeepLink {
-                    command: Some("git status".to_string()),
-                    dir: None,
-                }))
-            ))
+            Ok((NewTab, None))
         );
         assert_eq!(
             DeepLinkRoute::parse("termy://new?cmd=git%20status&dir=%2Ftmp%2Fdemo"),
             Ok((
                 NewTab,
                 Some(DeepLinkArgument::NewTab(NewTabDeepLink {
-                    command: Some("git status".to_string()),
+                    command: None,
                     dir: Some("/tmp/demo".to_string()),
                 }))
             ))
@@ -160,8 +153,15 @@ mod tests {
     }
 
     #[test]
+    fn ignores_new_tab_command_values() {
+        assert_eq!(
+            DeepLinkRoute::parse("termy://new?cmd=git%20status%0A"),
+            Ok((NewTab, None))
+        );
+    }
+
+    #[test]
     fn rejects_new_tab_control_characters() {
-        assert!(DeepLinkRoute::parse("termy://new?cmd=git%20status%0A").is_err());
         assert!(DeepLinkRoute::parse("termy://new?dir=%2Ftmp%2Fdemo%0D").is_err());
     }
 

--- a/crates/desktop_app/src/main.rs
+++ b/crates/desktop_app/src/main.rs
@@ -746,7 +746,7 @@ mod tests {
     }
 
     #[gpui::test]
-    fn new_tab_deeplink_passes_optional_command(cx: &mut TestAppContext) {
+    fn new_tab_deeplink_ignores_optional_command(cx: &mut TestAppContext) {
         let handled = RefCell::new(Vec::new());
 
         cx.update(|app| {
@@ -762,20 +762,11 @@ mod tests {
         });
 
         assert_eq!(cx.windows().len(), 1);
-        assert_eq!(
-            *handled.borrow(),
-            vec![(
-                DeepLinkRoute::NewTab,
-                Some(DeepLinkArgument::NewTab(NewTabDeepLink {
-                    command: Some("git status".to_string()),
-                    dir: None,
-                }))
-            )]
-        );
+        assert_eq!(*handled.borrow(), vec![(DeepLinkRoute::NewTab, None)]);
     }
 
     #[gpui::test]
-    fn new_tab_deeplink_passes_optional_command_and_dir(cx: &mut TestAppContext) {
+    fn new_tab_deeplink_ignores_optional_command_and_passes_dir(cx: &mut TestAppContext) {
         let handled = RefCell::new(Vec::new());
 
         cx.update(|app| {
@@ -798,7 +789,7 @@ mod tests {
             vec![(
                 DeepLinkRoute::NewTab,
                 Some(DeepLinkArgument::NewTab(NewTabDeepLink {
-                    command: Some("git status".to_string()),
+                    command: None,
                     dir: Some("/tmp/demo".to_string()),
                 }))
             )]

--- a/crates/desktop_app/src/terminal_view/interaction/actions.rs
+++ b/crates/desktop_app/src/terminal_view/interaction/actions.rs
@@ -342,13 +342,9 @@ impl TerminalView {
     ) {
         let _ = window;
         self.add_tab_with_working_dir(working_dir, cx);
-        if let Some(command_input) = command.and_then(deeplink_command_terminal_input)
-            && let Some(tab) = self.tabs.get(self.active_tab)
-            && let Some(terminal) = tab.active_terminal()
-        {
-            terminal.write_input(command_input.as_bytes());
-            cx.notify();
-        }
+        // Deeplinks may originate from browsers or documents via the OS URL
+        // protocol handler, so never write deeplink-provided commands to a PTY.
+        let _ = command;
     }
 
     pub(in super::super) fn handle_close_tab_action(
@@ -766,21 +762,6 @@ impl TerminalView {
     }
 }
 
-fn is_safe_deeplink_terminal_input(value: &str) -> bool {
-    !value.is_empty() && value.len() <= 4096 && !value.bytes().any(|byte| byte.is_ascii_control())
-}
-
-fn deeplink_command_terminal_input(value: &str) -> Option<String> {
-    let mut input = value.trim().to_string();
-    if !is_safe_deeplink_terminal_input(&input) {
-        return None;
-    }
-    if !input.ends_with('\n') {
-        input.push('\n');
-    }
-    Some(input)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -842,18 +823,5 @@ mod tests {
         assert!(!TerminalView::simple_mode_blocks_command_action(
             CommandAction::OpenConfig
         ));
-    }
-
-    #[test]
-    fn deeplink_command_input_appends_newline() {
-        assert_eq!(
-            deeplink_command_terminal_input("git status").as_deref(),
-            Some("git status\n")
-        );
-    }
-
-    #[test]
-    fn deeplink_command_input_rejects_control_characters() {
-        assert_eq!(deeplink_command_terminal_input("git\nstatus"), None);
     }
 }


### PR DESCRIPTION
### Motivation
- Close a Windows custom-protocol RCE vector where `termy://new?cmd=...` launches could URL-decode attacker-controlled bytes (including CR/LF) and write them directly to the PTY. 
- Prevent OS/browser-invoked `termy://` protocol handlers from injecting commands that execute with the user's privileges. 
- Preserve safe deeplink functionality such as opening a new tab and passing a working directory via `?dir=`.

### Description
- Stop honoring `?cmd=` on external `termy://new` deeplinks by forcing `command = None` in `crates/desktop_app/src/deeplink.rs` and keeping `dir` handling intact. 
- Add a defensive change in `crates/desktop_app/src/terminal_view/interaction/actions.rs` so `open_new_tab_from_deeplink` never writes deeplink-provided command text into the PTY and removed the helper that transformed deeplink `cmd` into terminal input. 
- Update unit tests in `crates/desktop_app/src/deeplink.rs` and `crates/desktop_app/src/main.rs` to reflect that `cmd` values are ignored while `dir` values continue to be validated and passed through. 
- No changes to other deeplink routes (`settings`, `open/config`, `store/theme-install`) or existing theme/install deeplink handling.

### Testing
- Ran `cargo fmt` to normalize formatting (succeeded). 
- Ran `git diff --check` to ensure no leftover whitespace issues (succeeded). 
- Ran `cargo check -p termy` to validate the workspace compiles (succeeded). 
- Attempted `cargo test -p termy deeplink`; test invocation and build progressed but the full `cargo test` run failed at the final linker step in this environment due to missing system libraries (`xkbcommon` / `xkbcommon-x11`), so tests that require those platform libs could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a349fad106c832ab84d6fd01d5a2c9f)