### PR TITLE
Lower memory usage: sRGB window surfaces, slim FFI cells, scrollback cap

### DIFF
--- a/crates/config_core/src/constants.rs
+++ b/crates/config_core/src/constants.rs
@@ -21,7 +21,11 @@ pub const MIN_LINE_HEIGHT: f32 = 0.8;
 /// unusably sparse.
 pub const MAX_LINE_HEIGHT: f32 = 2.5;
 pub(crate) const DEFAULT_SCROLLBACK_HISTORY: usize = 1000;
-pub(crate) const MAX_SCROLLBACK_HISTORY: usize = 100_000;
+/// Upper clamp for scrollback lines. Each pane eagerly grows toward
+/// `lines × cols × ~24 bytes` of grid memory, so at 200 columns this cap
+/// bounds a pane to roughly 100 MB; the previous 100k cap allowed ~480 MB
+/// from a single config line.
+pub(crate) const MAX_SCROLLBACK_HISTORY: usize = 20_000;
 pub(crate) const DEFAULT_INACTIVE_TAB_SCROLLBACK: Option<usize> = Some(250);
 pub(crate) const DEFAULT_PANE_FOCUS_STRENGTH: f32 = 0.6;
 pub(crate) const DEFAULT_TAB_SWITCH_MODIFIER_HINTS: bool = true;

