### PR TITLE
Fix new tabs ignoring configured working_dir when active cwd is non-local

### DIFF
--- a/crates/core/src/osc_intercept.rs
+++ b/crates/core/src/osc_intercept.rs
@@ -4,6 +4,7 @@
 //! alacritty_terminal does not expose as events:
 //! - OSC 7: Working directory (file:// URL)
 //! - OSC 9;4: Progress indicator (ConEmu/Windows Terminal)
+//! - OSC 9;9: Working directory (ConEmu path form; WSL reports its cwd this way)
 //! - OSC 133: Shell integration (prompt/command lifecycle)
 
 use crate::shell_integration::ProgressState;
@@ -11,8 +12,9 @@ use crate::shell_integration::ProgressState;
 /// Events extracted from custom OSC sequences
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum OscEvent {
-    /// OSC 7 - Working directory change
-    /// Format: ESC ] 7 ; file://hostname/path ST
+    /// OSC 7 / OSC 9;9 - Working directory change
+    /// Formats: ESC ] 7 ; file://hostname/path ST
+    ///          ESC ] 9 ; 9 ; path ST (path may be double-quoted; emitted by WSL)
     WorkingDirectory(String),
 
     /// OSC 9;4 - Progress indicator (ConEmu/Windows Terminal)
@@ -195,6 +197,15 @@ impl OscInterceptor {
             if let Some(progress_part) = rest.strip_prefix("4;") {
                 return parse_progress(progress_part);
             }
+            // OSC 9;9;path - ConEmu working directory report; WSL emits the
+            // Windows-visible cwd (e.g. \\wsl.localhost\...) this way, optionally
+            // wrapped in double quotes.
+            if let Some(cwd) = rest.strip_prefix("9;") {
+                let cwd = cwd.trim().trim_matches('"');
+                if !cwd.is_empty() {
+                    return Some(OscEvent::WorkingDirectory(cwd.to_string()));
+                }
+            }
             return None;
         }
 
@@ -294,6 +305,39 @@ mod tests {
             events,
             vec![OscEvent::WorkingDirectory("/home/user".to_string())]
         );
+    }
+
+    #[test]
+    fn parse_osc_9_9_working_directory() {
+        let mut interceptor = OscInterceptor::new();
+        let (output, events) = process_str(
+            &mut interceptor,
+            "\x1b]9;9;\\\\wsl.localhost\\Ubuntu\\home\\kamr\x07",
+        );
+        assert!(output.is_empty());
+        assert_eq!(
+            events,
+            vec![OscEvent::WorkingDirectory(
+                "\\\\wsl.localhost\\Ubuntu\\home\\kamr".to_string()
+            )]
+        );
+    }
+
+    #[test]
+    fn parse_osc_9_9_working_directory_strips_quotes() {
+        let mut interceptor = OscInterceptor::new();
+        let (_, events) = process_str(&mut interceptor, "\x1b]9;9;\"C:\\Users\\kamr\"\x07");
+        assert_eq!(
+            events,
+            vec![OscEvent::WorkingDirectory("C:\\Users\\kamr".to_string())]
+        );
+    }
+
+    #[test]
+    fn parse_osc_9_9_working_directory_ignores_empty_path() {
+        let mut interceptor = OscInterceptor::new();
+        let (_, events) = process_str(&mut interceptor, "\x1b]9;9;\"\"\x07");
+        assert!(events.is_empty());
     }
 
     #[test]

--- a/crates/desktop_app/src/terminal_view/mod.rs
+++ b/crates/desktop_app/src/terminal_view/mod.rs
@@ -47,6 +47,7 @@ use termy_terminal_ui::{
     WindowsShell as RuntimeWindowsShell, WorkingDirFallback as RuntimeWorkingDirFallback,
     find_link_in_line, hyperlink_at_viewport_cell, keystroke_to_input,
     normalize_working_directory_candidate, resolve_launch_working_directory,
+    resolve_working_directory_path,
 };
 use termy_toast::ToastManager;
 
@@ -2061,6 +2062,16 @@ impl TerminalView {
         value
     }
 
