### PR TITLE
Avoid UI dependency in xtask

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8819,7 +8819,7 @@ dependencies = [
  "tempfile",
  "termy_command_core",
  "termy_config_core",
- "termy_terminal_ui",
+ "termy_core",
 ]
 
 [[package]]

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -14,4 +14,4 @@ serde_json = { workspace = true }
 tempfile = { workspace = true }
 termy_command_core = { path = "../command_core" }
 termy_config_core = { path = "../config_core" }
-termy_terminal_ui = { path = "../terminal_ui" }
+termy_core = { path = "../core" }

--- a/crates/xtask/src/benchmark.rs
+++ b/crates/xtask/src/benchmark.rs
@@ -13,7 +13,7 @@ use std::{
     thread,
     time::{Duration, Instant},
 };
-use termy_terminal_ui::monotonic_now_ns;
+use termy_core::monotonic_now_ns;
 
 const DEFAULT_DURATION_SECS: u64 = 13;
 // Give launched apps enough room to finish the benchmark command, flush metrics,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Pull Request

## Description

- Switch `xtask` benchmark timestamp usage from `termy_terminal_ui` to `termy_core`.
- Drop the GPUI terminal UI dependency from `xtask` so `cargo run -p xtask -- check-dependency-policy` does not require Linux X11/xkb development libraries.
- Update `Cargo.lock` for the internal dependency change.

## Screenshots/Videos

N/A

## Related Issues

Fixes the release workflow failure in https://github.com/lassejlv/termy/actions/runs/27867833028

## Checklist

- [ ] I confirmed there is no existing open PR for the same or overlapping changes.
- [x] I ran the smallest validation pass for this change (see [CONTRIBUTING.md](CONTRIBUTING.md#testing-and-validation)).
- [x] `just check-boundaries` (if deps, config keys, commands, or generated docs changed). (`just` unavailable locally; ran `./scripts/check-boundaries.sh` directly.)
- [x] `just test-workspace` or targeted `cargo test -p <crate>` (if Rust behavior changed). (`cargo test -p xtask`)
- [ ] `just fmt-check` (if Rust formatting may have drifted). (Not run; no formatting-sensitive edits.)
- [ ] `just test-tmux-integration` (if tmux behavior changed). (Not applicable.)
- [ ] Regenerated `docs/configuration.md` / `docs/keybindings.md` when schema or defaults changed. (Not applicable.)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2c973bb-560b-437e-b2cb-556248fcc331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2c973bb-560b-437e-b2cb-556248fcc331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

