### PR TITLE
Reject unsafe control characters in dropped paths

### DIFF
--- a/macos/Sources/TermySwift/Support/TerminalDropInput.swift
+++ b/macos/Sources/TermySwift/Support/TerminalDropInput.swift
@@ -63,11 +63,20 @@ enum TerminalDropInput {
         guard !paths.isEmpty else {
             return nil
         }
+        guard paths.allSatisfy({ !containsTerminalControlCharacter($0) }) else {
+            return nil
+        }
 
         let text = paths
             .map(shellQuotePath)
             .joined(separator: " ") + " "
         return Array(text.utf8)
+    }
+
+    static func containsTerminalControlCharacter(_ path: String) -> Bool {
+        path.unicodeScalars.contains { scalar in
+            scalar.value < 0x20 || scalar.value == 0x7F
+        }
     }
 
     private static func shellQuotePath(_ path: String) -> String {

--- a/macos/Tests/TermySwiftTests/TerminalKeyboardInputViewTests.swift
+++ b/macos/Tests/TermySwiftTests/TerminalKeyboardInputViewTests.swift
@@ -74,6 +74,13 @@ final class TerminalKeyboardInputViewTests: XCTestCase {
         XCTAssertNil(view.hitTest(NSPoint(x: 50, y: 50)))
     }
 
+    func testDropInputRejectsTerminalControlCharactersInPaths() {
+        XCTAssertFalse(TerminalDropInput.containsTerminalControlCharacter("/tmp/safe file's name.txt"))
+        XCTAssertTrue(TerminalDropInput.containsTerminalControlCharacter("/tmp/\u{15}open -a Calculator\n"))
+        XCTAssertTrue(TerminalDropInput.containsTerminalControlCharacter("/tmp/carriage\rreturn"))
+        XCTAssertTrue(TerminalDropInput.containsTerminalControlCharacter("/tmp/delete\u{7f}char"))
+    }
+
     private static func escapeEvent() -> NSEvent {
         NSEvent.keyEvent(
             with: .keyDown,


### PR DESCRIPTION
### Motivation
- Prevent command injection via macOS drag-and-drop by refusing to send dropped file paths that contain C0 control characters or DEL to the PTY before shell-quoting.

### Description
- Add a check in `TerminalDropInput.shellQuotedBytes(for:)` to return `nil` if any path contains terminal control characters detected by `containsTerminalControlCharacter`.
- Implement `containsTerminalControlCharacter(_:)` to detect Unicode scalars with value `< 0x20` or `== 0x7F` and preserve the existing single-quote shell-quoting behavior in `shellQuotePath`.
- Add a unit test `testDropInputRejectsTerminalControlCharactersInPaths` in `macos/Tests/TermySwiftTests/TerminalKeyboardInputViewTests.swift` that asserts safe and malicious path examples are classified correctly.

### Testing
- Ran `swift test` in the container, but the test run failed because the macOS target imports `AppKit`, which is unavailable in this Linux environment, so automated tests could not complete.
- The new unit test was added to cover the control-character detection logic, but full execution must be validated on macOS where `AppKit` is present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a348f17d840832abb19b8603cf4574d)