--- a/crates/config_core/src/parser_tests.rs
+++ b/crates/config_core/src/parser_tests.rs
@@ -572,7 +572,7 @@ fn numeric_keys_parse_table_driven() {
     assert_eq!(parse("scrollback = 3000\n").scrollback_history, 3000);
     assert_eq!(
         parse("scrollback_history = 200000\n").scrollback_history,
-        100_000
+        20_000
     );
 
     assert_eq!(parse("font_size = inf\n").font_size, defaults.font_size);

--- a/crates/core/src/frame.rs
+++ b/crates/core/src/frame.rs
@@ -26,10 +26,11 @@ pub struct TermyColor {
     pub a: u8,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+/// One viewport cell. Carries no position: full frames are row-major
+/// (`index = row * cols + col`) and partial updates list cells in dirty-span
+/// order, so position is derived from context on the consuming side.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct TermyCell {
-    pub col: usize,
-    pub row: usize,
     pub char: char,
     pub fg: TermyColor,
     pub bg: TermyColor,
@@ -99,15 +100,8 @@ fn bold_foreground_color(color: AnsiColor) -> AnsiColor {
     }
 }
 
-fn default_cell(
-    col: usize,
-    row: usize,
-    live_colors: &Colors,
-    query_colors: TerminalQueryColors,
-) -> TermyCell {
+fn default_cell(live_colors: &Colors, query_colors: TerminalQueryColors) -> TermyCell {
     TermyCell {
-        col,
-        row,
         char: ' ',
         fg: color_to_rgba(
             AnsiColor::Named(NamedColor::Foreground),
@@ -126,8 +120,6 @@ fn default_cell(
 }
 
 fn cell_from_renderable_cell(
-    col: usize,
-    row: usize,
     cell: &Cell,
     live_colors: &Colors,
     query_colors: TerminalQueryColors,
@@ -153,8 +145,6 @@ fn cell_from_renderable_cell(
     }
 
     TermyCell {
-        col,
-        row,
         char: cell.c,
         fg,
         bg: color_to_rgba(bg, live_colors, query_colors),
@@ -176,19 +166,10 @@ pub(crate) fn snapshot_from_term<T: EventListener>(
     let cols = usize::from(size.cols);
     let rows = usize::from(size.rows);
     let live_colors = term.colors();
-    let mut cells = Vec::with_capacity(cols.saturating_mul(rows));
     // Resolving the default fg/bg colors costs several palette lookups per
-    // call; stamp coordinates onto one template instead of resolving per cell.
-    let template = default_cell(0, 0, live_colors, query_colors);
-    for row in 0..rows {
-        for col in 0..cols {
-            cells.push(TermyCell {
-                col,
-                row,
-                ..template.clone()
-            });
-        }
-    }
+    // call; resolve one template instead of resolving per cell.
+    let template = default_cell(live_colors, query_colors);
+    let mut cells = vec![template; cols.saturating_mul(rows)];
 
     let content = term.renderable_content();
     for indexed_cell in content.display_iter {
@@ -206,8 +187,7 @@ pub(crate) fn snapshot_from_term<T: EventListener>(
             .checked_mul(cols)
             .and_then(|base| base.checked_add(col))
             .expect("frame cell index must fit usize");
-        cells[idx] =
-            cell_from_renderable_cell(col, row, indexed_cell.cell, live_colors, query_colors);
+        cells[idx] = cell_from_renderable_cell(indexed_cell.cell, live_colors, query_colors);
     }
 
     let grid = term.grid();
@@ -248,7 +228,7 @@ pub(crate) fn snapshot_update_from_term<T: EventListener>(
         TerminalDamageSnapshot::Partial(spans) => {
             let mut update_spans = Vec::new();
             let mut cells = Vec::new();
-            let template = default_cell(0, 0, live_colors, query_colors);
+            let template = default_cell(live_colors, query_colors);
 
             for span in spans {
                 if span.row >= rows || cols == 0 {
@@ -266,13 +246,7 @@ pub(crate) fn snapshot_update_from_term<T: EventListener>(
                     right_col,
                     base_index,
                 });
-                for col in left_col..=right_col {
-                    cells.push(TermyCell {
-                        col,
-                        row: span.row,
-                        ..template.clone()
-                    });
-                }
+                cells.resize(cells.len() + (right_col - left_col + 1), template);
             }
 
             let display_offset = grid.display_offset() as i32;
@@ -281,8 +255,7 @@ pub(crate) fn snapshot_update_from_term<T: EventListener>(
                 for col in span.left_col..=span.right_col {
                     let index = span.base_index + (col - span.left_col);
                     let cell = &grid[line][Column(col)];
-                    cells[index] =
-                        cell_from_renderable_cell(col, span.row, cell, live_colors, query_colors);
+                    cells[index] = cell_from_renderable_cell(cell, live_colors, query_colors);
                 }
             }
 
@@ -471,23 +444,10 @@ mod tests {
                 right_col: 2,
             }])
         );
+        // Cells are listed in dirty-span order: (row 0, cols 1..=2).
         assert_eq!(update.cells.len(), 2);
-        assert_eq!(
-            (
-                update.cells[0].row,
-                update.cells[0].col,
-                update.cells[0].char
-            ),
-            (0, 1, 'b')
-        );
-        assert_eq!(
-            (
-                update.cells[1].row,
-                update.cells[1].col,
-                update.cells[1].char
-            ),
-            (0, 2, 'c')
-        );
+        assert_eq!(update.cells[0].char, 'b');
+        assert_eq!(update.cells[1].char, 'c');
     }
 
     #[test]
@@ -513,12 +473,9 @@ mod tests {
             }]),
         );
 
+        // One cell per dirty column (1..=3), all blanks.
         assert_eq!(update.cells.len(), 3);
         assert!(update.cells.iter().all(|cell| cell.char == ' '));
-        assert_eq!(
-            update.cells.iter().map(|cell| cell.col).collect::<Vec<_>>(),
-            vec![1, 2, 3]
-        );
     }
 
     #[test]
@@ -571,20 +528,14 @@ mod tests {
                 },
             ])
         );
+        // Cells follow the clipped spans in order: (0,1..=3) then (1,2..=4).
         assert_eq!(
             update
                 .cells
                 .iter()
-                .map(|cell| (cell.row, cell.col, cell.char))
+                .map(|cell| cell.char)
                 .collect::<Vec<_>>(),
-            vec![
-                (0, 1, 'b'),
-                (0, 2, 'c'),
-                (0, 3, 'd'),
-                (1, 2, 'h'),
-                (1, 3, 'i'),
-                (1, 4, 'j'),
-            ]
+            vec!['b', 'c', 'd', 'h', 'i', 'j']
         );
     }
 }

--- a/crates/core/src/runtime.rs
+++ b/crates/core/src/runtime.rs
@@ -908,10 +908,12 @@ impl EventListener for JsonEventListener {
     }
 }
 
