### PR TITLE
[codex] Fix macOS native tab chrome

### DIFF
--- a/macos/Sources/TermySwift/App/TermySwiftApp.swift
+++ b/macos/Sources/TermySwift/App/TermySwiftApp.swift
@@ -1228,13 +1228,13 @@ final class NativeTabWindowManager: NSObject, NSWindowDelegate {
             windows.append(window)
         }
 
-        append(sourceWindow)
         if let tabGroup = sourceWindow.tabGroup {
             tabGroup.windows.forEach(append)
             NSApp.windows
                 .filter { $0.tabGroup === tabGroup }
                 .forEach(append)
         }
+        append(sourceWindow)
         sourceWindow.tabbedWindows?.forEach(append)
 
         return windows.filter(isNativeTerminalTabWindow)
@@ -1301,6 +1301,18 @@ final class NativeTabWindowManager: NSObject, NSWindowDelegate {
             ),
             for: window
         )
+    }
+
+    @discardableResult
+    func applyFocusedTerminalChrome(for store: TerminalWorkspaceStore) -> Bool {
+        var didApply = false
+        for window in NSApp.windows where isNativeTerminalTabWindow(window) {
+            guard TerminalCommandRouter.shared.store(forWindow: window) === store else {
+                continue
+            }
+            didApply = applyFocusedTerminalChrome(for: window) || didApply
+        }
+        return didApply
     }
 
     @discardableResult

--- a/macos/Sources/TermySwift/Services/TerminalViewModel.swift
+++ b/macos/Sources/TermySwift/Services/TerminalViewModel.swift
@@ -238,6 +238,12 @@ final class TerminalViewModel: ObservableObject {
         }
     }
 
