### PR TITLE
Fix macOS bracketed paste handling

### DIFF
--- a/macos/Sources/TermySwift/App/TermySwiftApp.swift
+++ b/macos/Sources/TermySwift/App/TermySwiftApp.swift
@@ -635,7 +635,7 @@ private final class ConfiguredKeybindRouter {
             guard let text = NSPasteboard.general.string(forType: .string) else {
                 return false
             }
-            TerminalCommandRouter.shared.focusedStore(for: event)?.focusedTerminal?.send(bytes: Array(text.utf8))
+            TerminalCommandRouter.shared.focusedStore(for: event)?.focusedTerminal?.paste(text)
             return true
         case .openSearch:
             return withFocusedStore(event) { $0.showSearch() }

--- a/macos/Sources/TermySwift/Services/TerminalViewModel.swift
+++ b/macos/Sources/TermySwift/Services/TerminalViewModel.swift
@@ -395,9 +395,11 @@ final class TerminalViewModel: ObservableObject {
             return
         }
 
-        // Strip any embedded paste terminator so the payload can't close the
-        // bracket early. `\u{1b}[201~` is the only sequence that ends a paste.
-        let sanitized = text.replacingOccurrences(of: "\u{1b}[201~", with: "")
+        // Strip embedded bracketed-paste markers so the payload can't close
+        // the bracket early or smuggle a nested framed paste sequence.
+        let sanitized = text
+            .replacingOccurrences(of: "\u{1b}[200~", with: "")
+            .replacingOccurrences(of: "\u{1b}[201~", with: "")
         var bytes = Array("\u{1b}[200~".utf8)
         bytes.append(contentsOf: sanitized.utf8)
         bytes.append(contentsOf: Array("\u{1b}[201~".utf8))

--- a/macos/Sources/TermySwift/Views/TerminalWorkspaceView.swift
+++ b/macos/Sources/TermySwift/Views/TerminalWorkspaceView.swift
@@ -187,7 +187,7 @@ struct TerminalWorkspaceView: View {
                 guard let text = NSPasteboard.general.string(forType: .string) else {
                     return
                 }
-                store.focusedTerminal?.send(bytes: Array(text.utf8))
+                store.focusedTerminal?.paste(text)
             },
             clearScrollback: {
                 store.focusedTerminal?.clearScrollback()


### PR DESCRIPTION
### Motivation
- Close a security gap where macOS paste paths forwarded raw clipboard bytes directly to the PTY, bypassing bracketed-paste framing and allowing pasted newlines to be interpreted as typed input. 
- Ensure the Swift macOS host follows the same bracketed-paste protections as the desktop implementation by routing all paste actions through the sanitizer/framing logic. 

### Description
- Route menu/command-palette/configured-keybind paste actions to `TerminalViewModel.paste(_:)` instead of calling `send(bytes: Array(text.utf8))`, updating `macos/Sources/TermySwift/App/TermySwiftApp.swift` and `macos/Sources/TermySwift/Views/TerminalWorkspaceView.swift` to use `paste(text)`. 
- Harden `paste(_:)` sanitization in `macos/Sources/TermySwift/Services/TerminalViewModel.swift` to strip both embedded `ESC[200~` and `ESC[201~` markers before wrapping the payload with `ESC[200~`/`ESC[201~`. 
- Preserve existing behavior when bracketed-paste mode is disabled by falling back to the previous raw `send(bytes:)` path. 

### Testing
- Ran `git diff --check`, which produced no whitespace or diff-check issues (success). 
- Attempted `swift test -c debug`, but it cannot run in this Linux environment because the macOS target imports `AppKit` (error: `no such module 'AppKit'`), so macOS-specific build/test steps were blocked and could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a348fa95f48832aaca8844399365505)