-/// Sized at 2× `NATIVE_EVENT_LOOP_MAX_LOCKED_READ`: enough to keep
-/// accumulating PTY output while the UI holds the terminal lock, without
-/// dirtying a full megabyte of stack per session thread.
-const NATIVE_EVENT_LOOP_READ_BUFFER_SIZE: usize = 0x2_0000;
+/// Sized to hold one `NATIVE_EVENT_LOOP_MAX_LOCKED_READ` parse budget: reads
+/// accumulate here while the UI holds the terminal lock, and once a full
+/// budget is buffered the reader blocks on the lock anyway (the kernel PTY
+/// buffer absorbs the rest), so larger sizes only dirty more per-pane thread
+/// stack for the lifetime of the session.
+const NATIVE_EVENT_LOOP_READ_BUFFER_SIZE: usize = 0x1_0000;
 const NATIVE_EVENT_LOOP_MAX_LOCKED_READ: usize = u16::MAX as usize;
 #[cfg(not(target_os = "windows"))]
 const NATIVE_EVENT_LOOP_READ_WRITE_TOKEN: usize = 0;

--- a/crates/core/src/runtime.rs
+++ b/crates/core/src/runtime.rs
@@ -839,8 +839,46 @@ impl JsonEventListener {
     }
 
     fn send_terminal_event(&self, event: TerminalEvent) {
-        let _ = self.events_tx.send(RuntimeEvent::Terminal(event));
+        self.send_runtime_event(RuntimeEvent::Terminal(event));
         self.send_wake_signal();
+    }
+
+    /// Queues an event unless the host has stopped draining and the event is
+    /// safe to shed. The channel is unbounded because the producer may hold
+    /// the terminal lock while sending and the drain path takes the same lock,
+    /// so blocking backpressure could deadlock; this soft cap is what keeps a
+    /// non-draining host (hidden pane, stalled UI) from growing the queue
+    /// without bound instead.
+    fn send_runtime_event(&self, event: RuntimeEvent) {
+        if self.events_tx.len() >= EVENT_QUEUE_SOFT_CAP && droppable_when_backlogged(&event) {
+            return;
+        }
+        let _ = self.events_tx.send(event);
+    }
+}
+
+/// Soft cap on pending, undrained runtime events. Well above what a draining
+/// host ever accumulates (the per-frame drain batch is 2048), so shedding only
+/// starts once the host has clearly stopped consuming.
+const EVENT_QUEUE_SOFT_CAP: usize = 8192;
+
+/// Whether an event can be shed once the queue is backlogged. State-refresh
+/// events are safe: they either carry latest-wins state that the next
+/// occurrence re-synchronizes (title, working directory, progress) or are
+/// cosmetic (bell, cursor state, shell integration marks). Everything else —
+/// exit, clipboard, and the query events whose drain-time replies the child
+/// process may block on — is always queued.
+fn droppable_when_backlogged(event: &RuntimeEvent) -> bool {
+    match event {
+        RuntimeEvent::Alacritty(event) => matches!(
+            event,
+            AlacEvent::Title(_)
+                | AlacEvent::ResetTitle
+                | AlacEvent::Bell
+                | AlacEvent::CursorBlinkingChange
+                | AlacEvent::MouseCursorDirty
+        ),
+        RuntimeEvent::Terminal(_) => true,
     }
 }
 
@@ -864,7 +902,7 @@ impl EventListener for JsonEventListener {
             }
             return;
         }
-        let _ = self.events_tx.send(RuntimeEvent::Alacritty(event));
+        self.send_runtime_event(RuntimeEvent::Alacritty(event));
         // This channel only nudges the UI thread to drain terminal events promptly.
         self.send_wake_signal();
     }