+    /// While a tab is suspended (its window is occluded), we deliberately keep the
+    /// wakeup monitor running and drain PTY events without presenting a frame.
+    /// This is intentional: a fully-stopped backgrounded shell would block once
+    /// the PTY buffer fills (e.g. a build logging in a hidden tab), so we consume
+    /// output to keep it flowing. Draining without rendering is far cheaper than a
+    /// full `pollAndPresent`, so the occlusion CPU savings are largely preserved.
     private func drainEventsWhileSuspended() {
         do {
             handle(try terminal?.drainEvents() ?? [])

--- a/macos/Sources/TermySwift/Services/TerminalViewModel.swift
+++ b/macos/Sources/TermySwift/Services/TerminalViewModel.swift
@@ -221,7 +221,7 @@ final class TerminalViewModel: ObservableObject {
         // `cat bigfile`) schedules an extra full poll per chunk on top of the
         // 60 Hz link — `pendingWakeupPoll` only coalesces within a single
         // runloop turn, so the effective poll rate is otherwise unbounded.
-        guard terminal != nil, !isSuspended, cadence != .active, !pendingWakeupPoll else {
+        guard terminal != nil, cadence != .active, !pendingWakeupPoll else {
             return
         }
         pendingWakeupPoll = true
@@ -230,7 +230,19 @@ final class TerminalViewModel: ObservableObject {
                 return
             }
             self.pendingWakeupPoll = false
-            self.pollAndPresent()
+            if self.isSuspended {
+                self.drainEventsWhileSuspended()
+            } else {
+                self.pollAndPresent()
+            }
+        }
+    }
+
+    private func drainEventsWhileSuspended() {
+        do {
+            handle(try terminal?.drainEvents() ?? [])
+        } catch {
+            report(error)
         }
     }
 
@@ -299,7 +311,6 @@ final class TerminalViewModel: ObservableObject {
         applyConfiguredScrollbackLimit()
         refreshDriver?.stop()
         refreshDriver = nil
-        terminal?.stopWakeupMonitor()
         pendingResizeRefresh?.cancel()
         pendingResizeRefresh = nil
     }

--- a/macos/Sources/TermySwift/Views/TerminalSurfaceView.swift
+++ b/macos/Sources/TermySwift/Views/TerminalSurfaceView.swift
@@ -463,6 +463,7 @@ enum TerminalWindowChromeApplier {
         }
         window.titlebarAppearsTransparent = true
         window.backgroundColor = state.chromeBackgroundColor
+        TerminalWindowBlur.sync(state, in: window)
         let isOpaque = !state.requiresTransparentWindow
         if window.isOpaque != isOpaque {
             window.isOpaque = isOpaque
@@ -488,6 +489,10 @@ enum TerminalWindowChromeApplier {
             return true
         }
 
+        if TerminalWindowBlur.shouldInstall(for: state) != TerminalWindowBlur.contains(in: window) {
+            return true
+        }
+
         let expectedColor = state.chromeBackgroundColor.usingColorSpace(.sRGB)
         let actualColor = window.backgroundColor.usingColorSpace(.sRGB)
         guard let expectedColor, let actualColor else {
@@ -497,6 +502,62 @@ enum TerminalWindowChromeApplier {
             || abs(actualColor.greenComponent - expectedColor.greenComponent) > 0.001
             || abs(actualColor.blueComponent - expectedColor.blueComponent) > 0.001
             || abs(actualColor.alphaComponent - expectedColor.alphaComponent) > 0.001
+    }
+}
+
+@MainActor
+enum TerminalWindowBlur {
+    private static let identifier = NSUserInterfaceItemIdentifier("TermyWindowBlur")
+
+    static func shouldInstall(for state: TerminalWindowChromeState) -> Bool {
+        state.backgroundBlur && state.effectiveBackgroundAlpha < 0.999
+    }
+
+    static func contains(in window: NSWindow) -> Bool {
+        blurView(in: window) != nil
+    }
+
+    static func sync(_ state: TerminalWindowChromeState, in window: NSWindow) {
+        guard shouldInstall(for: state) else {
+            blurView(in: window)?.removeFromSuperview()
+            return
+        }
+        guard let container = window.contentView else {
+            return
+        }
+        let blurView = blurView(in: window) ?? makeBlurView(for: container)
+        if blurView.superview == nil {
+            container.addSubview(blurView, positioned: .below, relativeTo: container.subviews.first)
+        }
+        blurView.frame = container.bounds
+    }
+
+    private static func makeBlurView(for container: NSView) -> NSVisualEffectView {
+        let blurView = NSVisualEffectView(frame: container.bounds)
+        blurView.identifier = identifier
+        blurView.autoresizingMask = [.width, .height]
+        blurView.blendingMode = .behindWindow
+        blurView.material = .underWindowBackground
+        blurView.state = .active
+        return blurView
+    }
+
+    private static func blurView(in window: NSWindow) -> NSVisualEffectView? {
+        window.contentView?.firstDescendant(identifier: identifier) as? NSVisualEffectView
+    }
+}
+
+private extension NSView {
+    func firstDescendant(identifier: NSUserInterfaceItemIdentifier) -> NSView? {
+        for subview in subviews {
+            if subview.identifier == identifier {
+                return subview
+            }
+            if let found = subview.firstDescendant(identifier: identifier) {
+                return found
+            }
+        }
+        return nil
     }
 }
 

--- a/macos/Sources/TermySwift/Views/TerminalWorkspaceView.swift
+++ b/macos/Sources/TermySwift/Views/TerminalWorkspaceView.swift
@@ -36,6 +36,9 @@ struct TerminalWorkspaceView: View {
             .onReceive(NotificationCenter.default.publisher(for: NSApplication.willTerminateNotification)) { _ in
                 persistWorkspace()
             }
+            .onReceive(NotificationCenter.default.publisher(for: .termyNativeTabsChanged)) { _ in
+                NativeTabWindowManager.shared.applyFocusedTerminalChrome(for: store)
+            }
             .onReceive(configurationStore.$loadErrorMessage) { message in
                 appConfigurationError = message
             }

--- a/macos/Sources/TermySwift/Views/TerminalWorkspaceView.swift
+++ b/macos/Sources/TermySwift/Views/TerminalWorkspaceView.swift
@@ -922,18 +922,29 @@ private struct TerminalPaneLeafView: View {
                     }
                 )
 
-                if isDropTargeted, activeDropPlacement != nil {
-                    TerminalPaneDropPlacementOverlay(activePlacement: activeDropPlacement)
-                        .transition(.opacity)
-                        .allowsHitTesting(false)
+                // While any pane is being dragged, show the four drop bands on
+                // every other pane so the available placements are visible; the
+                // pane under the cursor highlights its nearest band.
+                if let draggingID = store.draggingPaneID, draggingID != pane.id {
+                    TerminalPaneDropPlacementOverlay(
+                        activePlacement: isDropTargeted ? activeDropPlacement : nil
+                    )
+                    .transition(.opacity)
+                    .allowsHitTesting(false)
                 }
 
                 if dragEnabled {
-                    TerminalPaneDragHandle(isSuppressed: isDropTargeted) {
-                        store.focus(pane)
-                        store.beginDraggingPane(pane.id)
-                        return TerminalPaneDragPayload.itemProvider(for: pane.id)
-                    }
+                    TerminalPaneDragHandle(
+                        isSuppressed: store.draggingPaneID != nil,
+                        onBegin: {
+                            store.focus(pane)
+                            store.beginDraggingPane(pane.id)
+                            return TerminalPaneDragPayload.pasteboardItem(for: pane.id)
+                        },
+                        onEnd: {
+                            store.endDraggingPane()
+                        }
+                    )
                     .padding(.top, 5)
                 }
 
@@ -944,6 +955,7 @@ private struct TerminalPaneLeafView: View {
                         .allowsHitTesting(false)
                 }
             }
+            .animation(.easeOut(duration: 0.12), value: store.draggingPaneID)
             .onDrop(
                 of: [UTType.termyPaneDrag],
                 delegate: TerminalPaneDropDelegate(
@@ -969,16 +981,16 @@ private extension UTType {
 }
 
 private enum TerminalPaneDragPayload {
-    static func itemProvider(for paneID: UUID) -> NSItemProvider {
-        let provider = NSItemProvider()
-        provider.registerDataRepresentation(
-            forTypeIdentifier: UTType.termyPaneDrag.identifier,
-            visibility: .ownProcess
-        ) { completion in
-            completion(Data(paneID.uuidString.utf8), nil)
-            return nil
-        }
-        return provider
+    /// The drag carries the pane id under our custom UTType so SwiftUI's
+    /// `.onDrop` validates it. `NSPasteboardItem` (unlike `NSItemProvider`)
+    /// conforms to `NSPasteboardWriting`, so it can back an `NSDraggingItem`.
+    static func pasteboardItem(for paneID: UUID) -> NSPasteboardItem {
+        let item = NSPasteboardItem()
+        item.setData(
+            Data(paneID.uuidString.utf8),
+            forType: NSPasteboard.PasteboardType(UTType.termyPaneDrag.identifier)
+        )
+        return item
     }
 }
 
@@ -1060,38 +1072,34 @@ private struct TerminalPaneDropDelegate: DropDelegate {
 
 private struct TerminalPaneDragHandle: View {
     let isSuppressed: Bool
-    let itemProvider: () -> NSItemProvider
+    let onBegin: () -> NSPasteboardItem
+    let onEnd: () -> Void
 
     @State private var isHovered = false
 
-    var body: some View {
-        dots(opacity: 0.86)
-        .frame(width: 34, height: 18)
-        .contentShape(Rectangle())
-        .opacity(isVisible ? 1 : 0)
-        .scaleEffect(isVisible ? 1 : 0.94)
-        .animation(.easeOut(duration: 0.1), value: isVisible)
-        .allowsHitTesting(!isSuppressed)
-        .onHover { hovering in
-            isHovered = hovering
-            if hovering {
-                NSCursor.pointingHand.set()
-            } else {
-                NSCursor.arrow.set()
-            }
-        }
-        .onDrag {
-            itemProvider()
-        } preview: {
-            dots(opacity: 1)
-                .frame(width: 26, height: 12)
-        }
-        .accessibilityLabel("Move pane")
-        .help("Move Pane")
-    }
-
     private var isVisible: Bool {
         isHovered && !isSuppressed
+    }
+
+    var body: some View {
+        dots(opacity: 0.86)
+            .frame(width: 34, height: 18)
+            .opacity(isVisible ? 1 : 0)
+            .scaleEffect(isVisible ? 1 : 0.94)
+            .animation(.easeOut(duration: 0.1), value: isVisible)
+            // A transparent AppKit view sits on top to own hit-testing, the grab
+            // cursor, and the drag itself — SwiftUI's `.onDrag`/`.onHover` never
+            // fire here because the terminal surface NSView consumes the mouse.
+            .overlay(
+                PaneDragSourceRepresentable(
+                    isEnabled: !isSuppressed,
+                    onHoverChange: { isHovered = $0 },
+                    onBegin: onBegin,
+                    onEnd: onEnd
+                )
+            )
+            .accessibilityLabel("Move pane")
+            .help("Move Pane")
     }
 
     private func dots(opacity: Double) -> some View {
@@ -1101,6 +1109,142 @@ private struct TerminalPaneDragHandle: View {
                     .fill(Color.secondary.opacity(opacity))
                     .frame(width: 3, height: 3)
             }
+        }
+    }
+}
+
+private struct PaneDragSourceRepresentable: NSViewRepresentable {
+    let isEnabled: Bool
+    let onHoverChange: (Bool) -> Void
+    let onBegin: () -> NSPasteboardItem
+    let onEnd: () -> Void
+
+    func makeNSView(context: Context) -> PaneDragSourceView {
+        let view = PaneDragSourceView()
+        apply(to: view)
+        return view
+    }
+
+    func updateNSView(_ view: PaneDragSourceView, context: Context) {
+        apply(to: view)
+        if !isEnabled {
+            view.onHoverChange(false)
+        }
+    }
+
+    private func apply(to view: PaneDragSourceView) {
+        view.onHoverChange = onHoverChange
+        view.onBegin = onBegin
+        view.onEnd = onEnd
+        view.isEnabledForDrag = isEnabled
+    }
+}
+
+/// Transparent overlay that starts a real AppKit drag session for a pane. Using
+/// an NSView (rather than SwiftUI `.onDrag`) is required: the terminal surface
+/// view consumes `mouseDown` before SwiftUI gestures see it. Being the topmost
+/// sibling in the ZStack, this view wins hit-testing for its small footprint.
+final class PaneDragSourceView: NSView, NSDraggingSource {
+    var isEnabledForDrag = true
+    var onHoverChange: (Bool) -> Void = { _ in }
+    var onBegin: () -> NSPasteboardItem = { NSPasteboardItem() }
+    var onEnd: () -> Void = {}
+
+    override var isFlipped: Bool { true }
+
+    // Allow grabbing the handle even when the window isn't key yet.
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        guard isEnabledForDrag, !isHidden else { return nil }
+        return super.hitTest(point)
+    }
+
+    // `cursorUpdate` runs in the window's cursor-management pass, which fires
+    // after the terminal view's per-move `NSCursor.set()`, so the open hand wins.
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        for area in trackingAreas {
+            removeTrackingArea(area)
+        }
+        addTrackingArea(NSTrackingArea(
+            rect: .zero,
+            options: [.activeInActiveApp, .inVisibleRect, .mouseEnteredAndExited, .cursorUpdate],
+            owner: self
+        ))
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        onHoverChange(true)
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        onHoverChange(false)
+    }
+
+    override func cursorUpdate(with event: NSEvent) {
+        NSCursor.openHand.set()
+    }
+
+    override func resetCursorRects() {
+        addCursorRect(bounds, cursor: .openHand)
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        guard isEnabledForDrag else {
+            super.mouseDown(with: event)
+            return
+        }
+
+        // `onBegin` focuses the pane, marks it dragging, and returns the pasteboard
+        // item carrying the pane UTType that the SwiftUI `.onDrop` side validates.
+        let item = NSDraggingItem(pasteboardWriter: onBegin())
+        let image = Self.dotsImage()
+        let local = convert(event.locationInWindow, from: nil)
+        item.setDraggingFrame(
+            NSRect(
+                x: local.x - image.size.width / 2,
+                y: local.y - image.size.height / 2,
+                width: image.size.width,
+                height: image.size.height
+            ),
+            contents: image
+        )
+        NSCursor.closedHand.set()
+        beginDraggingSession(with: [item], event: event, source: self)
+    }
+
+    func draggingSession(
+        _ session: NSDraggingSession,
+        sourceOperationMaskFor context: NSDraggingContext
+    ) -> NSDragOperation {
+        .move
+    }
+
+    func draggingSession(_ session: NSDraggingSession, willBeginAt screenPoint: NSPoint) {
+        NSCursor.closedHand.set()
+    }
+
+    // Fires on drop, cancel, and drop-outside-any-pane — the canonical teardown,
+    // so the placement overlay always clears even if `performDrop` never runs.
+    func draggingSession(
+        _ session: NSDraggingSession,
+        endedAt screenPoint: NSPoint,
+        operation: NSDragOperation
+    ) {
+        NSCursor.openHand.set()
+        onEnd()
+    }
+
+    private static func dotsImage() -> NSImage {
+        let size = NSSize(width: 26, height: 12)
+        return NSImage(size: size, flipped: false) { _ in
+            NSColor.secondaryLabelColor.setFill()
+            for index in 0..<3 {
+                let x = CGFloat(index) * 9 + 4
+                NSBezierPath(ovalIn: NSRect(x: x, y: 4.5, width: 3, height: 3)).fill()
+            }
+            return true
         }
     }
 }

--- a/macos/Sources/TermySwift/Views/TerminalWorkspaceView.swift
+++ b/macos/Sources/TermySwift/Views/TerminalWorkspaceView.swift
@@ -1255,48 +1255,36 @@ private struct TerminalPaneDropPlacementOverlay: View {
     var body: some View {
         GeometryReader { proxy in
             ZStack {
+                // A thin outline marks every pane that can receive the drop.
                 RoundedRectangle(cornerRadius: 8)
-                    .stroke(Color.accentColor.opacity(0.58), lineWidth: 1)
-                    .padding(6)
+                    .strokeBorder(
+                        Color.accentColor.opacity(activePlacement == nil ? 0.3 : 0.55),
+                        lineWidth: 1
+                    )
 
-                ForEach(TerminalPaneDropPlacement.allCases, id: \.self) { placement in
-                    placementBand(placement, in: proxy.size)
+                // On the pane under the cursor, fill the half the dragged pane
+                // will occupy so the resulting split is obvious.
+                if let activePlacement {
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(Color.accentColor.opacity(0.22))
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 6)
+                                .strokeBorder(Color.accentColor.opacity(0.85), lineWidth: 1.5)
+                        }
+                        .frame(
+                            width: activePlacement.splitsHorizontally ? proxy.size.width / 2 : nil,
+                            height: activePlacement.splitsVertically ? proxy.size.height / 2 : nil
+                        )
+                        .frame(
+                            maxWidth: .infinity,
+                            maxHeight: .infinity,
+                            alignment: activePlacement.overlayAlignment
+                        )
+                        .transition(.opacity)
                 }
             }
-            .background(Color.accentColor.opacity(0.035))
-        }
-    }
-
-    private func placementBand(_ placement: TerminalPaneDropPlacement, in size: CGSize) -> some View {
-        RoundedRectangle(cornerRadius: 7)
-            .fill(Color.accentColor.opacity(placement == activePlacement ? 0.34 : 0.13))
-            .overlay {
-                RoundedRectangle(cornerRadius: 7)
-                    .stroke(Color.accentColor.opacity(placement == activePlacement ? 0.82 : 0.28), lineWidth: 1)
-            }
-            .frame(
-                width: placementBandWidth(placement, in: size),
-                height: placementBandHeight(placement, in: size)
-            )
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: placement.overlayAlignment)
-            .padding(12)
-    }
-
-    private func placementBandWidth(_ placement: TerminalPaneDropPlacement, in size: CGSize) -> CGFloat? {
-        switch placement {
-        case .left, .right:
-            return max(32, min(84, size.width * 0.24))
-        case .top, .bottom:
-            return nil
-        }
-    }
-
-    private func placementBandHeight(_ placement: TerminalPaneDropPlacement, in size: CGSize) -> CGFloat? {
-        switch placement {
-        case .left, .right:
-            return nil
-        case .top, .bottom:
-            return max(28, min(72, size.height * 0.22))
+            .padding(5)
+            .animation(.easeOut(duration: 0.1), value: activePlacement)
         }
     }
 }
@@ -1313,6 +1301,14 @@ private extension TerminalPaneDropPlacement {
         case .bottom:
             return .bottom
         }
+    }
+
+    var splitsHorizontally: Bool {
+        self == .left || self == .right
+    }
+
+    var splitsVertically: Bool {
+        self == .top || self == .bottom
     }
 }
 

