### PR TITLE
Add Kitty graphics to native macOS app

### DIFF
--- a/crates/core/src/runtime.rs
+++ b/crates/core/src/runtime.rs
@@ -41,7 +41,7 @@ use std::{
     path::PathBuf,
     sync::{
         Arc,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
         mpsc::{self, Receiver as StdReceiver, Sender as StdSender, TryRecvError},
     },
     time::Instant,
@@ -1661,6 +1661,7 @@ struct NativeEventLoop {
     tx: StdSender<EventLoopMsg>,
     terminal: Arc<FairMutex<Term<JsonEventListener>>>,
     kitty_graphics: Arc<FairMutex<KittyGraphicsState>>,
+    kitty_graphics_revision: Arc<AtomicU64>,
     terminal_size: Arc<FairMutex<TerminalSize>>,
     event_proxy: JsonEventListener,
     drain_on_exit: bool,
@@ -1670,6 +1671,7 @@ impl NativeEventLoop {
     fn new(
         terminal: Arc<FairMutex<Term<JsonEventListener>>>,
         kitty_graphics: Arc<FairMutex<KittyGraphicsState>>,
+        kitty_graphics_revision: Arc<AtomicU64>,
         terminal_size: Arc<FairMutex<TerminalSize>>,
         event_proxy: JsonEventListener,
         pty: tty::Pty,
@@ -1683,6 +1685,7 @@ impl NativeEventLoop {
             tx,
             terminal,
             kitty_graphics,
+            kitty_graphics_revision,
             terminal_size,
             event_proxy,
             drain_on_exit,
@@ -1831,6 +1834,9 @@ impl NativeEventLoop {
             }
         }
 
+        if graphics_changed {
+            self.kitty_graphics_revision.fetch_add(1, Ordering::Relaxed);
+        }
         if graphics_changed || (state.parser.sync_bytes_count() < parsed && parsed > 0) {
             self.event_proxy.send_event(AlacEvent::Wakeup);
         }
@@ -2042,6 +2048,7 @@ pub struct Terminal {
     kitty_graphics_interceptor: FairMutex<KittyGraphicsInterceptor>,
     kitty_graphics_cursor_tracker: FairMutex<KittyGraphicsCursorTracker>,
     kitty_graphics: Arc<FairMutex<KittyGraphicsState>>,
+    kitty_graphics_revision: Arc<AtomicU64>,
     graphics_size: Arc<FairMutex<TerminalSize>>,
     /// Channel to send input to the PTY. `None` for display-only terminals
     /// (e.g. tmux control-mode panes) that are fed via `feed_output` and have
@@ -2122,6 +2129,7 @@ impl Terminal {
         let term = Term::new(term_config, &size, listener.clone());
         let term = Arc::new(FairMutex::new(term));
         let kitty_graphics = Arc::new(FairMutex::new(KittyGraphicsState::default()));
+        let kitty_graphics_revision = Arc::new(AtomicU64::new(0));
         let graphics_size = Arc::new(FairMutex::new(size));
 
         let window_id = 0;
@@ -2134,6 +2142,7 @@ impl Terminal {
         let event_loop = NativeEventLoop::new(
             term.clone(),
             kitty_graphics.clone(),
+            kitty_graphics_revision.clone(),
             graphics_size.clone(),
             listener.clone(),
             pty,
@@ -2149,6 +2158,7 @@ impl Terminal {
             kitty_graphics_interceptor: FairMutex::new(KittyGraphicsInterceptor::default()),
             kitty_graphics_cursor_tracker: FairMutex::new(KittyGraphicsCursorTracker::default()),
             kitty_graphics,
+            kitty_graphics_revision,
             graphics_size,
             pty_tx: Some(pty_tx),
             events_rx,
@@ -2172,6 +2182,7 @@ impl Terminal {
         let term = Term::new(term_config, &size, listener.clone());
         let term = Arc::new(FairMutex::new(term));
         let kitty_graphics = Arc::new(FairMutex::new(KittyGraphicsState::default()));
+        let kitty_graphics_revision = Arc::new(AtomicU64::new(0));
 
         Self {
             term,
@@ -2180,6 +2191,7 @@ impl Terminal {
             kitty_graphics_interceptor: FairMutex::new(KittyGraphicsInterceptor::default()),
             kitty_graphics_cursor_tracker: FairMutex::new(KittyGraphicsCursorTracker::default()),
             kitty_graphics,
+            kitty_graphics_revision,
             graphics_size: Arc::new(FairMutex::new(size)),
             pty_tx: None,
             events_rx,
@@ -2240,6 +2252,7 @@ impl Terminal {
         let mut cursor_tracker = self.kitty_graphics_cursor_tracker.lock();
         let mut parser = self.parser.lock();
         let mut term = self.term.lock();
+        let mut graphics_changed = false;
         for item in interceptor.process(bytes) {
             match item {
                 KittyGraphicsItem::Text(text) => {
@@ -2252,7 +2265,7 @@ impl Terminal {
                         track_scrolls,
                     );
                     if !effects.is_empty() {
-                        effects.apply_to(&mut self.kitty_graphics.lock());
+                        graphics_changed |= effects.apply_to(&mut self.kitty_graphics.lock());
                     }
                 }
                 KittyGraphicsItem::Command(command) => {
@@ -2270,6 +2283,7 @@ impl Terminal {
                         self.size,
                         screen,
                     );
+                    graphics_changed |= result.changed;
                     if result.cursor_advance_screen == Some(screen)
                         && let Some((cols, rows)) = result.cursor_advance
                     {
@@ -2280,13 +2294,17 @@ impl Terminal {
                             full_screen_scroll_region,
                         );
                         if untracked_scroll > 0 {
-                            self.kitty_graphics
+                            graphics_changed |= self
+                                .kitty_graphics
                                 .lock()
                                 .scroll_up_without_history_on_screen(untracked_scroll, screen);
                         }
                     }
                 }
             }
+        }
+        if graphics_changed {
+            self.kitty_graphics_revision.fetch_add(1, Ordering::Relaxed);
         }
     }
 
@@ -2336,16 +2354,30 @@ impl Terminal {
 
     /// Snapshot visible Kitty graphics placements for a renderer.
     pub fn kitty_graphics_placements(&self) -> Vec<KittyGraphicsRenderPlacement> {
+        self.kitty_graphics_snapshot().1
+    }
+
+    /// Monotonic revision for Kitty image or placement state.
+    pub fn kitty_graphics_revision(&self) -> u64 {
+        self.kitty_graphics_revision.load(Ordering::Relaxed)
+    }
+
+    /// Snapshot the current Kitty revision and visible placements together.
+    pub fn kitty_graphics_snapshot(&self) -> (u64, Vec<KittyGraphicsRenderPlacement>) {
         let term = self.term.lock();
         let grid = term.grid();
         let screen =
             KittyGraphicsScreen::from_alternate_screen(term.mode().contains(TermMode::ALT_SCREEN));
-        self.kitty_graphics.lock().render_placements_on_screen(
+        let placements = self.kitty_graphics.lock().render_placements_on_screen(
             grid.history_size(),
             grid.display_offset(),
             grid.screen_lines(),
             grid.columns(),
             screen,
+        );
+        (
+            self.kitty_graphics_revision.load(Ordering::Relaxed),
+            placements,
         )
     }
 
@@ -2725,9 +2757,11 @@ mod tests {
     #[test]
     fn display_terminal_intercepts_and_places_kitty_graphics() {
         let terminal = Terminal::new_display(test_terminal_size(), None);
+        let initial_revision = terminal.kitty_graphics_revision();
         terminal.feed_output(b"\x1b_Ga=T,f=32,s=1,v=1,i=77,c=2,r=3;AQID/w==\x1b\\");
 
-        let placements = terminal.kitty_graphics_placements();
+        let (revision, placements) = terminal.kitty_graphics_snapshot();
+        assert!(revision > initial_revision);
         assert_eq!(placements.len(), 1);
         assert_eq!(placements[0].image_id, 77);
         assert_eq!(placements[0].display_cols, Some(2));

--- a/crates/ffi/include/termy.h
+++ b/crates/ffi/include/termy.h
@@ -127,6 +127,38 @@ typedef struct {
 } TermyFfiBytes;
 
 typedef struct {
+  uint64_t placement_serial;
+  uint32_t image_id;
+  uint32_t placement_id;
+  TermyFfiBytes png;
+  uint32_t image_width;
+  uint32_t image_height;
+  uint64_t image_generation;
+  int32_t viewport_row;
+  size_t col;
+  uint32_t source_x;
+  uint32_t source_y;
+  uint32_t source_width;
+  uint32_t source_height;
+  bool has_display_cols;
+  uint32_t display_cols;
+  bool has_display_rows;
+  uint32_t display_rows;
+  uint32_t occupied_cols;
+  uint32_t occupied_rows;
+  uint32_t x_offset;
+  uint32_t y_offset;
+  int32_t z_index;
+} TermyFfiKittyGraphicsPlacement;
+
+typedef struct {
+  uint64_t revision;
+  TermyFfiKittyGraphicsPlacement *placements_ptr;
+  size_t placements_len;
+  size_t placements_capacity;
+} TermyFfiKittyGraphicsBatch;
+
+typedef struct {
   uint32_t kind;
   int32_t exit_code;
   uint8_t progress_state;
@@ -499,6 +531,14 @@ TermyFfiStatus termy_terminal_take_frame_update(
     bool force_full,
     TermyFfiFrameUpdate *out_update);
 TermyFfiStatus termy_frame_update_free(TermyFfiFrameUpdate *update);
+TermyFfiStatus termy_terminal_kitty_graphics_revision(
+    TermyFfiTerminal *terminal,
+    uint64_t *out_revision);
+TermyFfiStatus termy_terminal_kitty_graphics_placements(
+    TermyFfiTerminal *terminal,
+    TermyFfiKittyGraphicsBatch *out_batch);
+TermyFfiStatus termy_kitty_graphics_batch_free(
+    TermyFfiKittyGraphicsBatch *batch);
 TermyFfiStatus termy_terminal_hyperlink_at(
     TermyFfiTerminal *terminal,
     size_t row,

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -13,14 +13,14 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use flume::{Receiver, Sender, bounded};
 use termy_core::{
-    ConfigDiagnostic, ConfigDiagnosticKind, LoadedTermyConfig, ProgressState, Terminal,
-    TerminalClipboardTarget, TerminalDamageSnapshot, TerminalDirtySpan, TerminalEvent,
-    TerminalKeyEventKind, TerminalMouseButton, TerminalMouseEventKind, TerminalMouseModifiers,
-    TerminalMousePosition, TerminalOptions, TerminalQueryColors, TerminalReplyHost,
-    TerminalRuntimeConfig, TerminalSize, TermyCell, TermyColor, TermyFrameUpdate, TermyKeystroke,
-    TermyModifiers, TermySearchOptions, TermySharedSearchMatch, encode_mouse_report,
-    keystroke_to_input, load_config_from_contents, load_config_from_default_path,
-    load_config_from_path,
+    ConfigDiagnostic, ConfigDiagnosticKind, KittyGraphicsRenderPlacement, LoadedTermyConfig,
+    ProgressState, Terminal, TerminalClipboardTarget, TerminalDamageSnapshot, TerminalDirtySpan,
+    TerminalEvent, TerminalKeyEventKind, TerminalMouseButton, TerminalMouseEventKind,
+    TerminalMouseModifiers, TerminalMousePosition, TerminalOptions, TerminalQueryColors,
+    TerminalReplyHost, TerminalRuntimeConfig, TerminalSize, TermyCell, TermyColor,
+    TermyFrameUpdate, TermyKeystroke, TermyModifiers, TermySearchOptions, TermySharedSearchMatch,
+    encode_mouse_report, keystroke_to_input, load_config_from_contents,
+    load_config_from_default_path, load_config_from_path,
 };
 
 #[repr(C)]
@@ -121,6 +121,42 @@ pub struct TermyFfiBytes {
     pub ptr: *mut u8,
     pub len: usize,
     pub capacity: usize,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct TermyFfiKittyGraphicsPlacement {
+    pub placement_serial: u64,
+    pub image_id: u32,
+    pub placement_id: u32,
+    pub png: TermyFfiBytes,
+    pub image_width: u32,
+    pub image_height: u32,
+    pub image_generation: u64,
+    pub viewport_row: i32,
+    pub col: usize,
+    pub source_x: u32,
+    pub source_y: u32,
+    pub source_width: u32,
+    pub source_height: u32,
+    pub has_display_cols: bool,
+    pub display_cols: u32,
+    pub has_display_rows: bool,
+    pub display_rows: u32,
+    pub occupied_cols: u32,
+    pub occupied_rows: u32,
+    pub x_offset: u32,
+    pub y_offset: u32,
+    pub z_index: i32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct TermyFfiKittyGraphicsBatch {
+    pub revision: u64,
+    pub placements_ptr: *mut TermyFfiKittyGraphicsPlacement,
+    pub placements_len: usize,
+    pub placements_capacity: usize,
 }
 
 #[repr(C)]
@@ -470,6 +506,35 @@ fn ffi_bytes_from_vec(mut bytes: Vec<u8>) -> TermyFfiBytes {
 
 fn ffi_bytes_from_string(value: String) -> TermyFfiBytes {
     ffi_bytes_from_vec(value.into_bytes())
+}
+
+fn ffi_kitty_graphics_placement_from_placement(
+    placement: KittyGraphicsRenderPlacement,
+) -> TermyFfiKittyGraphicsPlacement {
+    TermyFfiKittyGraphicsPlacement {
+        placement_serial: placement.placement_serial,
+        image_id: placement.image_id,
+        placement_id: placement.placement_id,
+        png: ffi_bytes_from_vec(placement.png.as_ref().to_vec()),
+        image_width: placement.image_width,
+        image_height: placement.image_height,
+        image_generation: placement.image_generation,
+        viewport_row: placement.viewport_row,
+        col: placement.col,
+        source_x: placement.source_x,
+        source_y: placement.source_y,
+        source_width: placement.source_width,
+        source_height: placement.source_height,
+        has_display_cols: placement.display_cols.is_some(),
+        display_cols: placement.display_cols.unwrap_or_default(),
+        has_display_rows: placement.display_rows.is_some(),
+        display_rows: placement.display_rows.unwrap_or_default(),
+        occupied_cols: placement.occupied_cols,
+        occupied_rows: placement.occupied_rows,
+        x_offset: placement.x_offset,
+        y_offset: placement.y_offset,
+        z_index: placement.z_index,
+    }
 }
 
 fn progress_parts(progress: ProgressState) -> (u8, u8) {
@@ -2953,6 +3018,78 @@ pub unsafe extern "C" fn termy_frame_update_free(
             }
         }
         *update = TermyFfiFrameUpdate::default();
+        TermyFfiStatus::Ok
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn termy_terminal_kitty_graphics_revision(
+    terminal: *mut TermyFfiTerminal,
+    out_revision: *mut u64,
+) -> TermyFfiStatus {
+    ffi_status_guard(|| {
+        if terminal.is_null() || out_revision.is_null() {
+            return TermyFfiStatus::Null;
+        }
+
+        unsafe {
+            *out_revision = (*terminal).terminal.kitty_graphics_revision();
+        }
+        TermyFfiStatus::Ok
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn termy_terminal_kitty_graphics_placements(
+    terminal: *mut TermyFfiTerminal,
+    out_batch: *mut TermyFfiKittyGraphicsBatch,
+) -> TermyFfiStatus {
+    ffi_status_guard(|| {
+        if terminal.is_null() || out_batch.is_null() {
+            return TermyFfiStatus::Null;
+        }
+
+        let (revision, placements) = unsafe { (*terminal).terminal.kitty_graphics_snapshot() };
+        let placements = placements
+            .into_iter()
+            .map(ffi_kitty_graphics_placement_from_placement)
+            .collect::<Vec<_>>();
+        let (placements_ptr, placements_len, placements_capacity) = leak_vec(placements);
+        unsafe {
+            *out_batch = TermyFfiKittyGraphicsBatch {
+                revision,
+                placements_ptr,
+                placements_len,
+                placements_capacity,
+            };
+        }
+        TermyFfiStatus::Ok
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn termy_kitty_graphics_batch_free(
+    batch: *mut TermyFfiKittyGraphicsBatch,
+) -> TermyFfiStatus {
+    ffi_status_guard(|| {
+        if batch.is_null() {
+            return TermyFfiStatus::Null;
+        }
+
+        let batch = unsafe { &mut *batch };
+        if !batch.placements_ptr.is_null() {
+            let placements = unsafe {
+                Vec::from_raw_parts(
+                    batch.placements_ptr,
+                    batch.placements_len,
+                    batch.placements_capacity,
+                )
+            };
+            for placement in placements {
+                free_bytes(placement.png);
+            }
+        }
+        *batch = TermyFfiKittyGraphicsBatch::default();
         TermyFfiStatus::Ok
     })
 }

--- a/crates/ffi/tests/c_header_contract.rs
+++ b/crates/ffi/tests/c_header_contract.rs
@@ -22,12 +22,17 @@ void termy_header_contract(void) {
   TermyFfiSize size = termy_size_default();
   TermyFfiTerminal *terminal = 0;
   TermyFfiFrame frame = {0};
+  TermyFfiKittyGraphicsBatch graphics = {0};
+  uint64_t graphics_revision = 0;
   const uint8_t bytes[] = {'o', 'k'};
 
   TermyFfiStatus status = termy_display_terminal_new(size, &terminal);
   (void)status;
   (void)termy_terminal_feed_output(terminal, bytes, sizeof(bytes));
   (void)termy_terminal_snapshot(terminal, &frame);
+  (void)termy_terminal_kitty_graphics_revision(terminal, &graphics_revision);
+  (void)termy_terminal_kitty_graphics_placements(terminal, &graphics);
+  (void)termy_kitty_graphics_batch_free(&graphics);
   (void)termy_frame_free(&frame);
   (void)termy_terminal_free(terminal);
 }

--- a/crates/ffi/tests/display_terminal.rs
+++ b/crates/ffi/tests/display_terminal.rs
@@ -3,8 +3,11 @@
 //! through the normal snapshot/render FFI.
 
 use termy_ffi::{
-    TermyFfiFrame, TermyFfiStatus, TermyFfiTerminal, termy_display_terminal_new, termy_frame_free,
-    termy_size_default, termy_terminal_feed_output, termy_terminal_free, termy_terminal_snapshot,
+    TermyFfiFrame, TermyFfiKittyGraphicsBatch, TermyFfiStatus, TermyFfiTerminal,
+    termy_display_terminal_new, termy_frame_free, termy_kitty_graphics_batch_free,
+    termy_size_default, termy_terminal_feed_output, termy_terminal_free,
+    termy_terminal_kitty_graphics_placements, termy_terminal_kitty_graphics_revision,
+    termy_terminal_snapshot,
 };
 
 #[test]
@@ -59,6 +62,50 @@ fn display_terminal_write_is_noop_without_pty() {
         TermyFfiStatus::Ok
     );
     unsafe { termy_terminal_free(terminal) };
+}
+
+#[test]
+fn display_terminal_exposes_kitty_graphics_placements() {
+    let size = termy_size_default();
+    let mut terminal: *mut TermyFfiTerminal = std::ptr::null_mut();
+    assert_eq!(
+        unsafe { termy_display_terminal_new(size, &mut terminal) },
+        TermyFfiStatus::Ok
+    );
+
+    let command = b"\x1b_Ga=T,f=32,s=1,v=1,i=77,c=2,r=3;AQID/w==\x1b\\";
+    assert_eq!(
+        unsafe { termy_terminal_feed_output(terminal, command.as_ptr(), command.len()) },
+        TermyFfiStatus::Ok
+    );
+
+    let mut revision = 0;
+    assert_eq!(
+        unsafe { termy_terminal_kitty_graphics_revision(terminal, &mut revision) },
+        TermyFfiStatus::Ok
+    );
+    assert!(revision > 0);
+
+    let mut batch = TermyFfiKittyGraphicsBatch::default();
+    assert_eq!(
+        unsafe { termy_terminal_kitty_graphics_placements(terminal, &mut batch) },
+        TermyFfiStatus::Ok
+    );
+    assert_eq!(batch.revision, revision);
+    let placements =
+        unsafe { std::slice::from_raw_parts(batch.placements_ptr, batch.placements_len) };
+    assert_eq!(placements.len(), 1);
+    assert_eq!(placements[0].image_id, 77);
+    assert!(placements[0].has_display_cols);
+    assert_eq!(placements[0].display_cols, 2);
+    let png = unsafe { std::slice::from_raw_parts(placements[0].png.ptr, placements[0].png.len) };
+    assert!(png.starts_with(b"\x89PNG"));
+
+    assert_eq!(
+        unsafe { termy_kitty_graphics_batch_free(&mut batch) },
+        TermyFfiStatus::Ok
+    );
+    assert_eq!(unsafe { termy_terminal_free(terminal) }, TermyFfiStatus::Ok);
 }
 
 #[test]

--- a/macos/Sources/TermySwift/Models/TerminalKittyGraphics.swift
+++ b/macos/Sources/TermySwift/Models/TerminalKittyGraphics.swift
@@ -1,0 +1,137 @@
+import CoreGraphics
+import Foundation
+
+struct TerminalKittyGraphicsIdentity: Hashable {
+    var placementSerial: UInt64
+    var imageID: UInt32
+    var imageGeneration: UInt64
+}
+
+struct TerminalKittyGraphicsImageKey: Hashable {
+    var imageID: UInt32
+    var imageGeneration: UInt64
+}
+
+struct TerminalKittyGraphicsPlacement: Identifiable, Equatable {
+    var placementSerial: UInt64
+    var imageID: UInt32
+    var placementID: UInt32
+    var png: Data
+    var imageWidth: Int
+    var imageHeight: Int
+    var imageGeneration: UInt64
+    var viewportRow: Int
+    var col: Int
+    var sourceX: Int
+    var sourceY: Int
+    var sourceWidth: Int
+    var sourceHeight: Int
+    var displayCols: Int?
+    var displayRows: Int?
+    var occupiedCols: Int
+    var occupiedRows: Int
+    var xOffset: Int
+    var yOffset: Int
+    var zIndex: Int
+
+    var id: TerminalKittyGraphicsIdentity { identity }
+
+    var identity: TerminalKittyGraphicsIdentity {
+        TerminalKittyGraphicsIdentity(
+            placementSerial: placementSerial,
+            imageID: imageID,
+            imageGeneration: imageGeneration
+        )
+    }
+
+    var imageKey: TerminalKittyGraphicsImageKey {
+        TerminalKittyGraphicsImageKey(
+            imageID: imageID,
+            imageGeneration: imageGeneration
+        )
+    }
+
+    func bounds(renderConfig: TerminalRenderConfig) -> CGRect {
+        let width = displayCols.map { CGFloat($0) * renderConfig.cellWidth }
+            ?? CGFloat(sourceWidth)
+        let height = displayRows.map { CGFloat($0) * renderConfig.cellHeight }
+            ?? CGFloat(sourceHeight)
+        return CGRect(
+            x: renderConfig.paddingX + CGFloat(col) * renderConfig.cellWidth + CGFloat(xOffset),
+            y: renderConfig.paddingY + CGFloat(viewportRow) * renderConfig.cellHeight + CGFloat(yOffset),
+            width: width,
+            height: height
+        )
+    }
+
+    func intersects(
+        selection: TerminalSelection?,
+        cols: Int,
+        rows: Int
+    ) -> Bool {
+        let placementRows = viewportRow..<(viewportRow + max(1, occupiedRows))
+        let placementStartCol = col
+        let placementEndCol = col + max(1, occupiedCols) - 1
+        return selection?
+            .rowRanges(cols: cols, rows: rows)
+            .contains { range in
+                placementRows.contains(range.row)
+                    && range.startCol <= placementEndCol
+                    && range.endCol >= placementStartCol
+            } == true
+    }
+
+    static func == (
+        lhs: TerminalKittyGraphicsPlacement,
+        rhs: TerminalKittyGraphicsPlacement
+    ) -> Bool {
+        lhs.placementSerial == rhs.placementSerial
+            && lhs.imageID == rhs.imageID
+            && lhs.placementID == rhs.placementID
+            && lhs.imageWidth == rhs.imageWidth
+            && lhs.imageHeight == rhs.imageHeight
+            && lhs.imageGeneration == rhs.imageGeneration
+            && lhs.viewportRow == rhs.viewportRow
+            && lhs.col == rhs.col
+            && lhs.sourceX == rhs.sourceX
+            && lhs.sourceY == rhs.sourceY
+            && lhs.sourceWidth == rhs.sourceWidth
+            && lhs.sourceHeight == rhs.sourceHeight
+            && lhs.displayCols == rhs.displayCols
+            && lhs.displayRows == rhs.displayRows
+            && lhs.occupiedCols == rhs.occupiedCols
+            && lhs.occupiedRows == rhs.occupiedRows
+            && lhs.xOffset == rhs.xOffset
+            && lhs.yOffset == rhs.yOffset
+            && lhs.zIndex == rhs.zIndex
+    }
+
+    static func paintOrder(
+        _ lhs: TerminalKittyGraphicsPlacement,
+        _ rhs: TerminalKittyGraphicsPlacement
+    ) -> Bool {
+        if lhs.zIndex != rhs.zIndex {
+            return lhs.zIndex < rhs.zIndex
+        }
+        if lhs.imageID != rhs.imageID {
+            return lhs.imageID < rhs.imageID
+        }
+        if lhs.placementID != rhs.placementID {
+            return lhs.placementID < rhs.placementID
+        }
+        return lhs.placementSerial < rhs.placementSerial
+    }
+}
+
+struct TerminalKittyGraphicsSnapshot {
+    var revision: UInt64
+    var placements: [TerminalKittyGraphicsPlacement]
+}
+
+struct TerminalKittyGraphicsQuerySignature: Equatable {
+    var revision: UInt64
+    var cols: Int
+    var rows: Int
+    var displayOffset: Int
+    var historySize: Int
+}

--- a/macos/Sources/TermySwift/Services/LibTermyTerminal.swift
+++ b/macos/Sources/TermySwift/Services/LibTermyTerminal.swift
@@ -4,6 +4,7 @@ import Foundation
 enum LibTermyError: Error, CustomStringConvertible {
     case missingTerminal
     case missingCells
+    case missingGraphicsPlacements
     case cellCountMismatch
 
     var description: String {
@@ -12,6 +13,8 @@ enum LibTermyError: Error, CustomStringConvertible {
             return "libtermy did not return a terminal handle"
         case .missingCells:
             return "libtermy returned a frame without cells"
+        case .missingGraphicsPlacements:
+            return "libtermy returned graphics metadata without placements"
         case .cellCountMismatch:
             return "libtermy returned a cell count that does not match the frame damage"
         }
@@ -499,6 +502,75 @@ final class LibTermyTerminal {
             displayOffset: Int(update.display_offset),
             historySize: Int(update.history_size),
             damage: damage
+        )
+    }
+
+    func kittyGraphicsRevision() throws -> UInt64 {
+        let handle = try terminalHandle()
+        var revision: UInt64 = 0
+        try TermyFfiBridge.requireOK(
+            "termy_terminal_kitty_graphics_revision",
+            termy_terminal_kitty_graphics_revision(handle, &revision)
+        )
+        return revision
+    }
+
+    func kittyGraphicsPlacements() throws -> TerminalKittyGraphicsSnapshot {
+        let handle = try terminalHandle()
+        var batch = TermyFfiKittyGraphicsBatch()
+        try TermyFfiBridge.requireOK(
+            "termy_terminal_kitty_graphics_placements",
+            termy_terminal_kitty_graphics_placements(handle, &batch)
+        )
+        defer {
+            _ = termy_kitty_graphics_batch_free(&batch)
+        }
+
+        guard batch.placements_len > 0 else {
+            return TerminalKittyGraphicsSnapshot(revision: batch.revision, placements: [])
+        }
+        guard let placementsPtr = batch.placements_ptr else {
+            throw LibTermyError.missingGraphicsPlacements
+        }
+
+        let placements = UnsafeBufferPointer(
+            start: placementsPtr,
+            count: Int(batch.placements_len)
+        ).map { placement in
+            let png: Data
+            if placement.png.len > 0, let pngPtr = placement.png.ptr {
+                png = Data(bytes: pngPtr, count: Int(placement.png.len))
+            } else {
+                png = Data()
+            }
+            return TerminalKittyGraphicsPlacement(
+                placementSerial: placement.placement_serial,
+                imageID: placement.image_id,
+                placementID: placement.placement_id,
+                png: png,
+                imageWidth: Int(placement.image_width),
+                imageHeight: Int(placement.image_height),
+                imageGeneration: placement.image_generation,
+                viewportRow: Int(placement.viewport_row),
+                col: Int(placement.col),
+                sourceX: Int(placement.source_x),
+                sourceY: Int(placement.source_y),
+                sourceWidth: Int(placement.source_width),
+                sourceHeight: Int(placement.source_height),
+                displayCols: placement.has_display_cols ? Int(placement.display_cols) : nil,
+                displayRows: placement.has_display_rows ? Int(placement.display_rows) : nil,
+                occupiedCols: Int(placement.occupied_cols),
+                occupiedRows: Int(placement.occupied_rows),
+                xOffset: Int(placement.x_offset),
+                yOffset: Int(placement.y_offset),
+                zIndex: Int(placement.z_index)
+            )
+        }
+        .sorted(by: TerminalKittyGraphicsPlacement.paintOrder)
+
+        return TerminalKittyGraphicsSnapshot(
+            revision: batch.revision,
+            placements: placements
         )
     }
 

--- a/macos/Sources/TermySwift/Services/TerminalViewModel.swift
+++ b/macos/Sources/TermySwift/Services/TerminalViewModel.swift
@@ -14,6 +14,8 @@ final class TerminalViewModel: ObservableObject {
     @Published private(set) var hasVisibleContent = false
     @Published private(set) var frameMetadata = TerminalFrameMetadata.empty
     @Published private(set) var canCopySelection = false
+    @Published private(set) var kittyGraphicsPlacements: [TerminalKittyGraphicsPlacement] = []
+    @Published private(set) var selectedKittyGraphics: TerminalKittyGraphicsIdentity?
     @Published private(set) var currentWorkingDirectory: String?
     @Published private(set) var searchMatches: [TerminalSearchMatch] = []
     @Published private(set) var activeSearchMatchIndex = 0
@@ -108,6 +110,8 @@ final class TerminalViewModel: ObservableObject {
     private var activeSearchOptions = TerminalSearchOptions()
     private var lastSearchRefreshAt: Date?
     private var lastAutoCopiedSelectionText: String?
+    private var contextKittyGraphics: TerminalKittyGraphicsIdentity?
+    private var lastKittyGraphicsQuerySignature: TerminalKittyGraphicsQuerySignature?
     private var pendingWakeupPoll = false
     private var renderedFrameCount = 0
     private var skippedPresentCount = 0
@@ -400,6 +404,12 @@ final class TerminalViewModel: ObservableObject {
         isExited = true
         progress = .clear
         startupRefreshUntil = nil
+        kittyGraphicsPlacements = []
+        selectedKittyGraphics = nil
+        contextKittyGraphics = nil
+        lastKittyGraphicsQuerySignature = nil
+        hasVisibleContent = frameStore.hasVisibleContent
+        canCopySelection = frame.hasSelectedText(for: selection)
     }
 
     /// Re-read appearance settings from the config file and apply them to this
@@ -608,8 +618,13 @@ final class TerminalViewModel: ObservableObject {
     }
 
     func updateSelection(_ selection: TerminalSelection?) {
+        let clearedImageSelection = selectedKittyGraphics != nil
+        selectedKittyGraphics = nil
         self.selection = selection
         canCopySelection = frame.hasSelectedText(for: selection)
+        if clearedImageSelection {
+            invalidateKittyGraphicsSelection()
+        }
         guard renderConfig.copyOnSelect,
               let text = frame.selectedText(for: selection),
               !text.isEmpty
@@ -702,12 +717,54 @@ final class TerminalViewModel: ObservableObject {
     }
 
     func copySelection() -> Bool {
+        if let selectedKittyGraphics,
+           copyKittyGraphics(selectedKittyGraphics) {
+            return true
+        }
         guard let text = frame.selectedText(for: selection), !text.isEmpty else {
             return false
         }
 
         copy(text)
         return true
+    }
+
+    func selectKittyGraphics(at point: CGPoint) -> Bool {
+        let positivePlacement = topmostKittyGraphics(at: point, matching: { $0.zIndex >= 0 })
+        let placement = positivePlacement
+            ?? topmostKittyGraphics(at: point, matching: { _ in true })
+        guard let placement else {
+            return false
+        }
+        if placement.zIndex < 0, foregroundTerminalSemantics(at: point) {
+            return false
+        }
+
+        selection = nil
+        lastAutoCopiedSelectionText = nil
+        selectedKittyGraphics = placement.identity
+        canCopySelection = true
+        invalidateKittyGraphicsSelection()
+        return true
+    }
+
+    @discardableResult
+    func updateContextKittyGraphics(at point: CGPoint?) -> Bool {
+        guard let point,
+              let placement = topmostKittyGraphics(at: point, matching: { _ in true })
+        else {
+            contextKittyGraphics = nil
+            return false
+        }
+        contextKittyGraphics = placement.identity
+        return true
+    }
+
+    func copyContextKittyGraphics() -> Bool {
+        guard let contextKittyGraphics else {
+            return false
+        }
+        return copyKittyGraphics(contextKittyGraphics)
     }
 
     func search(
@@ -840,11 +897,12 @@ final class TerminalViewModel: ObservableObject {
             if let update {
                 nativeRenderMetricsRecorder.recordFrameUpdate(update, applyResult: applyResult)
             }
+            let kittyGraphicsChanged = try refreshKittyGraphicsIfNeeded()
             if Self.hasCadenceActivity(
                 events: events,
                 patchedCellCount: applyResult.patchedCellCount,
                 forceFull: forceFull,
-                changed: applyResult.changed
+                changed: applyResult.changed || kittyGraphicsChanged
             ) {
                 noteActivity()
             } else {
@@ -860,7 +918,7 @@ final class TerminalViewModel: ObservableObject {
                 cursorBlinkVisible = cursorBlinkPhase.isVisible
             }
 
-            guard forceFull || applyResult.changed else {
+            guard forceFull || applyResult.changed || kittyGraphicsChanged else {
                 presentCursorBlink(toggled: blinkToggled)
                 updateDebugMetrics(renderedFrame: false)
                 return
@@ -890,7 +948,9 @@ final class TerminalViewModel: ObservableObject {
             // so the grid view repaints the cursor row alongside the frame's
             // own dirty rows. The plan cache below keeps the narrower
             // `effectiveDamage`: a blink changes no cell content.
-            if blinkToggled, let cursor = frame.cursor {
+            if kittyGraphicsChanged {
+                renderDamage = .full
+            } else if blinkToggled, let cursor = frame.cursor {
                 renderDamage = effectiveDamage.union(
                     TerminalDirtySpan(row: cursor.row, leftCol: cursor.col, rightCol: cursor.col)
                 )
@@ -925,9 +985,95 @@ final class TerminalViewModel: ObservableObject {
 
     private func publishFrameState() {
         frame = frameStore.frame
-        hasVisibleContent = frameStore.hasVisibleContent
+        hasVisibleContent = frameStore.hasVisibleContent || !kittyGraphicsPlacements.isEmpty
         frameMetadata = TerminalFrameMetadata(frame: frame)
-        canCopySelection = frame.hasSelectedText(for: selection)
+        canCopySelection = selectedKittyGraphics != nil || frame.hasSelectedText(for: selection)
+    }
+
+    private func refreshKittyGraphicsIfNeeded() throws -> Bool {
+        guard let terminal else {
+            return false
+        }
+        let revision = try terminal.kittyGraphicsRevision()
+        let currentFrame = frameStore.frame
+        let signature = TerminalKittyGraphicsQuerySignature(
+            revision: revision,
+            cols: currentFrame.cols,
+            rows: currentFrame.rows,
+            displayOffset: currentFrame.displayOffset,
+            historySize: currentFrame.historySize
+        )
+        guard signature != lastKittyGraphicsQuerySignature else {
+            return false
+        }
+
+        let snapshot = try terminal.kittyGraphicsPlacements()
+        let placementsChanged = snapshot.placements != kittyGraphicsPlacements
+        kittyGraphicsPlacements = snapshot.placements
+        lastKittyGraphicsQuerySignature = TerminalKittyGraphicsQuerySignature(
+            revision: snapshot.revision,
+            cols: currentFrame.cols,
+            rows: currentFrame.rows,
+            displayOffset: currentFrame.displayOffset,
+            historySize: currentFrame.historySize
+        )
+
+        var selectionChanged = false
+        if let selectedKittyGraphics,
+           !snapshot.placements.contains(where: { $0.identity == selectedKittyGraphics }) {
+            self.selectedKittyGraphics = nil
+            selectionChanged = true
+        }
+        if let contextKittyGraphics,
+           !snapshot.placements.contains(where: { $0.identity == contextKittyGraphics }) {
+            self.contextKittyGraphics = nil
+        }
+        return placementsChanged || selectionChanged
+    }
+
+    private func topmostKittyGraphics(
+        at point: CGPoint,
+        matching predicate: (TerminalKittyGraphicsPlacement) -> Bool
+    ) -> TerminalKittyGraphicsPlacement? {
+        kittyGraphicsPlacements.reversed().first {
+            predicate($0) && $0.bounds(renderConfig: renderConfig).contains(point)
+        }
+    }
+
+    private func foregroundTerminalSemantics(at point: CGPoint) -> Bool {
+        let cellWidth = max(1, renderConfig.cellWidth)
+        let cellHeight = max(1, renderConfig.cellHeight)
+        let col = Int(floor((point.x - renderConfig.paddingX) / cellWidth))
+        let row = Int(floor((point.y - renderConfig.paddingY) / cellHeight))
+        let position = TerminalGridPosition(col: col, row: row)
+        guard col >= 0, col < frame.cols, row >= 0, row < frame.rows else {
+            return false
+        }
+        if let cell = frame.cell(row: row, col: col),
+           cell.renderText,
+           cell.character != " " {
+            return true
+        }
+        return link(at: position) != nil
+    }
+
+    private func copyKittyGraphics(_ identity: TerminalKittyGraphicsIdentity) -> Bool {
+        guard let placement = kittyGraphicsPlacements.first(where: { $0.identity == identity }),
+              !placement.png.isEmpty
+        else {
+            return false
+        }
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        return pasteboard.setData(
+            placement.png,
+            forType: NSPasteboard.PasteboardType("public.png")
+        )
+    }
+
+    private func invalidateKittyGraphicsSelection() {
+        renderDamage = .full
+        renderRevision &+= 1
     }
 
     private func shouldForceStartupRefresh() -> Bool {

--- a/macos/Sources/TermySwift/Support/TerminalSurfaceContextMenu.swift
+++ b/macos/Sources/TermySwift/Support/TerminalSurfaceContextMenu.swift
@@ -1,7 +1,12 @@
 import AppKit
 
 enum TerminalSurfaceContextMenu {
-    static func make(canCopy: Bool, canPaste: Bool, target: KeyboardCaptureView) -> NSMenu {
+    static func make(
+        canCopy: Bool,
+        canCopyImage: Bool = false,
+        canPaste: Bool,
+        target: KeyboardCaptureView
+    ) -> NSMenu {
         let menu = NSMenu()
         menu.autoenablesItems = false
 
@@ -12,6 +17,14 @@ enum TerminalSurfaceContextMenu {
             target: target,
             isEnabled: canCopy
         ))
+        if canCopyImage {
+            menu.addItem(item(
+                title: "Copy Image",
+                action: #selector(KeyboardCaptureView.copyImageFromTerminalContextMenu(_:)),
+                keyEquivalent: "",
+                target: target
+            ))
+        }
         menu.addItem(item(
             title: "Paste",
             action: #selector(KeyboardCaptureView.pasteFromTerminalContextMenu(_:)),

--- a/macos/Sources/TermySwift/Views/TerminalGridView.swift
+++ b/macos/Sources/TermySwift/Views/TerminalGridView.swift
@@ -7,6 +7,8 @@ struct TerminalGridView: View {
     let renderPlan: TerminalRenderPlan
     let renderDamage: TerminalDamage
     let selection: TerminalSelection?
+    let kittyGraphicsPlacements: [TerminalKittyGraphicsPlacement]
+    let selectedKittyGraphics: TerminalKittyGraphicsIdentity?
     let renderConfig: TerminalRenderConfig
     let searchMatches: [TerminalSearchMatch]
     let activeSearchMatch: TerminalSearchMatch?
@@ -20,6 +22,8 @@ struct TerminalGridView: View {
             renderPlan: renderPlan,
             renderDamage: renderDamage,
             selection: selection,
+            kittyGraphicsPlacements: kittyGraphicsPlacements,
+            selectedKittyGraphics: selectedKittyGraphics,
             renderConfig: renderConfig,
             searchMatches: searchMatches,
             activeSearchMatch: activeSearchMatch,
@@ -37,6 +41,8 @@ private struct TerminalGridRepresentable: NSViewRepresentable {
     let renderPlan: TerminalRenderPlan
     let renderDamage: TerminalDamage
     let selection: TerminalSelection?
+    let kittyGraphicsPlacements: [TerminalKittyGraphicsPlacement]
+    let selectedKittyGraphics: TerminalKittyGraphicsIdentity?
     let renderConfig: TerminalRenderConfig
     let searchMatches: [TerminalSearchMatch]
     let activeSearchMatch: TerminalSearchMatch?
@@ -54,6 +60,8 @@ private struct TerminalGridRepresentable: NSViewRepresentable {
             renderPlan: renderPlan,
             renderDamage: renderDamage,
             selection: selection,
+            kittyGraphicsPlacements: kittyGraphicsPlacements,
+            selectedKittyGraphics: selectedKittyGraphics,
             renderConfig: renderConfig,
             searchMatches: searchMatches,
             activeSearchMatch: activeSearchMatch,
@@ -68,6 +76,8 @@ final class TerminalGridNSView: NSView {
     private var terminalFrame = TerminalFrame.empty
     private var renderPlan = TerminalRenderPlan.empty
     private var selection: TerminalSelection?
+    private var kittyGraphicsPlacements: [TerminalKittyGraphicsPlacement] = []
+    private var selectedKittyGraphics: TerminalKittyGraphicsIdentity?
     private var renderConfig = TerminalRenderConfig.default
     private var searchMatches: [TerminalSearchMatch] = []
     private var activeSearchMatch: TerminalSearchMatch?
@@ -85,6 +95,7 @@ final class TerminalGridNSView: NSView {
     private var cachedBoldFont = NSFont.monospacedSystemFont(ofSize: 12, weight: .semibold)
     private var nsColorCache: [UInt32: NSColor] = [:]
     private var alphaColorCache: [UInt64: NSColor] = [:]
+    private var kittyGraphicsImageCache: [TerminalKittyGraphicsImageKey: NSImage] = [:]
     private let lineCache = TextLineCache()
     private var occlusionObserver: NotificationObserverToken?
 
@@ -215,6 +226,8 @@ final class TerminalGridNSView: NSView {
         renderPlan: TerminalRenderPlan,
         renderDamage: TerminalDamage,
         selection: TerminalSelection?,
+        kittyGraphicsPlacements: [TerminalKittyGraphicsPlacement],
+        selectedKittyGraphics: TerminalKittyGraphicsIdentity?,
         renderConfig: TerminalRenderConfig,
         searchMatches: [TerminalSearchMatch],
         activeSearchMatch: TerminalSearchMatch?,
@@ -227,6 +240,8 @@ final class TerminalGridNSView: NSView {
             || terminalFrame.displayOffset != frame.displayOffset
             || self.renderConfig != renderConfig
             || self.selection != selection
+            || self.kittyGraphicsPlacements != kittyGraphicsPlacements
+            || self.selectedKittyGraphics != selectedKittyGraphics
             || self.searchMatches != searchMatches
             || self.activeSearchMatch != activeSearchMatch
             || self.hoveredLink != hoveredLink
@@ -235,12 +250,18 @@ final class TerminalGridNSView: NSView {
         self.terminalFrame = frame
         self.renderPlan = renderPlan
         self.selection = selection
+        self.kittyGraphicsPlacements = kittyGraphicsPlacements
+        self.selectedKittyGraphics = selectedKittyGraphics
         self.renderConfig = renderConfig
         self.searchMatches = searchMatches
         self.activeSearchMatch = activeSearchMatch
         self.hoveredLink = hoveredLink
         self.isTerminalFocused = isFocused
         self.isCursorVisible = isCursorVisible
+        let activeImageKeys = Set(kittyGraphicsPlacements.map(\.imageKey))
+        kittyGraphicsImageCache = kittyGraphicsImageCache.filter {
+            activeImageKeys.contains($0.key)
+        }
 
         if requiresFullRedraw || renderDamage == .full {
             needsDisplay = true
@@ -262,6 +283,7 @@ final class TerminalGridNSView: NSView {
         }
 
         let dirtyBounds = dirtyGridBounds(for: dirtyRect)
+        drawKittyGraphics(aboveText: false, in: dirtyRect)
         drawBackgrounds(in: dirtyRect, dirtyBounds: dirtyBounds)
         drawSearch(in: dirtyRect, dirtyBounds: dirtyBounds)
         drawSelection(in: dirtyRect, dirtyBounds: dirtyBounds)
@@ -270,6 +292,74 @@ final class TerminalGridNSView: NSView {
         drawStrokeGlyphs(in: dirtyRect, dirtyBounds: dirtyBounds)
         drawText(in: dirtyRect, dirtyBounds: dirtyBounds)
         drawHoveredLink(in: dirtyRect, dirtyBounds: dirtyBounds)
+        drawKittyGraphics(aboveText: true, in: dirtyRect)
+    }
+
+    private func drawKittyGraphics(aboveText: Bool, in dirtyRect: NSRect) {
+        for placement in kittyGraphicsPlacements
+        where (placement.zIndex >= 0) == aboveText {
+            let destination = placement.bounds(renderConfig: renderConfig)
+            guard destination.width > 0,
+                  destination.height > 0,
+                  destination.intersects(dirtyRect),
+                  placement.sourceWidth > 0,
+                  placement.sourceHeight > 0,
+                  placement.imageWidth > 0,
+                  placement.imageHeight > 0,
+                  let image = kittyGraphicsImage(for: placement)
+            else {
+                continue
+            }
+
+            let scaleX = destination.width / CGFloat(placement.sourceWidth)
+            let scaleY = destination.height / CGFloat(placement.sourceHeight)
+            let fullImageRect = CGRect(
+                x: destination.minX - CGFloat(placement.sourceX) * scaleX,
+                y: destination.minY - CGFloat(placement.sourceY) * scaleY,
+                width: CGFloat(placement.imageWidth) * scaleX,
+                height: CGFloat(placement.imageHeight) * scaleY
+            )
+
+            NSGraphicsContext.saveGraphicsState()
+            NSBezierPath(rect: destination).addClip()
+            image.draw(
+                in: fullImageRect,
+                from: .zero,
+                operation: .sourceOver,
+                fraction: 1,
+                respectFlipped: true,
+                hints: [.interpolation: NSImageInterpolation.high]
+            )
+
+            let selected = selectedKittyGraphics == placement.identity
+                || placement.intersects(
+                    selection: selection,
+                    cols: terminalFrame.cols,
+                    rows: terminalFrame.rows
+                )
+            if selected {
+                NSColor.controlAccentColor.withAlphaComponent(0.22).setFill()
+                fill(destination)
+                NSColor.controlAccentColor.withAlphaComponent(0.92).setStroke()
+                let border = NSBezierPath(rect: destination.insetBy(dx: 1, dy: 1))
+                border.lineWidth = 2
+                border.stroke()
+            }
+            NSGraphicsContext.restoreGraphicsState()
+        }
+    }
+
+    private func kittyGraphicsImage(
+        for placement: TerminalKittyGraphicsPlacement
+    ) -> NSImage? {
+        if let cached = kittyGraphicsImageCache[placement.imageKey] {
+            return cached
+        }
+        guard let image = NSImage(data: placement.png) else {
+            return nil
+        }
+        kittyGraphicsImageCache[placement.imageKey] = image
+        return image
     }
 
     private var backingScale: CGFloat {

--- a/macos/Sources/TermySwift/Views/TerminalKeyboardInputView.swift
+++ b/macos/Sources/TermySwift/Views/TerminalKeyboardInputView.swift
@@ -29,9 +29,12 @@ struct TerminalKeyboardInputView: NSViewRepresentable {
     var onSelectWord: (TerminalGridPosition) -> Void
     var onSelectLine: (TerminalGridPosition) -> Void
     var onSelectAll: () -> Void
+    var onSelectKittyGraphics: (CGPoint) -> Bool
+    var onContextKittyGraphics: (CGPoint?) -> Bool
     var onHoverProbe: (TerminalGridPosition?) -> Bool
     var onOpenLink: (TerminalGridPosition) -> Bool
     var onCopy: () -> Bool
+    var onCopyKittyGraphics: () -> Bool
     var onPaste: (String) -> Void
     var onMarkedTextChanged: (String) -> Void = { _ in }
 
@@ -80,9 +83,12 @@ final class KeyboardCaptureView: NSView {
     var onSelectWord: (TerminalGridPosition) -> Void = { _ in }
     var onSelectLine: (TerminalGridPosition) -> Void = { _ in }
     var onSelectAll: () -> Void = {}
+    var onSelectKittyGraphics: (CGPoint) -> Bool = { _ in false }
+    var onContextKittyGraphics: (CGPoint?) -> Bool = { _ in false }
     var onHoverProbe: (TerminalGridPosition?) -> Bool = { _ in false }
     var onOpenLink: (TerminalGridPosition) -> Bool = { _ in false }
     var onCopy: () -> Bool = { false }
+    var onCopyKittyGraphics: () -> Bool = { false }
     var onPaste: (String) -> Void = { _ in }
     var onMarkedTextChanged: (String) -> Void = { _ in }
 
@@ -221,6 +227,11 @@ final class KeyboardCaptureView: NSView {
 
         activeMouseButton = nil
         guard button == .left else {
+            return
+        }
+
+        if onSelectKittyGraphics(terminalPoint(for: event)) {
+            selectionAnchor = nil
             return
         }
 
@@ -619,8 +630,13 @@ final class KeyboardCaptureView: NSView {
     }
 
     private func showTerminalContextMenu(for event: NSEvent) {
+        let canCopyImage = onContextKittyGraphics(terminalPoint(for: event))
+        defer {
+            _ = onContextKittyGraphics(nil)
+        }
         let menu = TerminalSurfaceContextMenu.make(
             canCopy: canCopy,
+            canCopyImage: canCopyImage,
             canPaste: NSPasteboard.general.string(forType: .string) != nil,
             target: self
         )
@@ -629,6 +645,10 @@ final class KeyboardCaptureView: NSView {
 
     @objc func copyFromTerminalContextMenu(_ sender: Any?) {
         _ = onCopy()
+    }
+
+    @objc func copyImageFromTerminalContextMenu(_ sender: Any?) {
+        _ = onCopyKittyGraphics()
     }
 
     @objc func pasteFromTerminalContextMenu(_ sender: Any?) {
@@ -783,6 +803,11 @@ final class KeyboardCaptureView: NSView {
         return TerminalGridPosition(col: col, row: row)
     }
 
+    private func terminalPoint(for event: NSEvent) -> CGPoint {
+        let point = convert(event.locationInWindow, from: nil)
+        return CGPoint(x: point.x, y: bounds.height - point.y)
+    }
+
     nonisolated static func dragSelection(
         anchor: TerminalGridPosition,
         active: TerminalGridPosition
@@ -935,9 +960,12 @@ private extension KeyboardCaptureView {
         onSelectWord = configuration.onSelectWord
         onSelectLine = configuration.onSelectLine
         onSelectAll = configuration.onSelectAll
+        onSelectKittyGraphics = configuration.onSelectKittyGraphics
+        onContextKittyGraphics = configuration.onContextKittyGraphics
         onHoverProbe = configuration.onHoverProbe
         onOpenLink = configuration.onOpenLink
         onCopy = configuration.onCopy
+        onCopyKittyGraphics = configuration.onCopyKittyGraphics
         onPaste = configuration.onPaste
         onMarkedTextChanged = configuration.onMarkedTextChanged
     }

--- a/macos/Sources/TermySwift/Views/TerminalSurfaceView.swift
+++ b/macos/Sources/TermySwift/Views/TerminalSurfaceView.swift
@@ -34,6 +34,8 @@ struct TerminalSurfaceView: View {
                     renderPlan: terminal.renderPlan,
                     renderDamage: terminal.renderDamage,
                     selection: terminal.selection,
+                    kittyGraphicsPlacements: terminal.kittyGraphicsPlacements,
+                    selectedKittyGraphics: terminal.selectedKittyGraphics,
                     renderConfig: terminal.renderConfig,
                     searchMatches: terminal.searchMatches,
                     activeSearchMatch: terminal.searchMatches[safe: terminal.activeSearchMatchIndex],
@@ -105,6 +107,12 @@ struct TerminalSurfaceView: View {
                     onSelectAll: {
                         terminal.selectAll()
                     },
+                    onSelectKittyGraphics: { point in
+                        terminal.selectKittyGraphics(at: point)
+                    },
+                    onContextKittyGraphics: { point in
+                        terminal.updateContextKittyGraphics(at: point)
+                    },
                     onHoverProbe: { position in
                         terminal.updateHoveredLink(at: position)
                     },
@@ -113,6 +121,9 @@ struct TerminalSurfaceView: View {
                     },
                     onCopy: {
                         terminal.copySelection()
+                    },
+                    onCopyKittyGraphics: {
+                        terminal.copyContextKittyGraphics()
                     },
                     onPaste: { text in
                         pasteOverride?(text) ?? terminal.paste(text)

--- a/macos/Tests/TermySwiftTests/DisplayTerminalTests.swift
+++ b/macos/Tests/TermySwiftTests/DisplayTerminalTests.swift
@@ -17,6 +17,22 @@ final class DisplayTerminalTests: XCTestCase {
         XCTAssertNoThrow(try terminal.write(Array("ignored".utf8)))
     }
 
+    func testKittyGraphicsPlacementsRoundTripThroughFFI() throws {
+        let terminal = try LibTermyTerminal(displayCols: 20, rows: 4, loadUserConfig: false)
+        let initialRevision = try terminal.kittyGraphicsRevision()
+        try terminal.feedOutput(Array(
+            "\u{1b}_Ga=T,f=32,s=1,v=1,i=77,c=2,r=1,C=1;AQID/w==\u{1b}\\".utf8
+        ))
+
+        let snapshot = try terminal.kittyGraphicsPlacements()
+
+        XCTAssertGreaterThan(snapshot.revision, initialRevision)
+        XCTAssertEqual(snapshot.placements.count, 1)
+        XCTAssertEqual(snapshot.placements[0].imageID, 77)
+        XCTAssertEqual(snapshot.placements[0].displayCols, 2)
+        XCTAssertTrue(snapshot.placements[0].png.starts(with: [0x89, 0x50, 0x4E, 0x47]))
+    }
+
     @MainActor
     func testDisplayTerminalViewModelPresentsFedOutput() throws {
         let terminal = try LibTermyTerminal(displayCols: 20, rows: 4, loadUserConfig: false)
@@ -31,6 +47,33 @@ final class DisplayTerminalTests: XCTestCase {
         XCTAssertTrue(viewModel.visibleTextSnapshot().contains("tmux pane"))
         viewModel.stop()
         XCTAssertFalse(viewModel.isReady)
+    }
+
+    @MainActor
+    func testDisplayTerminalPresentsSelectsAndClearsKittyGraphics() throws {
+        let terminal = try LibTermyTerminal(displayCols: 20, rows: 4, loadUserConfig: false)
+        let viewModel = TerminalViewModel(displayTerminal: terminal)
+        viewModel.start()
+        defer { viewModel.stop() }
+
+        try terminal.feedOutput(Array(
+            "\u{1b}_Ga=T,f=32,s=1,v=1,i=91,c=2,r=1,C=1;AQID/w==\u{1b}\\".utf8
+        ))
+        viewModel.refreshExternalOutput()
+
+        let placement = try XCTUnwrap(viewModel.kittyGraphicsPlacements.first)
+        XCTAssertTrue(viewModel.hasVisibleContent)
+        let bounds = placement.bounds(renderConfig: viewModel.renderConfig)
+        XCTAssertTrue(viewModel.selectKittyGraphics(at: CGPoint(x: bounds.midX, y: bounds.midY)))
+        XCTAssertEqual(viewModel.selectedKittyGraphics, placement.identity)
+        XCTAssertTrue(viewModel.canCopySelection)
+
+        try terminal.feedOutput(Array("\u{1b}[2J".utf8))
+        viewModel.refreshExternalOutput()
+
+        XCTAssertTrue(viewModel.kittyGraphicsPlacements.isEmpty)
+        XCTAssertNil(viewModel.selectedKittyGraphics)
+        XCTAssertFalse(viewModel.hasVisibleContent)
     }
 
     /// FFI cells carry no position; the binding derives it from row-major

--- a/macos/Tests/TermySwiftTests/TerminalKeyboardInputViewTests.swift
+++ b/macos/Tests/TermySwiftTests/TerminalKeyboardInputViewTests.swift
@@ -224,6 +224,37 @@ final class TerminalKeyboardInputViewTests: XCTestCase {
         XCTAssertEqual(selections.compactMap { $0 }, [selection, selection])
     }
 
+    func testLeftClickSelectsKittyGraphicsBeforeStartingTextSelection() {
+        let harness = AppKitEventHarness()
+        harness.inputView.cols = 80
+        harness.inputView.rows = 24
+        var selectedPoint: CGPoint?
+        var selections: [TerminalSelection?] = []
+        harness.inputView.onMouseInput = { _ in false }
+        harness.inputView.onSelectKittyGraphics = {
+            selectedPoint = $0
+            return true
+        }
+        harness.inputView.onSelectionChanged = { selections.append($0) }
+
+        let clickPoint = harness.point(col: 3, row: 2)
+        harness.sendMouse(type: .leftMouseDown, at: clickPoint)
+        harness.sendMouse(type: .leftMouseUp, at: clickPoint)
+
+        let config = harness.inputView.renderConfig
+        XCTAssertEqual(
+            selectedPoint?.x ?? -1,
+            config.paddingX + 3.5 * config.cellWidth,
+            accuracy: 0.001
+        )
+        XCTAssertEqual(
+            selectedPoint?.y ?? -1,
+            config.paddingY + 2.5 * config.cellHeight,
+            accuracy: 0.001
+        )
+        XCTAssertTrue(selections.isEmpty)
+    }
+
     func testDragSelectionIgnoresSameCellJitter() {
         let position = TerminalGridPosition(col: 12, row: 4)
 

--- a/macos/Tests/TermySwiftTests/TerminalSurfaceContextMenuTests.swift
+++ b/macos/Tests/TermySwiftTests/TerminalSurfaceContextMenuTests.swift
@@ -27,4 +27,18 @@ final class TerminalSurfaceContextMenuTests: XCTestCase {
             ]
         )
     }
+
+    @MainActor
+    func testTerminalContextMenuIncludesCopyImageForGraphicsHit() {
+        let target = KeyboardCaptureView()
+
+        let menu = TerminalSurfaceContextMenu.make(
+            canCopy: false,
+            canCopyImage: true,
+            canPaste: false,
+            target: target
+        )
+
+        XCTAssertEqual(menu.items.prefix(3).map(\.title), ["Copy", "Copy Image", "Paste"])
+    }
 }


### PR DESCRIPTION
## Summary
- expose revisioned Kitty graphics placements through the C FFI
- render cropped and scaled images in the native AppKit grid with z-index layering and image caching
- add image selection, PNG clipboard copy, and a Copy Image context-menu action
- clear native image state when terminal erase/reset removes placements

## Validation
- cargo test -p termy_core
- cargo test -p termy_ffi
- swift test --disable-sandbox --package-path macos --skip LibTermyTmuxControlTests --skip TmuxControlSessionTests --skip TmuxControlWorkspaceInteractionTests
- cargo macos build

The excluded Swift tests require live local tmux sockets and failed independently of this change; 225 other Swift tests passed with one environment skip.