@@ -1775,10 +1813,10 @@ mod tests {
     #[cfg(target_os = "windows")]
     use super::quote_shell_program_if_needed;
     use super::{
-        DEFAULT_TERM, GHOSTTY_COMPAT_TERM_PROGRAM, GHOSTTY_COMPAT_TERM_PROGRAM_VERSION,
-        JsonEventListener, RuntimeEvent, TERMY_TERM_PROGRAM, TerminalCursorState,
-        TerminalCursorStyle, TerminalDamageSnapshot, TerminalEvent, TerminalRuntimeConfig,
-        TerminalSize, WindowsShell, WorkingDirFallback, apply_term_config,
+        DEFAULT_TERM, EVENT_QUEUE_SOFT_CAP, GHOSTTY_COMPAT_TERM_PROGRAM,
+        GHOSTTY_COMPAT_TERM_PROGRAM_VERSION, JsonEventListener, RuntimeEvent, TERMY_TERM_PROGRAM,
+        TerminalCursorState, TerminalCursorStyle, TerminalDamageSnapshot, TerminalEvent,
+        TerminalRuntimeConfig, TerminalSize, WindowsShell, WorkingDirFallback, apply_term_config,
         cursor_position_from_term, cursor_state_from_term, default_shell_launch,
         drain_runtime_events, normalize_working_directory_candidate, pty_env_overrides,
         resolve_launch_working_directory, resolve_shell_path, search_term_buffer,
@@ -2189,6 +2227,29 @@ mod tests {
         ));
 
         assert_eq!(wake_rx.try_iter().count(), 2);
+    }
+
+    #[test]
+    fn backlogged_event_queue_sheds_state_refresh_events_only() {
+        let (events_tx, events_rx) = unbounded();
+        let listener = JsonEventListener::new(events_tx, None);
+
+        for _ in 0..(EVENT_QUEUE_SOFT_CAP + 100) {
+            listener.send_event(alacritty_terminal::event::Event::Title("t".to_string()));
+        }
+        assert_eq!(events_rx.len(), EVENT_QUEUE_SOFT_CAP);
+
+        // OSC-derived terminal events shed under backlog too.
+        listener.send_terminal_event(TerminalEvent::Bell);
+        assert_eq!(events_rx.len(), EVENT_QUEUE_SOFT_CAP);
+
+        // Protocol-critical events are queued even while backlogged.
+        listener.send_event(alacritty_terminal::event::Event::Exit);
+        listener.send_event(alacritty_terminal::event::Event::ClipboardStore(
+            ClipboardType::Clipboard,
+            "x".to_string(),
+        ));
+        assert_eq!(events_rx.len(), EVENT_QUEUE_SOFT_CAP + 2);
     }
 
     #[test]

--- a/crates/core/src/search.rs
+++ b/crates/core/src/search.rs
@@ -199,13 +199,11 @@ mod tests {
             a: 255,
         };
         let mut cells = Vec::new();