--- a/macos/Sources/TermySwift/Views/TitlebarTabsWindow.swift
+++ b/macos/Sources/TermySwift/Views/TitlebarTabsWindow.swift
@@ -96,8 +96,29 @@ final class TitlebarTabsWindow: NSWindow, NSToolbarDelegate {
         // is main, moving it on focus changes — so re-pin it every time we gain
         // main. `setupTabBar` is idempotent.
         if titlebarTabs {
+            // Defer a tick so the sync sees the post-transition tab-bar state
+            // (e.g. after closing the key tab, this window only learns it is now
+            // alone via becoming main — there is no accessory-removal callback).
+            DispatchQueue.main.async { [weak self] in
+                self?.syncTitleVisibility()
+            }
             setupTabBar()
         }
+    }
+
+    /// True when the native tab bar is occupying the titlebar row. We gate the
+    /// centered title on the bar's *visibility*, not the tab count: a force-shown
+    /// bar (System Settings "Prefer tabs: Always", or View ▸ Show Tab Bar) leaves
+    /// a lone window at count 1 with a visible bar, so a count-based gate would
+    /// draw the title on top of the strip. `isTabBarVisible` also stays false for
+    /// a leftover empty bar, preserving the no-blank-title intent.
+    private var isTabBarOccupyingRow: Bool {
+        tabGroup?.isTabBarVisible ?? false
+    }
+
+    /// Show the centered window title only when the tab bar is not on the row.
+    private func syncTitleVisibility() {
+        titleField.isHidden = isTabBarOccupyingRow
     }
 
     override func resignMain() {
@@ -161,8 +182,11 @@ final class TitlebarTabsWindow: NSWindow, NSToolbarDelegate {
         super.removeTitlebarAccessoryViewController(at: index)
         if wasTabBar {
             tabBarObserver = nil
-            // Back to a single tab: show the centered title again.
-            titleField.isHidden = false
+            // Back to a single tab: show the centered title again. Defer a tick so
+            // `tabbedWindows` reflects the post-removal count, not the stale group.
+            DispatchQueue.main.async { [weak self] in
+                self?.syncTitleVisibility()
+            }
         }
     }
 
@@ -177,7 +201,7 @@ final class TitlebarTabsWindow: NSWindow, NSToolbarDelegate {
               let tabBarView = self.tabBarView
         else {
             // No tab bar present (single tab): show the centered title.
-            titleField.isHidden = false
+            syncTitleVisibility()
             return
         }
 
@@ -194,8 +218,9 @@ final class TitlebarTabsWindow: NSWindow, NSToolbarDelegate {
             return
         }
 
-        // A tab bar exists: hide the centered title so it doesn't overlap.
-        titleField.isHidden = true
+        // A tab bar exists: hide the centered title so it doesn't overlap (unless
+        // this is a lone window with a leftover empty bar).
+        syncTitleVisibility()
 
         // Keep the tab bar from being vertically stretched: AppKit sizes the new
         // tab button square, so match the bar height to its width.

--- a/macos/Sources/TermySwift/Views/TitlebarTabsWindow.swift
+++ b/macos/Sources/TermySwift/Views/TitlebarTabsWindow.swift
@@ -7,11 +7,15 @@ import AppKit
 /// AppKit normally adds the window tab bar as an `NSTitlebarAccessoryViewController`
 /// laid out as a full-width strip *below* the titlebar. Hiding the window title
 /// only collapses the (empty) title row; the tab strip still sits on its own
-/// line. To merge it into the traffic-light row we (1) install an empty
-/// `NSToolbar` with `toolbarStyle = .unifiedCompact` so the titlebar and toolbar
-/// share one band, and (2) flip the tab accessory's `layoutAttribute` to `.right`
-/// and constrain its clip view into that unified `NSToolbarView`, leaving a
-/// gutter on the left for the window buttons.
+/// line. To merge it into the traffic-light row we (1) install an `NSToolbar`
+/// with `toolbarStyle = .unifiedCompact` so the titlebar and toolbar share one
+/// band, and (2) flip the tab accessory's `layoutAttribute` to `.right` and
+/// constrain its clip view into that unified `NSToolbarView`, leaving a gutter on
+/// the left for the window buttons.
+///
+/// When there is only one tab (no tab bar), a centered toolbar item shows the
+/// window title instead — matching Ghostty. The title item collapses to nothing
+/// while the tab bar is present.
 ///
 /// This is the macOS 26 (Tahoe) technique, ported from Ghostty's
 /// `TitlebarTabsTahoeTerminalWindow`. It relies on private AppKit view-class
@@ -20,11 +24,14 @@ import AppKit
 /// lookup is guarded and early-returns on mismatch, so on an OS where the
 /// internal layout changes the merge simply no-ops and the tab bar falls back to
 /// the standard strip below the traffic lights — it never crashes.
-final class TitlebarTabsWindow: NSWindow {
+final class TitlebarTabsWindow: NSWindow, NSToolbarDelegate {
     static let tabBarIdentifier = NSUserInterfaceItemIdentifier("_termyTabBar")
 
     /// Left gutter reserved for the traffic-light buttons.
     private static let windowButtonsGutter: CGFloat = 70
+
+    /// The centered window-title label, shown only when there is no tab bar.
+    private let titleField = TitlebarTitleField(labelWithString: "")
 
     /// Observes the native tab bar's frame so we can re-pin our constraints when
     /// AppKit resizes it (appearance changes, tab open/close clear our layout).
@@ -60,33 +67,54 @@ final class TitlebarTabsWindow: NSWindow {
     }
 
     // Assigning `title` re-reveals the native title view on macOS 15+/26; re-hide
-    // it while titlebar tabs are active so the merged row stays clean.
+    // it while titlebar tabs are active (our custom toolbar item shows it instead).
     override var title: String {
         didSet {
-            if titlebarTabs {
-                titleVisibility = .hidden
-            }
+            guard titlebarTabs else { return }
+            titleVisibility = .hidden
+            titleField.stringValue = title
         }
     }
 
     private func generateToolbar() {
         guard toolbar == nil else { return }
         let toolbar = NSToolbar(identifier: "TermyTitlebarTabs")
+        toolbar.delegate = self
         toolbar.showsBaselineSeparator = false
+        toolbar.centeredItemIdentifiers.insert(.termyTitle)
         self.toolbar = toolbar
         toolbarStyle = .unifiedCompact
+        titleField.stringValue = title
     }
 
     // MARK: NSWindow
 
     override func becomeMain() {
         super.becomeMain()
+        titleField.textColor = .labelColor
         // AppKit only attaches the live NSTabBar to whichever window in the group
         // is main, moving it on focus changes — so re-pin it every time we gain
         // main. `setupTabBar` is idempotent.
         if titlebarTabs {
             setupTabBar()
         }
+    }
+
+    override func resignMain() {
+        super.resignMain()
+        titleField.textColor = .tertiaryLabelColor
+    }
+
+    override func sendEvent(_ event: NSEvent) {
+        if event.type == .leftMouseDown,
+           event.clickCount == 2,
+           titlebarTabs,
+           shouldHandleTitlebarDoubleClick(at: event.locationInWindow)
+        {
+            performTitlebarDoubleClickAction()
+            return
+        }
+        super.sendEvent(event)
     }
 
     /// Matches AppKit's window tab bar accessory. AppKit first attaches an empty
@@ -133,6 +161,8 @@ final class TitlebarTabsWindow: NSWindow {
         super.removeTitlebarAccessoryViewController(at: index)
         if wasTabBar {
             tabBarObserver = nil
+            // Back to a single tab: show the centered title again.
+            titleField.isHidden = false
         }
     }
 
@@ -146,6 +176,8 @@ final class TitlebarTabsWindow: NSWindow {
         guard let titlebarView,
               let tabBarView = self.tabBarView
         else {
+            // No tab bar present (single tab): show the centered title.
+            titleField.isHidden = false
             return
         }
 
@@ -161,6 +193,9 @@ final class TitlebarTabsWindow: NSWindow {
         else {
             return
         }
+
+        // A tab bar exists: hide the centered title so it doesn't overlap.
+        titleField.isHidden = true
 
         // Keep the tab bar from being vertically stretched: AppKit sizes the new
         // tab button square, so match the bar height to its width.
@@ -200,6 +235,130 @@ final class TitlebarTabsWindow: NSWindow {
             }
         }
     }
+
+    // MARK: NSToolbarDelegate
+
+    func toolbarAllowedItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
+        [.termyTitle, .flexibleSpace, .space]
+    }
+
+    func toolbarDefaultItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
+        // Flexible spaces on both sides keep the title centered as it grows.
+        [.flexibleSpace, .termyTitle, .flexibleSpace]
+    }
+
+    func toolbar(
+        _ toolbar: NSToolbar,
+        itemForItemIdentifier itemIdentifier: NSToolbarItem.Identifier,
+        willBeInsertedIntoToolbar flag: Bool
+    ) -> NSToolbarItem? {
+        guard itemIdentifier == .termyTitle else {
+            return NSToolbarItem(itemIdentifier: itemIdentifier)
+        }
+        let item = NSToolbarItem(itemIdentifier: .termyTitle)
+        item.view = titleField
+        item.visibilityPriority = .user
+        item.isEnabled = false
+        // Avoids the glass capsule background NSToolbar draws around custom views.
+        item.isBordered = false
+        // Size to the text and let the flexible spaces center it. Hugging low so
+        // the field can grow toward (but not past) the available width.
+        titleField.translatesAutoresizingMaskIntoConstraints = false
+        titleField.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        titleField.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+        titleField.heightAnchor.constraint(equalToConstant: 22).isActive = true
+        return item
+    }
+
+    private func shouldHandleTitlebarDoubleClick(at windowPoint: NSPoint) -> Bool {
+        guard isPointInTitlebarBand(windowPoint) else {
+            return false
+        }
+        if let hitView = contentView?.rootView.hitTest(windowPoint),
+           hitView.isInteractiveTitlebarTabControl
+        {
+            return false
+        }
+        return true
+    }
+
+    private func isPointInTitlebarBand(_ windowPoint: NSPoint) -> Bool {
+        let contentMaxY = contentLayoutRect.maxY
+        if windowPoint.y >= contentMaxY {
+            return true
+        }
+
+        if let titlebarView {
+            let titlebarFrame = titlebarView.convert(titlebarView.bounds, to: nil)
+            if titlebarFrame.contains(windowPoint) {
+                return true
+            }
+        }
+
+        if let toolbarView = titlebarView?.firstDescendant(withClassName: "NSToolbarView") {
+            let toolbarFrame = toolbarView.convert(toolbarView.bounds, to: nil)
+            if toolbarFrame.contains(windowPoint) {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    private func performTitlebarDoubleClickAction() {
+        switch UserDefaults.standard.string(forKey: "AppleActionOnDoubleClick")?.lowercased() {
+        case "minimize":
+            performMiniaturize(nil)
+        case "none":
+            return
+        default:
+            zoom(nil)
+        }
+    }
+}
+
+private extension NSView {
+    var isInteractiveTitlebarTabControl: Bool {
+        var view: NSView? = self
+        while let current = view {
+            if current.className == "NSTabBarButton"
+                || current.className == "NSTabBarNewTabButton"
+                || current.className == "NSButton"
+            {
+                return true
+            }
+            if current.className == "NSTitlebarView"
+                || current.className == "NSToolbarView"
+            {
+                return false
+            }
+            view = current.superview
+        }
+        return false
+    }
+}
+
+/// A non-interactive, vertically-centered titlebar label that passes clicks
+/// through so titlebar dragging and double-click-to-zoom keep working.
+private final class TitlebarTitleField: NSTextField {
+    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+
+    override func viewDidMoveToSuperview() {
+        super.viewDidMoveToSuperview()
+        isEditable = false
+        isSelectable = false
+        isBordered = false
+        drawsBackground = false
+        alignment = .center
+        lineBreakMode = .byTruncatingTail
+        cell?.truncatesLastVisibleLine = true
+        font = .titleBarFont(ofSize: NSFont.systemFontSize)
+        textColor = .labelColor
+    }
+}
+
+private extension NSToolbarItem.Identifier {
+    static let termyTitle = NSToolbarItem.Identifier("TermyTitle")
 }
 
 // MARK: - Private AppKit view-hierarchy access

--- a/macos/Tests/TermySwiftTests/NativeTabChromeApplierTests.swift
+++ b/macos/Tests/TermySwiftTests/NativeTabChromeApplierTests.swift
@@ -39,6 +39,38 @@ final class NativeTabChromeApplierTests: XCTestCase {
         XCTAssertEqual(second.title, "Active Second")
     }
 
+    func testNativeTabDescriptorsKeepAppKitTabGroupOrderWhenSourceIsSecondTab() {
+        let manager = NativeTabWindowManager.shared
+        let first = makeBareWindow()
+        let second = makeBareWindow()
+        manager.configure(first)
+        manager.configure(second)
+        first.title = "First"
+        second.title = "Second"
+        first.addTabbedWindow(second, ordered: .above)
+
+        let descriptors = manager.tabDescriptors(for: second)
+
+        XCTAssertEqual(descriptors.map(\.title), ["First", "Second"])
+        XCTAssertEqual(descriptors.map(\.index), [0, 1])
+    }
+
+    func testStoreScopedChromeRefreshUpdatesInactiveTabWindowTitle() {
+        let manager = NativeTabWindowManager.shared
+        let window = makeBareWindow()
+        let store = TerminalWorkspaceStore()
+        manager.configure(window)
+        TerminalCommandRouter.shared.register(store, for: window)
+        defer {
+            TerminalCommandRouter.shared.unregister(window: window)
+        }
+
+        XCTAssertTrue(store.focusedTerminal?.applyTerminalTitle("background build") ?? false)
+        XCTAssertTrue(manager.applyFocusedTerminalChrome(for: store))
+
+        XCTAssertEqual(window.title, "background build")
+    }
+
     private func assertColor(
         _ color: NSColor,
         matches expected: TerminalRGBA,


### PR DESCRIPTION
## What changed

**Titlebar tabs (macOS 26 / Tahoe)**
- Merge the native tab bar onto the traffic-light row (`TitlebarTabsWindow`, Ghostty "Tahoe" technique): an empty `unifiedCompact` `NSToolbar` creates one band, and the system tab accessory is relocated `.bottom → .right` and constrained into the `NSToolbarView`. All private view-hierarchy access is class-name guarded, so on an unrecognised OS layout it no-ops back to the standard strip rather than crashing.
- Single-tab windows show a centered window title in the unified toolbar; it hides when the tab bar occupies the row. Visibility is gated on `tabGroup?.isTabBarVisible` (not tab count) so a force-shown bar on a lone window — "Prefer tabs: Always" / View ▸ Show Tab Bar — doesn't paint the title over the strip.
- Double-clicking the merged titlebar band triggers the system zoom/minimize action (per `AppleActionOnDoubleClick`), since the merged row otherwise has no native double-click target.

**Native tab ordering**
- Keep tab order aligned with AppKit's tab-group order so `Cmd+1/2/…` select visual positions instead of treating the current tab as index 0. Regression test added.

**Background-tab liveness**
- Suspended (occluded) native tabs keep their FFI wakeup monitor and drain runtime events without repainting frames, so a hidden shell doesn't block on a full PTY and tab titles still refresh. Intent documented inline.

**Window blur**
- `TerminalWindowBlur` installs a behind-window `NSVisualEffectView` when blur + transparency are configured (also satisfies the existing `TerminalSurfaceViewTests` reference).

## Why

The native macOS tab chrome had several AppKit integration gaps: the tab bar sat in a separate strip below the titlebar, single-tab windows had no title, numeric tab selection used source-window-first ordering, the merged row had no double-click target, and occluded tabs stopped processing title-change events.

## Validation

- `cargo build -p termy_ffi`
- `swift build --package-path macos` — clean
- `swift test --package-path macos` — 184 tests pass. (Build `termy_ffi` first so the schema-parity tests link the current Rust config; `just test-macos-config` handles this for you. Visual checks of the merged titlebar still warrant a manual `just run-macos` pass.)

## Note on scope

This PR bundles the titlebar-tabs work with adjacent native-tab fixes (window blur, background-tab draining, tab ordering). They share the native-tab architecture but are independently reviewable — flagged here so the non-tab changes aren't invisible.