+    fn inherited_working_dir_candidate(candidate: Option<&str>) -> Option<String> {
+        // Session-derived cwds (prompt/process/title) can name paths from another
+        // filesystem namespace — a shell inside WSL or over SSH reports its remote
+        // cwd. A candidate that does not resolve locally must fall through to the
+        // configured working_dir instead of shadowing it and collapsing to the
+        // home-directory fallback at spawn time (issue #336).
+        normalize_working_directory_candidate(candidate)
+            .filter(|value| resolve_working_directory_path(Some(value)).is_some())
+    }
+
     fn resolve_preferred_working_directory(
         explicit_working_dir: Option<&str>,
         prompt_cwd: Option<&str>,
@@ -2072,12 +2083,12 @@ impl TerminalView {
         // Keep tmux and native session creation on the same cwd precedence chain so
         // new tabs/panes do not drift based on which runtime happens to be active.
         let explicit_working_dir = normalize_working_directory_candidate(explicit_working_dir);
-        let prompt_cwd = normalize_working_directory_candidate(prompt_cwd);
-        let process_cwd = normalize_working_directory_candidate(process_cwd);
+        let prompt_cwd = Self::inherited_working_dir_candidate(prompt_cwd);
+        let process_cwd = Self::inherited_working_dir_candidate(process_cwd);
         let title_cwd = title_cwd
             .map(str::trim)
             .filter(|value| Self::looks_like_working_dir_path(value))
-            .and_then(|value| normalize_working_directory_candidate(Some(value)));
+            .and_then(|value| Self::inherited_working_dir_candidate(Some(value)));
 
         explicit_working_dir
             .or(prompt_cwd)
@@ -4745,25 +4756,32 @@ mod tests {
 
     #[test]
     fn preferred_working_directory_prefers_active_sources_before_configured_and_fallback() {
+        // Inherited candidates only count when they exist locally, so use two
+        // distinct real directories.
+        let prompt = std::env::temp_dir().to_string_lossy().into_owned();
+        let process = std::env::current_dir()
+            .expect("current dir")
+            .to_string_lossy()
+            .into_owned();
         let cwd = TerminalView::resolve_preferred_working_directory(
             None,
-            Some("/prompt"),
-            Some("/process"),
-            Some("/title"),
+            Some(prompt.as_str()),
+            Some(process.as_str()),
+            None,
             Some("/configured"),
             RuntimeWorkingDirFallback::Process,
         );
-        assert_eq!(cwd.as_deref(), Some("/prompt"));
+        assert_eq!(cwd.as_deref(), Some(prompt.as_str()));
 
         let cwd = TerminalView::resolve_preferred_working_directory(
             None,
             None,
-            Some("/process"),
-            Some("/title"),
+            Some(process.as_str()),
+            None,
             Some("/configured"),
             RuntimeWorkingDirFallback::Process,
         );
-        assert_eq!(cwd.as_deref(), Some("/process"));
+        assert_eq!(cwd.as_deref(), Some(process.as_str()));
     }
 
     #[test]
@@ -4847,15 +4865,36 @@ mod tests {
 
     #[test]
     fn attach_resolution_uses_active_working_directory_before_default_launch_dir() {
+        let active = std::env::current_dir()
+            .expect("current dir")
+            .to_string_lossy()
+            .into_owned();
         let cwd = TerminalView::resolve_preferred_working_directory(
             None,
-            Some("/active/project"),
+            Some(active.as_str()),
             None,
             None,
             Some("/configured"),
             RuntimeWorkingDirFallback::Process,
         );
-        assert_eq!(cwd.as_deref(), Some("/active/project"));
+        assert_eq!(cwd.as_deref(), Some(active.as_str()));
+    }
+
+    #[test]
+    fn non_local_prompt_cwd_falls_through_to_configured_working_directory() {
+        // A shell inside WSL or over SSH reports a cwd that does not exist on the
+        // host; new sessions must keep honoring the configured working_dir
+        // instead of collapsing to the home fallback (issue #336).
+        let configured = std::env::current_dir().expect("current dir");
+        let cwd = TerminalView::resolve_preferred_working_directory(
+            None,
+            Some("/home/kamr"),
+            Some("/also/not/a/local/path"),
+            None,
+            Some(configured.to_string_lossy().as_ref()),
+            RuntimeWorkingDirFallback::Home,
+        );
+        assert_eq!(cwd.as_deref(), Some(configured.to_string_lossy().as_ref()));
     }
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
Fixes #336

## Problem

With `shell = wsl.exe` and `working_dir = \\wsl.localhost\Ubuntu\home\kamr`, the first tab opens in the WSL home, but every new tab (ctrl+T) opens in the Windows home directory while still using the WSL shell.

New sessions inherit the active tab's cwd (prompt → process → title) ahead of the configured `working_dir`. When the active shell runs in another filesystem namespace (WSL, SSH), its reported cwd (e.g. `/home/kamr` via OSC 7) doesn't exist on the host — but it still shadowed the configured `working_dir`, and then `resolve_launch_working_directory` silently collapsed to the home-directory fallback at spawn time.

## Fix

- **`desktop_app`**: inherited cwd candidates only participate in the precedence chain when they resolve to an existing local directory; non-local paths fall through to the configured `working_dir`. Explicit user-provided dirs are unaffected. This also fixes the same failure over SSH on all platforms.
- **`core`**: parse OSC 9;9 (ConEmu cwd report, optionally quoted) into the same `WorkingDirectory` event as OSC 7. WSL emits its cwd in Windows-visible form (`\\wsl.localhost\...`) this way, so new tabs can genuinely inherit the active WSL directory instead of merely falling back to the configured one.

## Validation

- New regression test: non-local prompt/process cwd falls through to configured `working_dir`
- Three new OSC 9;9 parser tests (UNC path, quoted path, empty payload)
- Updated two existing tests that used non-existent placeholder paths (`/prompt`, `/active/project`) to use real directories, since local existence is now part of the inherit contract
- `cargo test -p termy_core` (167) and `cargo test -p termy` (624) pass; `cargo fmt --check` and clippy clean

Caveat: mechanism verified by tests on macOS; worth a quick manual check of the original WSL repro on a Windows machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)