-        for (row, text) in rows.iter().enumerate() {
+        for text in rows {
             let mut chars = text.chars();
-            for col in 0..usize::from(cols) {
+            for _ in 0..usize::from(cols) {
                 let char = chars.next().unwrap_or(' ');
                 cells.push(TermyCell {
-                    col,
-                    row,
                     char,
                     fg: color,
                     bg: TermyColor::default(),

--- a/crates/ffi/include/termy.h
+++ b/crates/ffi/include/termy.h
@@ -62,9 +62,10 @@ typedef struct {
   uint8_t a;
 } TermyFfiColor;
 
+/* One viewport cell. Carries no position: full frames are row-major
+ * (index = row * cols + col) and frame-update cells follow the dirty spans
+ * in order, so the host derives position from context. */
 typedef struct {
-  size_t col;
-  size_t row;
   uint32_t codepoint;
   TermyFfiColor fg;
   TermyFfiColor bg;

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -59,11 +59,12 @@ pub struct TermyFfiColor {
     pub a: u8,
 }
 
+/// One viewport cell. Carries no position: full frames are row-major
+/// (`index = row * cols + col`) and frame-update cells follow the dirty spans
+/// in order, so the host derives position from context.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct TermyFfiCell {
-    pub col: usize,
-    pub row: usize,
     pub codepoint: u32,
     pub fg: TermyFfiColor,
     pub bg: TermyFfiColor,
@@ -357,8 +358,6 @@ impl From<TermyColor> for TermyFfiColor {
 impl From<TermyCell> for TermyFfiCell {
     fn from(cell: TermyCell) -> Self {
         Self {
-            col: cell.col,
-            row: cell.row,
             codepoint: cell.char as u32,
             fg: cell.fg.into(),
             bg: cell.bg.into(),

--- a/macos/Sources/TermySwift/App/TermySwiftApp.swift
+++ b/macos/Sources/TermySwift/App/TermySwiftApp.swift
@@ -887,6 +887,11 @@ final class NativeTabWindowManager: NSObject, NSWindowDelegate {
         window.tabbingMode = .preferred
         window.tabbingIdentifier = tabbingIdentifier
         window.collectionBehavior.insert(.fullScreenPrimary)
+        // Terminal colors are 24-bit sRGB; without a pinned color space the
+        // Tahoe compositor backs the window with half-float (8 bytes/px)
+        // drawables, doubling window-surface memory (~42 MB → ~15 MB each
+        // for a full-screen window).
+        window.colorSpace = .sRGB
 
         let identifier = ObjectIdentifier(window)
         registerWindowLifecycleObservers(for: window)

--- a/macos/Sources/TermySwift/Services/LibTermyTerminal.swift
+++ b/macos/Sources/TermySwift/Services/LibTermyTerminal.swift
@@ -4,6 +4,7 @@ import Foundation
 enum LibTermyError: Error, CustomStringConvertible {
     case missingTerminal
     case missingCells
+    case cellCountMismatch
 
     var description: String {
         switch self {
@@ -11,6 +12,8 @@ enum LibTermyError: Error, CustomStringConvertible {
             return "libtermy did not return a terminal handle"
         case .missingCells:
             return "libtermy returned a frame without cells"
+        case .cellCountMismatch:
+            return "libtermy returned a cell count that does not match the frame damage"
         }
     }
 }
@@ -382,8 +385,16 @@ final class LibTermyTerminal {
             throw LibTermyError.missingCells
         }
 
+        // Full frames are row-major; positions are derived from the index.
+        let cols = Int(frame.cols)
+        guard cols > 0, Int(frame.cells_len) == cols * Int(frame.rows) else {
+            throw LibTermyError.cellCountMismatch
+        }
         let cells = UnsafeBufferPointer(start: cellsPtr, count: Int(frame.cells_len))
-            .map(Self.cell(from:))
+            .enumerated()
+            .map { index, ffiCell in
+                Self.cell(from: ffiCell, col: index % cols, row: index / cols)
+            }
         let cursor = frame.cursor.visible
             ? TerminalCursor(
                 col: Int(frame.cursor.col),
@@ -414,17 +425,6 @@ final class LibTermyTerminal {
             _ = termy_frame_update_free(&update)
         }
 
-        let cells: [TerminalCell]
-        if update.cells_len > 0 {
-            guard let cellsPtr = update.cells_ptr else {
-                throw LibTermyError.missingCells
-            }
-            cells = UnsafeBufferPointer(start: cellsPtr, count: Int(update.cells_len))
-                .map(Self.cell(from:))
-        } else {
-            cells = []
-        }
-
         let damage: TerminalDamage
         switch update.damage_kind {
         case 1:
@@ -449,6 +449,46 @@ final class LibTermyTerminal {
             }
         default:
             damage = .none
+        }
+
+        // Cells carry no position over the FFI: a full update is row-major and
+        // a partial update lists cells in dirty-span order.
+        let cells: [TerminalCell]
+        if update.cells_len > 0 {
+            guard let cellsPtr = update.cells_ptr else {
+                throw LibTermyError.missingCells
+            }
+            let ffiCells = UnsafeBufferPointer(start: cellsPtr, count: Int(update.cells_len))
+            switch damage {
+            case .full:
+                let cols = Int(update.cols)
+                guard cols > 0, ffiCells.count == cols * Int(update.rows) else {
+                    throw LibTermyError.cellCountMismatch
+                }
+                cells = ffiCells.enumerated().map { index, ffiCell in
+                    Self.cell(from: ffiCell, col: index % cols, row: index / cols)
+                }
+            case .partial(let spans):
+                guard spans.allSatisfy({ $0.leftCol <= $0.rightCol }),
+                      ffiCells.count == spans.reduce(0, { $0 + ($1.rightCol - $1.leftCol + 1) })
+                else {
+                    throw LibTermyError.cellCountMismatch
+                }
+                var result: [TerminalCell] = []
+                result.reserveCapacity(ffiCells.count)
+                var index = 0
+                for span in spans {
+                    for col in span.leftCol...span.rightCol {
+                        result.append(Self.cell(from: ffiCells[index], col: col, row: span.row))
+                        index += 1
+                    }
+                }
+                cells = result
+            case .none:
+                throw LibTermyError.cellCountMismatch
+            }
+        } else {
+            cells = []
         }
 
         return TerminalFrameUpdate(
@@ -643,10 +683,10 @@ final class LibTermyTerminal {
         }
     }
 
-    private static func cell(from ffiCell: TermyFfiCell) -> TerminalCell {
+    private static func cell(from ffiCell: TermyFfiCell, col: Int, row: Int) -> TerminalCell {
         TerminalCell(
-            col: Int(ffiCell.col),
-            row: Int(ffiCell.row),
+            col: col,
+            row: row,
             codepoint: ffiCell.codepoint,
             foreground: TerminalRGBA(ffiCell.fg),
             background: TerminalRGBA(ffiCell.bg),

--- a/macos/Sources/TermySwift/Support/AppLogo.swift
+++ b/macos/Sources/TermySwift/Support/AppLogo.swift
@@ -52,12 +52,36 @@ final class AppLogoManager: ObservableObject {
         return image
     }
 
+    /// The logo already baked into the bundle as `CFBundleIconFile`; the Dock
+    /// shows it without any in-process image.
+    private static let bundleIconResourceName = "TermyIcon"
+
     /// Applies the selected logo to the running app's Dock / Cmd-Tab icon.
     /// Called on launch and whenever the selection changes.
+    ///
+    /// Setting `NSApp.applicationIconImage` makes AppKit render and retain a
+    /// process-lifetime snapshot at `image.size × screen scale` in deep color
+    /// (a 1024 pt image costs a 2048×2048×8B ≈ 32 MB bitmap). So the bundle's
+    /// own icon is restored with `nil` instead of re-assigned, and custom
+    /// logos are capped at 512 pt — the source PNGs are 1024 px, so the
+    /// snapshot stays pixel-identical at 4× less memory.
     func applyToDock() {
-        if let image = image(for: selected) {
-            NSApp.applicationIconImage = image
+        guard selected.resourceName != Self.bundleIconResourceName else {
+            NSApp.applicationIconImage = nil
+            return
         }
+        guard let image = image(for: selected), let dockImage = image.copy() as? NSImage else {
+            return
+        }
+        let maxSide: CGFloat = 512
+        if dockImage.size.width > maxSide || dockImage.size.height > maxSide {
+            let scale = maxSide / max(dockImage.size.width, dockImage.size.height)
+            dockImage.size = NSSize(
+                width: dockImage.size.width * scale,
+                height: dockImage.size.height * scale
+            )
+        }
+        NSApp.applicationIconImage = dockImage
     }
 
     func reloadFromConfig() {

--- a/macos/Tests/TermySwiftTests/DisplayTerminalTests.swift
+++ b/macos/Tests/TermySwiftTests/DisplayTerminalTests.swift
@@ -16,4 +16,29 @@ final class DisplayTerminalTests: XCTestCase {
         let terminal = try LibTermyTerminal(displayCols: 80, rows: 24, loadUserConfig: false)
         XCTAssertNoThrow(try terminal.write(Array("ignored".utf8)))
     }
+
+    /// FFI cells carry no position; the binding derives it from row-major
+    /// order (full frames) or dirty-span order (partial updates). Pin exact
+    /// coordinates through the real library for both paths.
+    func testFrameUpdateDerivesCellPositions() throws {
+        let terminal = try LibTermyTerminal(displayCols: 20, rows: 4, loadUserConfig: false)
+        try terminal.feedOutput(Array("hello".utf8))
+
+        let full = try terminal.frameUpdate(forceFull: true)
+        XCTAssertEqual(full.damage, .full)
+        let hello = full.cells.filter { "hello".contains($0.character) && $0.renderText }
+        XCTAssertEqual(hello.map(\.row), [0, 0, 0, 0, 0])
+        XCTAssertEqual(hello.map(\.col), [0, 1, 2, 3, 4])
+
+        // Write "XY" at row 2, col 5 (1-based CUP 3;6) and expect the next
+        // update to place exactly those cells there.
+        try terminal.feedOutput(Array("\u{1b}[3;6HXY".utf8))
+        let update = try terminal.frameUpdate(forceFull: false)
+        let x = update.cells.first { $0.character == "X" }
+        let y = update.cells.first { $0.character == "Y" }
+        XCTAssertEqual(x?.row, 2)
+        XCTAssertEqual(x?.col, 5)
+        XCTAssertEqual(y?.row, 2)
+        XCTAssertEqual(y?.col, 6)
+    }
 }


### PR DESCRIPTION
## Summary

Three memory reductions for the native macOS host, measured against a running instance (340 MB footprint at one window):

- **Pin `NSWindow.colorSpace` to sRGB.** The Tahoe compositor otherwise backs terminal windows with half-float (8 bytes/px) "CA Whippet" drawables; pinning flips them to BGRA, halving window-surface memory (41.9 MB → 14.8 MB per drawable, ~30 MB total at launch, more at full-screen). Lossless: the grid renderer already produces all colors in sRGB. (Note: view-level `CALayer.contentsFormat` and `NSWindow.depthLimit` were tested first and had no effect — the window color space is the knob that works.)
- **Drop the redundant `col`/`row` fields from `TermyCell`/`TermyFfiCell`** (40 → 16 bytes per cell). Full frames are row-major and partial updates follow the dirty spans in order, so the Swift binding now derives positions from context and validates cell counts against the damage shape (new `cellCountMismatch` error instead of silently misplacing cells). Every frame crossing the FFI shrinks 60%; a fullscreen repaint drops from ~1.3 MB to ~0.5 MB of transient allocation.
- **Clamp `scrollback_history` at 20k lines (was 100k).** Pane grids grow toward `lines × cols × ~24 bytes`, so the old ceiling let one config line cost ~480 MB per pane; the new cap bounds it to ~100 MB. Default (1000) and inactive-tab trim (250) are unchanged.

- **Shed state-refresh events when the runtime event queue is backlogged.** The per-pane event channel is unbounded (blocking backpressure could deadlock: the PTY reader can send while holding the terminal lock the drain path also takes), so a host that stops draining could grow it without bound. A soft cap (8192, 4× the per-frame drain batch) now sheds latest-wins/cosmetic events (titles, bell, cursor state, OSC shell marks) at enqueue, while exit, clipboard, and reply-generating query events always queue.

- **Halve the per-pane PTY read buffer (128 KB → 64 KB).** The reader thread's accumulation buffer was 2× the 64 KB per-lock parse budget, dirtied on the thread stack for every pane's lifetime. Once one budget is buffered the reader blocks on the terminal lock regardless (the kernel PTY buffer absorbs the rest), so the extra headroom bought nothing durable.

- **Stop paying 32 MB for the Dock icon snapshot.** Setting `NSApp.applicationIconImage` makes AppKit retain a process-lifetime snapshot at `image.size × screen scale` in deep color — our 1024 pt logo cost a 2048×2048×8B (32 MB) bitmap on every launch, upscaled from a 1024 px source (found via `MallocStackLogging` + `malloc_history`). The default icon now assigns `nil` (Dock uses the bundle icon, zero in-process memory); custom logos are capped at 512 pt, keeping the snapshot at the source's native 1024 px — pixel-identical at 8 MB.

## Testing

- New test `backlogged_event_queue_sheds_state_refresh_events_only` pins the shed policy: droppable events cap at 8192, critical events still queue past the cap.
- `cargo test -p termy_core -p termy_ffi -p termy_config_core --release` — all pass; frame tests updated to assert span-order instead of embedded coordinates.
- New end-to-end test `testFrameUpdateDerivesCellPositions` drives the real library: asserts exact row/col for glyphs in a full update, then cursor-positions text via ANSI CUP and asserts the partial update lands cells at exactly those coordinates.
- Full Swift suite (190 tests) passes, including `SettingsSchemaParityTests`; generated config docs verified in sync (`generate-config-doc --check`).
- Verified live: dock-icon snapshot region gone from `vmmap` with the default icon and 8 MB with a custom icon; launch footprint now 144 MB (from 197 MB at branch start).
- Verified live (earlier): relaunched app shows BGRA drawables in `vmmap` and footprint down 197 MB → 167 MB at launch; background blur/transparency visually confirmed intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


