### PR TITLE
feat: tmux runtime on Windows and remote hosts via tmux_command_prefix

### DIFF
--- a/crates/config_core/src/default_config.txt
+++ b/crates/config_core/src/default_config.txt
@@ -31,6 +31,8 @@ simple_mode = false
 onboarding_complete = true
 # tmux executable path or binary name
 tmux_binary = tmux
+# Command prefix used to reach tmux, for example `wsl.exe -e` on Windows or `ssh myhost`; set to none to run tmux directly
+tmux_command_prefix = none
 # Show active tmux pane border highlight in managed sessions
 tmux_show_active_pane_border = false
 # Initial directory for new sessions

--- a/crates/config_core/src/parser.rs
+++ b/crates/config_core/src/parser.rs
@@ -339,6 +339,21 @@ impl AppConfig {
                         config.tmux_binary = parsed;
                     }
                 }
+                RootSettingId::TmuxCommandPrefix => {
+                    if value.trim().eq_ignore_ascii_case("none") {
+                        config.tmux_command_prefix = None;
+                    } else if value.is_empty() {
+                        push_invalid_value(
+                            &mut diagnostics,
+                            line_number,
+                            key,
+                            value,
+                            "a non-empty command prefix or none",
+                        );
+                    } else {
+                        config.tmux_command_prefix = Some(value.to_string());
+                    }
+                }
                 RootSettingId::TmuxShowActivePaneBorder => {
                     if let Some(parsed) =
                         parse_bool_field(&mut diagnostics, line_number, key, value)

--- a/crates/config_core/src/parser_tests.rs
+++ b/crates/config_core/src/parser_tests.rs
@@ -612,6 +612,28 @@ fn tmux_runtime_options_parse() {
 }
 
 #[test]
+fn tmux_command_prefix_parses_none_resets_and_empty_is_invalid() {
+    let config = parse("tmux_command_prefix = wsl.exe -e\n");
+    assert_eq!(config.tmux_command_prefix.as_deref(), Some("wsl.exe -e"));
+    assert_eq!(
+        config.tmux_command_prefix_argv(),
+        vec!["wsl.exe".to_string(), "-e".to_string()]
+    );
+
+    let config = parse("tmux_command_prefix = ssh myhost\ntmux_command_prefix = none\n");
+    assert!(config.tmux_command_prefix.is_none());
+    assert!(config.tmux_command_prefix_argv().is_empty());
+
+    let report = parse_report("tmux_command_prefix =\n");
+    assert_eq!(report.diagnostics.len(), 1);
+    assert_eq!(
+        report.diagnostics[0].kind,
+        ConfigDiagnosticKind::InvalidValue
+    );
+    assert!(report.config.tmux_command_prefix.is_none());
+}
+
+#[test]
 fn removed_tmux_persist_scrollback_key_produces_unknown_root_key_diagnostic() {
     let report = parse_report("tmux_persist_scrollback = true\n");
     assert_eq!(report.diagnostics.len(), 1);

--- a/crates/config_core/src/schema.rs
+++ b/crates/config_core/src/schema.rs
@@ -380,6 +380,7 @@ define_root_settings! {
     (SimpleMode, "simple_mode", [], Advanced, "UI", "Simple Mode", "Open the config file instead of the Settings window and disable the command palette", ["simple", "mode", "settings", "config", "palette"], RootSettingValueKind::Boolean, false),
     (OnboardingComplete, "onboarding_complete", [], Advanced, "ONBOARDING", "Onboarding Complete", "Whether the first-run welcome flow has been completed; set to false to see it again", ["onboarding", "welcome", "first run", "tutorial"], RootSettingValueKind::Boolean, false),
     (TmuxBinary, "tmux_binary", [], Terminal, "TMUX", "Tmux Binary", "tmux executable path or binary name", ["tmux", "binary", "path"], RootSettingValueKind::Text, false),
+    (TmuxCommandPrefix, "tmux_command_prefix", [], Terminal, "TMUX", "Tmux Command Prefix", "Command prefix used to reach tmux, for example `wsl.exe -e` on Windows or `ssh myhost`; set to none to run tmux directly", ["tmux", "command", "prefix", "wsl", "ssh", "windows", "remote"], RootSettingValueKind::Text, false),
     (TmuxShowActivePaneBorder, "tmux_show_active_pane_border", [], Terminal, "TMUX", "Show Active Pane Border", "Show active tmux pane border highlight in managed sessions", ["tmux", "pane", "border", "highlight"], RootSettingValueKind::Boolean, false),
     (WorkingDir, "working_dir", [], Advanced, "STARTUP", "Working Directory", "Initial directory for new sessions", ["working directory", "cwd", "startup", "path"], RootSettingValueKind::Text, false),
     (WorkingDirFallback, "working_dir_fallback", ["default_working_dir"], Advanced, "STARTUP", "Working Directory Fallback", "Directory used when working_dir is unset", ["working directory", "fallback", "cwd", "startup"], RootSettingValueKind::Enum, false),
@@ -515,6 +516,7 @@ pub fn root_setting_default_value(config: &AppConfig, id: RootSettingId) -> Opti
         RootSettingId::SimpleMode => Some(config.simple_mode.to_string()),
         RootSettingId::OnboardingComplete => Some(config.onboarding_complete.to_string()),
         RootSettingId::TmuxBinary => Some(config.tmux_binary.clone()),
+        RootSettingId::TmuxCommandPrefix => config.tmux_command_prefix.clone(),
         RootSettingId::TmuxShowActivePaneBorder => {
             Some(config.tmux_show_active_pane_border.to_string())
         }

--- a/crates/config_core/src/types.rs
+++ b/crates/config_core/src/types.rs
@@ -358,6 +358,7 @@ pub struct AppConfig {
     pub native_buffer_persistence: bool,
     pub show_debug_overlay: bool,
     pub tmux_binary: String,
+    pub tmux_command_prefix: Option<String>,
     pub tmux_show_active_pane_border: bool,
     pub working_dir: Option<String>,
     pub working_dir_fallback: WorkingDirFallback,
@@ -429,6 +430,17 @@ pub struct TaskConfig {
     pub keybind: Option<KeybindConfigLine>,
 }
 
+impl AppConfig {
+    /// The configured tmux command prefix split into argv items
+    /// (`wsl.exe -e` becomes `["wsl.exe", "-e"]`). Empty when unset.
+    pub fn tmux_command_prefix_argv(&self) -> Vec<String> {
+        self.tmux_command_prefix
+            .as_deref()
+            .map(|prefix| prefix.split_whitespace().map(str::to_string).collect())
+            .unwrap_or_default()
+    }
+}
+
 impl Default for AppConfig {
     fn default() -> Self {
         Self {
@@ -446,6 +458,7 @@ impl Default for AppConfig {
             native_buffer_persistence: false,
             show_debug_overlay: false,
             tmux_binary: DEFAULT_TMUX_BINARY.to_string(),
+            tmux_command_prefix: None,
             tmux_show_active_pane_border: DEFAULT_TMUX_SHOW_ACTIVE_PANE_BORDER,
             working_dir: None,
             working_dir_fallback: WorkingDirFallback::default(),

--- a/crates/desktop_app/src/main.rs
+++ b/crates/desktop_app/src/main.rs
@@ -93,14 +93,26 @@ fn preflight_tmux_runtime(config: &config::AppConfig) -> Result<(), StartupBlock
         return Ok(());
     }
 
-    TmuxClient::verify_tmux_version(config.tmux_binary.as_str(), 3, 3)
-        .map_err(|error| StartupBlocker::TmuxPreflight(format!("tmux preflight failed: {error}")))
+    TmuxClient::verify_tmux_version(
+        &config.tmux_command_prefix_argv(),
+        config.tmux_binary.as_str(),
+        3,
+        3,
+    )
+    .map_err(|error| StartupBlocker::TmuxPreflight(format!("tmux preflight failed: {error}")))
 }
 
 #[cfg(target_os = "windows")]
 fn preflight_tmux_runtime(config: &config::AppConfig) -> Result<(), StartupBlocker> {
-    let _ = config;
-    Ok(())
+    let command_prefix = config.tmux_command_prefix_argv();
+    // Without a command prefix the runtime silently stays native on Windows,
+    // so there is nothing to preflight.
+    if !config.tmux_enabled || command_prefix.is_empty() {
+        return Ok(());
+    }
+
+    TmuxClient::verify_tmux_version(&command_prefix, config.tmux_binary.as_str(), 3, 3)
+        .map_err(|error| StartupBlocker::TmuxPreflight(format!("tmux preflight failed: {error}")))
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]

--- a/crates/desktop_app/src/settings_view/sections.rs
+++ b/crates/desktop_app/src/settings_view/sections.rs
@@ -296,7 +296,6 @@ impl SettingsWindow {
             .child(self.render_terminal_cursor_group(cx))
             .child(self.render_terminal_shell_group(cx));
 
-        #[cfg(not(target_os = "windows"))]
         let section = section.child(self.render_terminal_tmux_group(cx));
 
         section
@@ -398,10 +397,12 @@ impl SettingsWindow {
     #[cfg(not(target_os = "windows"))]
     pub(super) fn render_terminal_tmux_group(&mut self, cx: &mut Context<Self>) -> AnyElement {
         let binary_meta = Self::setting_metadata_or_fallback("tmux_binary");
+        let command_prefix_meta = Self::setting_metadata_or_fallback("tmux_command_prefix");
         let tmux_enabled = self.config.tmux_enabled;
         let tmux_persistence = self.config.tmux_persistence;
         let tmux_show_active_pane_border = self.config.tmux_show_active_pane_border;
         let binary = self.config.tmux_binary.clone();
+        let command_prefix = self.config.tmux_command_prefix.clone().unwrap_or_default();
 
         let mut rows = vec![self.render_root_bool_setting_row(
             "tmux_enabled",
@@ -435,6 +436,14 @@ impl SettingsWindow {
                 binary_meta.title,
                 binary_meta.description,
                 binary,
+                cx,
+            ));
+            rows.push(self.render_editable_row(
+                "tmux_command_prefix",
+                EditableField::TmuxCommandPrefix,
+                command_prefix_meta.title,
+                command_prefix_meta.description,
+                command_prefix,
                 cx,
             ));
         }

--- a/crates/desktop_app/src/settings_view/state.rs
+++ b/crates/desktop_app/src/settings_view/state.rs
@@ -24,8 +24,8 @@ pub(super) enum EditableField {
     Shell,
     Term,
     Colorterm,
-    #[cfg_attr(target_os = "windows", allow(dead_code))]
     TmuxBinary,
+    TmuxCommandPrefix,
     ScrollbackHistory,
     InactiveTabScrollback,
     ScrollMultiplier,
@@ -242,14 +242,10 @@ impl SettingsWindow {
             return false;
         }
 
+        // tmux settings stay visible on Windows: the runtime is reachable
+        // there through tmux_command_prefix (e.g. `wsl.exe -e`).
         if cfg!(target_os = "windows") {
-            return !matches!(
-                setting,
-                RootSettingId::TmuxEnabled
-                    | RootSettingId::TmuxPersistence
-                    | RootSettingId::TmuxShowActivePaneBorder
-                    | RootSettingId::TmuxBinary
-            );
+            return true;
         }
 
         !matches!(setting, RootSettingId::WindowsShell)
@@ -430,6 +426,7 @@ impl SettingsWindow {
             | EditableField::Term
             | EditableField::Colorterm
             | EditableField::TmuxBinary
+            | EditableField::TmuxCommandPrefix
             | EditableField::ScrollbackHistory
             | EditableField::InactiveTabScrollback
             | EditableField::ScrollMultiplier
@@ -556,6 +553,9 @@ impl SettingsWindow {
             EditableField::Term => Self::text_field_spec(Some(RootSettingId::Term)),
             EditableField::Colorterm => Self::text_field_spec(Some(RootSettingId::Colorterm)),
             EditableField::TmuxBinary => Self::text_field_spec(Some(RootSettingId::TmuxBinary)),
+            EditableField::TmuxCommandPrefix => {
+                Self::text_field_spec(Some(RootSettingId::TmuxCommandPrefix))
+            }
             EditableField::ScrollbackHistory => Self::numeric_field_spec(
                 RootSettingId::ScrollbackHistory,
                 NumericStepSpec {
@@ -915,6 +915,9 @@ impl SettingsWindow {
             EditableField::Term => self.config.term.clone(),
             EditableField::Colorterm => self.config.colorterm.clone().unwrap_or_default(),
             EditableField::TmuxBinary => self.config.tmux_binary.clone(),
+            EditableField::TmuxCommandPrefix => {
+                self.config.tmux_command_prefix.clone().unwrap_or_default()
+            }
             EditableField::ScrollbackHistory => self.config.scrollback_history.to_string(),
             EditableField::InactiveTabScrollback => self
                 .config
@@ -1294,6 +1297,7 @@ mod tests {
             EditableField::Term,
             EditableField::Colorterm,
             EditableField::TmuxBinary,
+            EditableField::TmuxCommandPrefix,
             EditableField::ScrollbackHistory,
             EditableField::InactiveTabScrollback,
             EditableField::ScrollMultiplier,

--- a/crates/desktop_app/src/settings_view/state_apply.rs
+++ b/crates/desktop_app/src/settings_view/state_apply.rs
@@ -25,6 +25,7 @@ impl SettingsWindow {
             | EditableField::Term
             | EditableField::Colorterm
             | EditableField::TmuxBinary
+            | EditableField::TmuxCommandPrefix
             | EditableField::ScrollbackHistory
             | EditableField::InactiveTabScrollback
             | EditableField::ScrollMultiplier
@@ -269,6 +270,21 @@ impl SettingsWindow {
                 }
                 self.config.tmux_binary = value.to_string();
                 config::set_root_setting(termy_config_core::RootSettingId::TmuxBinary, value)
+            }
+            EditableField::TmuxCommandPrefix => {
+                if value.is_empty() {
+                    self.config.tmux_command_prefix = None;
+                    config::set_root_setting(
+                        termy_config_core::RootSettingId::TmuxCommandPrefix,
+                        "none",
+                    )
+                } else {
+                    self.config.tmux_command_prefix = Some(value.to_string());
+                    config::set_root_setting(
+                        termy_config_core::RootSettingId::TmuxCommandPrefix,
+                        value,
+                    )
+                }
             }
             EditableField::ScrollbackHistory => {
                 let parsed = value

--- a/crates/desktop_app/src/terminal_view/command_palette/tmux_sessions.rs
+++ b/crates/desktop_app/src/terminal_view/command_palette/tmux_sessions.rs
@@ -90,16 +90,21 @@ impl TerminalView {
         }
     }
 
-    fn tmux_binary_for_session_palette(&mut self) -> Result<String, String> {
-        let binary = if self.runtime_uses_tmux() {
-            self.tmux_runtime().config.binary.trim().to_string()
+    /// Resolve the (command prefix, binary) pair used to spawn out-of-band
+    /// tmux commands for the session palette.
+    fn tmux_invocation_for_session_palette(&mut self) -> Result<(Vec<String>, String), String> {
+        let (command_prefix, binary) = if self.runtime_uses_tmux() {
+            (
+                self.tmux_runtime().config.command_prefix.clone(),
+                self.tmux_runtime().config.binary.trim().to_string(),
+            )
         } else if let Some(cached) = self
             .cached_tmux_binary
             .as_deref()
             .map(str::trim)
             .filter(|cached| !cached.is_empty())
         {
-            cached.to_string()
+            (self.cached_tmux_command_prefix.clone(), cached.to_string())
         } else {
             let loaded = config::load_runtime_config(
                 &mut self.last_config_error_message,
@@ -107,12 +112,14 @@ impl TerminalView {
             );
             let loaded_binary = loaded.config.tmux_binary.trim().to_string();
             self.cached_tmux_binary = (!loaded_binary.is_empty()).then_some(loaded_binary.clone());
-            loaded_binary
+            let loaded_prefix = loaded.config.tmux_command_prefix_argv();
+            self.cached_tmux_command_prefix = loaded_prefix.clone();
+            (loaded_prefix, loaded_binary)
         };
         if binary.is_empty() {
             return Err("tmux_binary must not be empty".to_string());
         }
-        Ok(binary)
+        Ok((command_prefix, binary))
     }
 
     pub(super) fn reload_tmux_session_palette_items(&mut self) -> Result<(), String> {
@@ -121,12 +128,13 @@ impl TerminalView {
             .first()
             .cloned()
             .unwrap_or(TmuxSocketTarget::Default);
-        let binary = self.tmux_binary_for_session_palette()?;
+        let (command_prefix, binary) = self.tmux_invocation_for_session_palette()?;
         let mut rows = Vec::<TmuxSessionRow>::new();
         let mut failures = Vec::<String>::new();
 
         for socket_target in socket_targets {
-            match TmuxClient::list_sessions(binary.as_str(), socket_target.clone()) {
+            match TmuxClient::list_sessions(&command_prefix, binary.as_str(), socket_target.clone())
+            {
                 Ok(sessions) => {
                     rows.extend(sessions.into_iter().map(|summary| TmuxSessionRow {
                         summary,
@@ -281,8 +289,8 @@ impl TerminalView {
             return;
         }
 
-        let binary = match self.tmux_binary_for_session_palette() {
-            Ok(binary) => binary,
+        let (command_prefix, binary) = match self.tmux_invocation_for_session_palette() {
+            Ok(invocation) => invocation,
             Err(error) => {
                 termy_toast::error(error);
                 self.notify_overlay(cx);
@@ -291,6 +299,7 @@ impl TerminalView {
         };
 
         if let Err(error) = TmuxClient::rename_session(
+            &command_prefix,
             binary.as_str(),
             socket_target,
             current_session_name,
@@ -349,8 +358,9 @@ impl TerminalView {
 
             let _ = cx.update(|cx| {
                 this.update(cx, |view, cx| {
-                    let binary = match view.tmux_binary_for_session_palette() {
-                        Ok(binary) => binary,
+                    let (command_prefix, binary) = match view.tmux_invocation_for_session_palette()
+                    {
+                        Ok(invocation) => invocation,
                         Err(error) => {
                             termy_toast::error(error);
                             view.notify_overlay(cx);
@@ -359,6 +369,7 @@ impl TerminalView {
                     };
 
                     if let Err(error) = TmuxClient::kill_session(
+                        &command_prefix,
                         binary.as_str(),
                         socket_target,
                         session_name.as_str(),

--- a/crates/desktop_app/src/terminal_view/mod.rs
+++ b/crates/desktop_app/src/terminal_view/mod.rs
@@ -1172,6 +1172,7 @@ pub struct TerminalView {
     config_fingerprint: Option<u64>,
     last_config_error_message: Option<String>,
     cached_tmux_binary: Option<String>,
+    cached_tmux_command_prefix: Vec<String>,
     font_family: SharedString,
     ui_font_family: SharedString,
     base_font_size: f32,
@@ -3651,6 +3652,7 @@ impl TerminalView {
                 let binary = config.tmux_binary.trim().to_string();
                 (!binary.is_empty()).then_some(binary)
             },
+            cached_tmux_command_prefix: config.tmux_command_prefix_argv(),
             font_family: config.font_family.into(),
             ui_font_family: config.ui_font_family.into(),
             base_font_size,
@@ -3932,6 +3934,7 @@ impl TerminalView {
             let binary = config.tmux_binary.trim().to_string();
             (!binary.is_empty()).then_some(binary)
         };
+        self.cached_tmux_command_prefix = config.tmux_command_prefix_argv();
         let previous_font_family = self.font_family.clone();
         let previous_font_size = self.font_size;
         self.theme_mode = config.theme_mode;

--- a/crates/desktop_app/src/terminal_view/runtime/mod.rs
+++ b/crates/desktop_app/src/terminal_view/runtime/mod.rs
@@ -39,19 +39,28 @@ impl RuntimeKind {
         matches!(self, Self::Tmux)
     }
 
-    #[cfg(target_os = "windows")]
-    pub(super) fn from_app_config(_config: &AppConfig) -> Self {
-        // Hard cutover: tmux runtime is unsupported on Windows, regardless of config value.
-        Self::Native
+    pub(super) fn from_app_config(config: &AppConfig) -> Self {
+        Self::from_runtime_options(
+            config.tmux_enabled,
+            cfg!(target_os = "windows"),
+            config.tmux_command_prefix_argv().is_empty(),
+        )
     }
 
-    #[cfg(not(target_os = "windows"))]
-    pub(super) fn from_app_config(config: &AppConfig) -> Self {
-        if config.tmux_enabled {
-            Self::Tmux
-        } else {
-            Self::Native
+    fn from_runtime_options(
+        tmux_enabled: bool,
+        is_windows: bool,
+        command_prefix_is_empty: bool,
+    ) -> Self {
+        if !tmux_enabled {
+            return Self::Native;
         }
+        // Windows has no local pty spawn path for tmux; the runtime is only
+        // reachable through a configured command prefix (e.g. `wsl.exe -e`).
+        if is_windows && command_prefix_is_empty {
+            return Self::Native;
+        }
+        Self::Tmux
     }
 }
 
@@ -127,6 +136,7 @@ impl TerminalView {
     pub(super) fn tmux_runtime_from_app_config(config: &AppConfig) -> TmuxRuntimeConfig {
         TmuxRuntimeConfig {
             binary: config.tmux_binary.trim().to_string(),
+            command_prefix: config.tmux_command_prefix_argv(),
             launch: TmuxLaunchTarget::Managed {
                 persistence: config.tmux_persistence,
             },
@@ -227,6 +237,26 @@ impl TerminalView {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn tmux_runtime_gate_requires_command_prefix_on_windows() {
+        assert_eq!(
+            RuntimeKind::from_runtime_options(false, false, true),
+            RuntimeKind::Native
+        );
+        assert_eq!(
+            RuntimeKind::from_runtime_options(true, false, true),
+            RuntimeKind::Tmux
+        );
+        assert_eq!(
+            RuntimeKind::from_runtime_options(true, true, true),
+            RuntimeKind::Native
+        );
+        assert_eq!(
+            RuntimeKind::from_runtime_options(true, true, false),
+            RuntimeKind::Tmux
+        );
+    }
 
     #[test]
     fn startup_snapshot_cleanup_decision_only_warns_when_cleanup_fails() {

--- a/crates/desktop_app/src/terminal_view/runtime/tmux/transition.rs
+++ b/crates/desktop_app/src/terminal_view/runtime/tmux/transition.rs
@@ -14,6 +14,7 @@ impl TerminalView {
             self.simple_mode = keybind_config.simple_mode;
             let binary = keybind_config.tmux_binary.trim().to_string();
             self.cached_tmux_binary = (!binary.is_empty()).then_some(binary);
+            self.cached_tmux_command_prefix = keybind_config.tmux_command_prefix_argv();
             keybindings::install_keybindings(cx, &keybind_config, self.runtime_uses_tmux());
         }
         cx.set_menus(crate::menus::app_menus(
@@ -57,9 +58,10 @@ impl TerminalView {
         launch: TmuxLaunchTarget,
         cx: &mut Context<Self>,
     ) -> bool {
-        let (binary, show_active_pane_border) = if self.runtime_uses_tmux() {
+        let (binary, command_prefix, show_active_pane_border) = if self.runtime_uses_tmux() {
             (
                 self.tmux_runtime().config.binary.clone(),
+                self.tmux_runtime().config.command_prefix.clone(),
                 self.tmux_runtime().config.show_active_pane_border,
             )
         } else {
@@ -72,20 +74,33 @@ impl TerminalView {
                 if !loaded_binary.is_empty() {
                     self.cached_tmux_binary = Some(loaded_binary.clone());
                 }
-                (loaded_binary, loaded.config.tmux_show_active_pane_border)
+                let loaded_prefix = loaded.config.tmux_command_prefix_argv();
+                self.cached_tmux_command_prefix = loaded_prefix.clone();
+                (
+                    loaded_binary,
+                    loaded_prefix,
+                    loaded.config.tmux_show_active_pane_border,
+                )
             } else {
                 (
                     self.cached_tmux_binary.clone().unwrap_or_default(),
+                    self.cached_tmux_command_prefix.clone(),
                     self.tmux_show_active_pane_border,
                 )
             }
         };
         let runtime_config = TmuxRuntimeConfig {
             binary,
+            command_prefix,
             launch,
             show_active_pane_border,
         };
-        if let Err(error) = TmuxClient::verify_tmux_version(runtime_config.binary.as_str(), 3, 3) {
+        if let Err(error) = TmuxClient::verify_tmux_version(
+            &runtime_config.command_prefix,
+            runtime_config.binary.as_str(),
+            3,
+            3,
+        ) {
             termy_toast::error(format!("tmux preflight failed: {error}"));
             return false;
         }
@@ -310,7 +325,12 @@ impl TerminalView {
             )
             .map(|path| path.to_string_lossy().into_owned())
         });
-        if let Err(error) = TmuxClient::verify_tmux_version(next_config.binary.as_str(), 3, 3) {
+        if let Err(error) = TmuxClient::verify_tmux_version(
+            &next_config.command_prefix,
+            next_config.binary.as_str(),
+            3,
+            3,
+        ) {
             termy_toast::error(format!("tmux preflight failed: {error}"));
             return;
         }

--- a/crates/terminal_ui/src/tmux/client.rs
+++ b/crates/terminal_ui/src/tmux/client.rs
@@ -21,6 +21,7 @@ use tmux_control_core::control::{
 use super::launch::spawn_tmux_control_mode;
 use super::launch::{
     SessionLaunchPlan, append_working_dir_args, managed_session_window_option_override_commands,
+    spawn_tmux_control_mode_via_prefix,
 };
 use super::session::{self, run_tmux_command_with_socket};
 use super::shutdown::{
@@ -35,15 +36,21 @@ use tmux_control_core::control::{
 use tmux_control_core::payload::{
     capture_full_pane_args, capture_pane_range_args, sanitize_tmux_payload, unescape_tmux_payload,
 };
-#[cfg(unix)]
-use tmux_control_core::types::TmuxLaunchTarget;
 use tmux_control_core::types::{
-    TmuxControlError, TmuxNotification, TmuxRuntimeConfig, TmuxSessionSummary, TmuxShutdownMode,
-    TmuxSnapshot, TmuxSocketTarget,
+    TmuxControlError, TmuxLaunchTarget, TmuxNotification, TmuxRuntimeConfig, TmuxSessionSummary,
+    TmuxShutdownMode, TmuxSnapshot, TmuxSocketTarget,
 };
 
 pub struct TmuxClient {
     tmux_binary: String,
+    /// Argv prefix used to reach the tmux binary for out-of-band commands
+    /// (`["wsl.exe", "-e"]`, `["ssh", "myhost"]`); empty for local tmux.
+    command_prefix: Vec<String>,
+    /// Whether out-of-band tmux commands (spawning the tmux binary directly,
+    /// possibly through `command_prefix`) can reach the same server as the
+    /// control channel. False for stream-based clients, whose transport is
+    /// opaque to this process.
+    out_of_band_commands_available: bool,
     session_name: String,
     socket_target: TmuxSocketTarget,
     show_active_pane_border: bool,
@@ -82,7 +89,6 @@ impl TmuxClient {
         super::launch::launch_plan(config)
     }
 
-    #[cfg(unix)]
     pub fn new(
         config: TmuxRuntimeConfig,
         cols: u16,
@@ -95,22 +101,88 @@ impl TmuxClient {
         if launch_plan.session_name.trim().is_empty() {
             return Err(anyhow!("tmux session name cannot be empty"));
         }
-        #[cfg(unix)]
-        let (child, child_stdin, child_stdout) = spawn_tmux_control_mode(
-            &config,
-            &launch_plan.socket_target,
-            launch_plan.session_name.as_str(),
-            launch_plan.attach_existing,
-            initial_working_dir,
-        )?;
 
+        if !config.command_prefix.is_empty() {
+            let (child, child_stdin, child_stdout) = spawn_tmux_control_mode_via_prefix(
+                &config,
+                &launch_plan.socket_target,
+                launch_plan.session_name.as_str(),
+                launch_plan.attach_existing,
+            )?;
+            // The local child (wsl.exe, ssh, ...) is not the tmux client the
+            // server sees, so its pid cannot be matched against
+            // `#{client_pid}`; pid 0 routes detach through the control
+            // channel instead.
+            return Self::from_spawned_control_client(
+                config,
+                launch_plan,
+                enforce_managed_session_ui,
+                child,
+                0,
+                child_stdin,
+                child_stdout,
+                cols,
+                rows,
+                event_wakeup_tx,
+            );
+        }
+
+        #[cfg(unix)]
+        {
+            let (child, child_stdin, child_stdout) = spawn_tmux_control_mode(
+                &config,
+                &launch_plan.socket_target,
+                launch_plan.session_name.as_str(),
+                launch_plan.attach_existing,
+                initial_working_dir,
+            )?;
+            let control_client_pid = child.id();
+            Self::from_spawned_control_client(
+                config,
+                launch_plan,
+                enforce_managed_session_ui,
+                child,
+                control_client_pid,
+                child_stdin,
+                child_stdout,
+                cols,
+                rows,
+                event_wakeup_tx,
+            )
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = initial_working_dir;
+            Err(anyhow!(
+                "tmux control mode on this platform requires tmux_command_prefix \
+                 (for example `wsl.exe -e` or `ssh myhost`)"
+            ))
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn from_spawned_control_client<W, R>(
+        config: TmuxRuntimeConfig,
+        launch_plan: SessionLaunchPlan,
+        enforce_managed_session_ui: bool,
+        child: std::process::Child,
+        control_client_pid: u32,
+        child_stdin: W,
+        child_stdout: R,
+        cols: u16,
+        rows: u16,
+        event_wakeup_tx: Option<Sender<()>>,
+    ) -> Result<Self>
+    where
+        W: Write + Send + 'static,
+        R: Read + Send + 'static,
+    {
         let (request_tx, request_rx) = flume::bounded::<ControlRequest>(REQUEST_QUEUE_BOUND);
         let (pending_tx, pending_rx) = flume::bounded(PENDING_QUEUE_BOUND);
         let (notifications_tx, notifications_rx) =
             flume::bounded::<TmuxNotification>(NOTIFICATION_QUEUE_BOUND);
         let (fatal_exit_tx, fatal_exit_rx) =
             flume::bounded::<Option<String>>(FATAL_EXIT_QUEUE_BOUND);
-        let control_client_pid = child.id();
 
         spawn_control_threads(
             Some(child),
@@ -126,6 +198,8 @@ impl TmuxClient {
 
         let client = Self {
             tmux_binary: config.binary,
+            command_prefix: config.command_prefix,
+            out_of_band_commands_available: true,
             session_name: launch_plan.session_name,
             socket_target: launch_plan.socket_target,
             show_active_pane_border: config.show_active_pane_border,
@@ -142,20 +216,6 @@ impl TmuxClient {
         }
         client.set_client_size(cols, rows)?;
         Ok(client)
-    }
-
-    #[cfg(not(unix))]
-    pub fn new(
-        config: TmuxRuntimeConfig,
-        cols: u16,
-        rows: u16,
-        initial_working_dir: Option<&str>,
-        event_wakeup_tx: Option<Sender<()>>,
-    ) -> Result<Self> {
-        let _ = (config, cols, rows, initial_working_dir, event_wakeup_tx);
-        Err(anyhow!(
-            "tmux control mode is only supported on unix targets"
-        ))
     }
 
     /// Create a `TmuxClient` from existing control-mode I/O streams instead of
@@ -208,6 +268,8 @@ impl TmuxClient {
 
         Ok(Self {
             tmux_binary,
+            command_prefix: Vec::new(),
+            out_of_band_commands_available: false,
             session_name,
             socket_target,
             show_active_pane_border: false,
@@ -470,13 +532,13 @@ impl TmuxClient {
     }
 
     fn shutdown_impl(&self, mode: TmuxShutdownMode) -> Result<()> {
-        // Stream-based clients (pid == 0) have no local process to teardown.
+        // Stream-based clients cannot reach the tmux binary out-of-band.
         // Downgrade to detach-only to avoid running local tmux commands against
         // a potentially unrelated or nonexistent session.
-        let mode = if self.control_client_pid == 0 {
-            TmuxShutdownMode::DetachOnly
-        } else {
+        let mode = if self.out_of_band_commands_available {
             mode
+        } else {
+            TmuxShutdownMode::DetachOnly
         };
         run_shutdown_actions(
             mode,
@@ -493,6 +555,7 @@ impl TmuxClient {
                 // Isolated managed sessions are ephemeral. Teardown is always attempted in
                 // this mode, even if detach failed, so stale sessions cannot accumulate.
                 let teardown_result = Self::kill_session(
+                    &self.command_prefix,
                     self.tmux_binary.as_str(),
                     self.socket_target.clone(),
                     self.session_name.as_str(),
@@ -604,24 +667,32 @@ impl TmuxClient {
         Ok(finalize_capture_payload(&out, false))
     }
 
-    pub fn verify_tmux_version(binary: &str, minimum_major: u8, minimum_minor: u8) -> Result<()> {
-        session::verify_tmux_version(binary, minimum_major, minimum_minor)
+    pub fn verify_tmux_version(
+        command_prefix: &[String],
+        binary: &str,
+        minimum_major: u8,
+        minimum_minor: u8,
+    ) -> Result<()> {
+        session::verify_tmux_version(command_prefix, binary, minimum_major, minimum_minor)
     }
 
     pub fn list_sessions(
+        command_prefix: &[String],
         binary: &str,
         socket_target: TmuxSocketTarget,
     ) -> Result<Vec<TmuxSessionSummary>> {
-        session::list_sessions(binary, socket_target)
+        session::list_sessions(command_prefix, binary, socket_target)
     }
 
     pub fn rename_session(
+        command_prefix: &[String],
         binary: &str,
         socket_target: TmuxSocketTarget,
         current_session_name: &str,
         next_session_name: &str,
     ) -> Result<()> {
         session::rename_session(
+            command_prefix,
             binary,
             socket_target,
             current_session_name,
@@ -630,11 +701,12 @@ impl TmuxClient {
     }
 
     pub fn kill_session(
+        command_prefix: &[String],
         binary: &str,
         socket_target: TmuxSocketTarget,
         session_name: &str,
     ) -> Result<()> {
-        session::kill_session(binary, socket_target, session_name)
+        session::kill_session(command_prefix, binary, socket_target, session_name)
     }
 
     fn enqueue_control_request(&self, request: ControlRequest) -> Result<()> {
@@ -712,14 +784,19 @@ impl TmuxClient {
     }
 
     fn run_tmux_command(&self, args: &[&str]) -> Result<std::process::Output> {
-        run_tmux_command_with_socket(self.tmux_binary.as_str(), &self.socket_target, args)
-            .with_context(|| {
-                format!(
-                    "failed to execute tmux command via '{}': {}",
-                    self.tmux_binary,
-                    tmux_command_line(args)
-                )
-            })
+        run_tmux_command_with_socket(
+            &self.command_prefix,
+            self.tmux_binary.as_str(),
+            &self.socket_target,
+            args,
+        )
+        .with_context(|| {
+            format!(
+                "failed to execute tmux command via '{}': {}",
+                self.tmux_binary,
+                tmux_command_line(args)
+            )
+        })
     }
 
     fn enforce_native_session_ui(&self) -> Result<()> {
@@ -832,6 +909,8 @@ mod tests {
         let (_fatal_exit_tx, fatal_exit_rx) = flume::bounded::<Option<String>>(1);
         TmuxClient {
             tmux_binary: "tmux".to_string(),
+            command_prefix: Vec::new(),
+            out_of_band_commands_available: false,
             session_name: "test-session".to_string(),
             socket_target: TmuxSocketTarget::DedicatedTermy,
             show_active_pane_border: false,

--- a/crates/terminal_ui/src/tmux/client.rs
+++ b/crates/terminal_ui/src/tmux/client.rs
@@ -158,6 +158,19 @@ impl TmuxClient {
         ))
     }
 
+    /// Create a `TmuxClient` from existing control-mode I/O streams instead of
+    /// spawning a local tmux process.
+    ///
+    /// `stdin`/`stdout` must be connected to a tmux control-mode client
+    /// (`tmux -CC`) that is already running — for example over an SSH channel,
+    /// in an embedded host, or an in-memory pair for tests. The streams are
+    /// wired directly into the existing control worker threads; no local
+    /// process is spawned or waited on.
+    ///
+    /// `tmux_binary` and `socket_target` are still used for out-of-band tmux
+    /// commands issued outside the control channel. Because there is no local
+    /// child process, shutdown is always downgraded to detach-only regardless
+    /// of the requested mode.
     pub fn from_streams<W, R>(
         stdin: W,
         stdout: R,

--- a/crates/terminal_ui/src/tmux/launch.rs
+++ b/crates/terminal_ui/src/tmux/launch.rs
@@ -1,20 +1,16 @@
 #![cfg_attr(not(unix), allow(dead_code))]
 
-#[cfg(unix)]
 use anyhow::{Context, Result, anyhow};
 #[cfg(unix)]
 use std::fs::File;
 #[cfg(unix)]
-use std::process::Command;
+use std::os::fd::{FromRawFd, IntoRawFd};
+use std::process::{Command, Stdio};
 use std::time::{SystemTime, UNIX_EPOCH};
-#[cfg(unix)]
-use std::{
-    os::fd::{FromRawFd, IntoRawFd},
-    process::Stdio,
-};
 
 #[cfg(unix)]
-use super::session::{append_socket_args, normalize_tmux_command_env};
+use super::session::normalize_tmux_command_env;
+use super::session::{append_socket_args, tmux_base_command};
 use tmux_control_core::types::{
     TmuxLaunchTarget, TmuxRuntimeConfig, TmuxShutdownMode, TmuxSocketTarget,
 };
@@ -121,6 +117,58 @@ pub(crate) fn spawn_tmux_control_mode(
     Ok((child, writer, controller))
 }
 
+/// Spawn the tmux control-mode client through the configured command prefix
+/// (`wsl.exe -e tmux ...`, `ssh myhost tmux ...`) with plain piped stdio.
+///
+/// Control-mode clients do not need a pty, so this path works on every
+/// platform — including Windows, where the local pty spawn path is
+/// unavailable. The working directory is intentionally not forwarded: the
+/// filesystem behind the prefix (WSL distro, remote host) does not share
+/// paths with the host process.
+pub(crate) fn spawn_tmux_control_mode_via_prefix(
+    config: &TmuxRuntimeConfig,
+    socket_target: &TmuxSocketTarget,
+    session_name: &str,
+    attach_existing: bool,
+) -> Result<(
+    std::process::Child,
+    std::process::ChildStdin,
+    std::process::ChildStdout,
+)> {
+    let mut command = tmux_base_command(&config.command_prefix, config.binary.as_str());
+    append_socket_args(&mut command, socket_target);
+    command.args(new_session_args(session_name, attach_existing, None));
+    let mut child = command
+        .env("TERMY_SHELL_INTEGRATION", "0")
+        .env_remove("TERMY_TAB_TITLE_PREFIX")
+        // Avoid inheriting an outer tmux client context; nested `TMUX` can
+        // redirect control-mode startup away from the requested session/socket.
+        .env_remove("TMUX")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        // Keep stderr attached to the app so prefix failures (ssh auth, WSL
+        // startup) stay visible in logs; the control protocol itself only
+        // uses stdout.
+        .stderr(Stdio::inherit())
+        .spawn()
+        .with_context(|| {
+            format!(
+                "failed to spawn tmux control mode via '{}'",
+                config.command_prefix.join(" ")
+            )
+        })?;
+
+    let child_stdin = child
+        .stdin
+        .take()
+        .context("tmux control mode child is missing a piped stdin")?;
+    let child_stdout = child
+        .stdout
+        .take()
+        .context("tmux control mode child is missing a piped stdout")?;
+    Ok((child, child_stdin, child_stdout))
+}
+
 pub(crate) fn append_working_dir_args<'a>(args: &mut Vec<&'a str>, working_dir: Option<&'a str>) {
     let working_dir = working_dir
         .map(str::trim)
@@ -196,6 +244,7 @@ mod tests {
     fn persistent_launch_plan_reuses_fixed_session_without_teardown() {
         let plan = launch_plan(&TmuxRuntimeConfig {
             binary: "tmux".to_string(),
+            command_prefix: Vec::new(),
             launch: TmuxLaunchTarget::Managed { persistence: true },
             show_active_pane_border: false,
         });
@@ -209,6 +258,7 @@ mod tests {
     fn isolated_launch_plan_uses_fresh_session_and_teardown() {
         let plan = launch_plan(&TmuxRuntimeConfig {
             binary: "tmux".to_string(),
+            command_prefix: Vec::new(),
             launch: TmuxLaunchTarget::Managed { persistence: false },
             show_active_pane_border: false,
         });
@@ -225,6 +275,7 @@ mod tests {
     fn explicit_session_launch_plan_uses_requested_target_without_teardown() {
         let plan = launch_plan(&TmuxRuntimeConfig {
             binary: "tmux".to_string(),
+            command_prefix: Vec::new(),
             launch: TmuxLaunchTarget::Session {
                 name: "work".to_string(),
                 socket: TmuxSocketTarget::Named("work".to_string()),

--- a/crates/terminal_ui/src/tmux/session.rs
+++ b/crates/terminal_ui/src/tmux/session.rs
@@ -49,13 +49,29 @@ pub(crate) fn normalize_tmux_command_env(command: &mut Command) {
     }
 }
 
+/// Build the base tmux `Command`, routing through the configured command
+/// prefix when present (`["wsl.exe", "-e"]` yields `wsl.exe -e <binary> ...`).
+pub(crate) fn tmux_base_command(command_prefix: &[String], binary: &str) -> Command {
+    let mut command = match command_prefix.split_first() {
+        Some((program, rest)) => {
+            let mut command = Command::new(program);
+            command.args(rest);
+            command.arg(binary);
+            command
+        }
+        None => Command::new(binary),
+    };
+    normalize_tmux_command_env(&mut command);
+    command
+}
+
 pub(crate) fn run_tmux_command_with_socket(
+    command_prefix: &[String],
     binary: &str,
     socket_target: &TmuxSocketTarget,
     args: &[&str],
 ) -> Result<std::process::Output> {
-    let mut command = Command::new(binary);
-    normalize_tmux_command_env(&mut command);
+    let mut command = tmux_base_command(command_prefix, binary);
     append_socket_args(&mut command, socket_target);
     let output = command.args(args).output()?;
 
@@ -78,12 +94,12 @@ pub(crate) fn run_tmux_command_with_socket(
 }
 
 pub(crate) fn verify_tmux_version(
+    command_prefix: &[String],
     binary: &str,
     minimum_major: u8,
     minimum_minor: u8,
 ) -> Result<()> {
-    let mut command = Command::new(binary);
-    normalize_tmux_command_env(&mut command);
+    let mut command = tmux_base_command(command_prefix, binary);
     let output = command
         .arg("-V")
         .output()
@@ -110,23 +126,29 @@ pub(crate) fn verify_tmux_version(
 }
 
 pub(crate) fn list_sessions(
+    command_prefix: &[String],
     binary: &str,
     socket_target: TmuxSocketTarget,
 ) -> Result<Vec<TmuxSessionSummary>> {
     let format = session_snapshot_format();
-    let output =
-        run_tmux_command_with_socket(binary, &socket_target, &["list-sessions", "-F", format])
-            .with_context(|| {
-                format!(
-                    "tmux session listing failed: {}",
-                    tmux_command_line(&["list-sessions", "-F", format])
-                )
-            })?;
+    let output = run_tmux_command_with_socket(
+        command_prefix,
+        binary,
+        &socket_target,
+        &["list-sessions", "-F", format],
+    )
+    .with_context(|| {
+        format!(
+            "tmux session listing failed: {}",
+            tmux_command_line(&["list-sessions", "-F", format])
+        )
+    })?;
     let stdout = String::from_utf8_lossy(&output.stdout);
     parse_session_summaries(stdout.as_ref())
 }
 
 pub(crate) fn rename_session(
+    command_prefix: &[String],
     binary: &str,
     socket_target: TmuxSocketTarget,
     current_session_name: &str,
@@ -143,6 +165,7 @@ pub(crate) fn rename_session(
     }
 
     run_tmux_command_with_socket(
+        command_prefix,
         binary,
         &socket_target,
         &[
@@ -167,6 +190,7 @@ pub(crate) fn rename_session(
 }
 
 pub(crate) fn kill_session(
+    command_prefix: &[String],
     binary: &str,
     socket_target: TmuxSocketTarget,
     session_name: &str,
@@ -177,6 +201,7 @@ pub(crate) fn kill_session(
     }
 
     run_tmux_command_with_socket(
+        command_prefix,
         binary,
         &socket_target,
         &["kill-session", "-t", session_name],
@@ -216,7 +241,7 @@ mod tests {
 
     #[test]
     fn rename_session_rejects_empty_session_names() {
-        let empty_current = rename_session("tmux", TmuxSocketTarget::Default, " ", "next")
+        let empty_current = rename_session(&[], "tmux", TmuxSocketTarget::Default, " ", "next")
             .expect_err("expected empty current session name failure");
         assert!(
             empty_current
@@ -224,7 +249,7 @@ mod tests {
                 .contains("tmux current session name cannot be empty")
         );
 
-        let empty_next = rename_session("tmux", TmuxSocketTarget::Default, "current", " ")
+        let empty_next = rename_session(&[], "tmux", TmuxSocketTarget::Default, "current", " ")
             .expect_err("expected empty next session name failure");
         assert!(
             empty_next
@@ -235,13 +260,32 @@ mod tests {
 
     #[test]
     fn kill_session_rejects_empty_session_name() {
-        let error = kill_session("tmux", TmuxSocketTarget::Default, " ")
+        let error = kill_session(&[], "tmux", TmuxSocketTarget::Default, " ")
             .expect_err("expected empty session name failure");
         assert!(
             error
                 .to_string()
                 .contains("tmux session name cannot be empty")
         );
+    }
+
+    #[test]
+    fn tmux_base_command_without_prefix_runs_binary_directly() {
+        let command = tmux_base_command(&[], "/usr/bin/tmux");
+        assert_eq!(command.get_program().to_string_lossy(), "/usr/bin/tmux");
+        assert_eq!(command.get_args().count(), 0);
+    }
+
+    #[test]
+    fn tmux_base_command_with_prefix_wraps_binary() {
+        let prefix = vec!["wsl.exe".to_string(), "-e".to_string()];
+        let command = tmux_base_command(&prefix, "tmux");
+        assert_eq!(command.get_program().to_string_lossy(), "wsl.exe");
+        let args = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(args, vec!["-e", "tmux"]);
     }
 
     #[test]

--- a/crates/terminal_ui/tests/support/tmux_harness.rs
+++ b/crates/terminal_ui/tests/support/tmux_harness.rs
@@ -65,7 +65,7 @@ exec tmux -f /dev/null \"${args[@]}\"\n";
 }
 
 pub(crate) fn tmux_preflight(binary: &str) {
-    TmuxClient::verify_tmux_version(binary, 3, 3).unwrap_or_else(|error| {
+    TmuxClient::verify_tmux_version(&[], binary, 3, 3).unwrap_or_else(|error| {
         panic!("tmux integration preflight failed for binary '{binary}': {error}")
     });
 }

--- a/crates/terminal_ui/tests/tmux_split_integration.rs
+++ b/crates/terminal_ui/tests/tmux_split_integration.rs
@@ -145,6 +145,7 @@ fn new_tmux_client_with_persistence_live_in_dir(
     for _attempt in 0..6 {
         let config = TmuxRuntimeConfig {
             binary: binary.to_string(),
+            command_prefix: Vec::new(),
             launch: TmuxLaunchTarget::Managed { persistence },
             show_active_pane_border: false,
         };

--- a/crates/tmux_control_core/src/types.rs
+++ b/crates/tmux_control_core/src/types.rs
@@ -1,6 +1,11 @@
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TmuxRuntimeConfig {
     pub binary: String,
+    /// Argv prefix used to reach the tmux binary, e.g. `["wsl.exe", "-e"]` or
+    /// `["ssh", "myhost"]`. When non-empty, the control client and out-of-band
+    /// tmux commands run through this prefix with piped stdio instead of a
+    /// locally spawned tmux on a pty, which also works on non-unix hosts.
+    pub command_prefix: Vec<String>,
     pub launch: TmuxLaunchTarget,
     pub show_active_pane_border: bool,
 }
@@ -45,6 +50,7 @@ impl Default for TmuxRuntimeConfig {
     fn default() -> Self {
         Self {
             binary: "tmux".to_string(),
+            command_prefix: Vec::new(),
             launch: TmuxLaunchTarget::Managed { persistence: false },
             show_active_pane_border: false,
         }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,6 +102,11 @@ Platform note: the Agent Sidebar/Workspace is currently unavailable on Windows b
 - tmux executable path or binary name
 - Group: `TMUX`
 
+`tmux_command_prefix`
+- Default: unset
+- Command prefix used to reach tmux, for example `wsl.exe -e` on Windows or `ssh myhost`; set to none to run tmux directly
+- Group: `TMUX`
+
 `tmux_show_active_pane_border`
 - Default: `false`
 - Show active tmux pane border highlight in managed sessions

--- a/macos/Tests/TermySwiftTests/SettingsSchemaParityTests.swift
+++ b/macos/Tests/TermySwiftTests/SettingsSchemaParityTests.swift
@@ -14,6 +14,7 @@ final class SettingsSchemaParityTests: XCTestCase {
             "tmux_enabled",
             "tmux_persistence",
             "tmux_binary",
+            "tmux_command_prefix",
             "tmux_show_active_pane_border",
             "simple_mode",
             "native_tab_persistence",

--- a/website/content/docs/using-termy/tmux-sessions.mdx
+++ b/website/content/docs/using-termy/tmux-sessions.mdx
@@ -3,12 +3,13 @@ title: Tmux sessions
 description: Optional tmux-backed tabs and panes.
 ---
 
-Requires `tmux` ≥ 3.3 on `PATH` (macOS / Linux).
+Requires `tmux` ≥ 3.3 on `PATH` (macOS / Linux), or reachable through a command prefix (Windows / remote).
 
 ```txt
 tmux_enabled                 = true
 tmux_persistence             = true
 tmux_binary                  = tmux
+tmux_command_prefix          = none
 tmux_show_active_pane_border = false
 ```
 
@@ -17,10 +18,32 @@ tmux_show_active_pane_border = false
 | `tmux_enabled` | New tabs use tmux instead of a raw PTY |
 | `tmux_persistence` | Sessions survive app restarts |
 | `tmux_binary` | Path or name of the tmux binary |
+| `tmux_command_prefix` | Command that tmux runs through, e.g. `wsl.exe -e` or `ssh myhost` |
 
 Open **Manage tmux Sessions** from the command palette, or bind `manage_tmux_sessions`.
 
 Termy creates one session per window (`termy-<window-id>`). Splits map to real tmux panes.
+
+## Windows (WSL) and remote hosts
+
+tmux cannot run natively on Windows, but Termy can drive a tmux that lives inside WSL
+or on a remote machine. Set `tmux_command_prefix` to the command that reaches it:
+
+```txt
+# tmux inside WSL (default distro)
+tmux_enabled        = true
+tmux_command_prefix = wsl.exe -e
+
+# tmux on a remote host over SSH (needs key-based auth)
+tmux_enabled        = true
+tmux_command_prefix = ssh myhost
+```
+
+Termy then launches `wsl.exe -e tmux ...` (or `ssh myhost tmux ...`) for the control
+channel and all session management commands. The prefix is split on whitespace, so it
+cannot contain arguments with embedded spaces. On Windows, tmux mode stays off until a
+prefix is configured. New sessions start in the default directory of the WSL distro or
+remote shell — the host working directory is not forwarded.
 
 ## Troubleshooting
 
@@ -30,3 +53,5 @@ Termy creates one session per window (`termy-<window-id>`). Splits map to real t
 | `protocol version mismatch` | Point `tmux_binary` at the tmux version you intend to use |
 | Sessions lost on quit | Set `tmux_persistence = true` |
 | Double active-pane border | Set `tmux_show_active_pane_border = false` |
+| tmux mode ignored on Windows | Set `tmux_command_prefix` (e.g. `wsl.exe -e`) |
+| `ssh` prefix hangs at startup | Use key-based auth; the control channel cannot answer password prompts |


### PR DESCRIPTION
## Summary

Follow-up to #305 / #306 and the WSL discussion in the issue thread: `TmuxClient::new()` only worked via a local pty spawn (unix-only), so tmux mode was hard-disabled on Windows. This adds a `tmux_command_prefix` config key that routes the control-mode client and all out-of-band tmux commands through a wrapper command with plain piped stdio:

```txt
tmux_enabled        = true
tmux_command_prefix = wsl.exe -e     # tmux inside WSL
# or
tmux_command_prefix = ssh myhost     # tmux on a remote host
```

Control-mode clients don't need a pty, so this path works on every platform.

## Changes

- **config_core**: new optional `tmux_command_prefix` key (`none` clears it) + whitespace-split argv helper; parser/schema/default-config/tests
- **tmux_control_core**: `TmuxRuntimeConfig.command_prefix`
- **terminal_ui**: `tmux_base_command()` prefix composition; cross-platform `spawn_tmux_control_mode_via_prefix()` (piped stdio, no openpty); `TmuxClient::new()` unified across platforms — prefix mode on all, local pty spawn on unix, clear error otherwise; explicit out-of-band-availability flag replaces the `pid == 0` shutdown downgrade heuristic so prefix-managed sessions still tear down correctly while `from_streams()` clients stay detach-only
- **desktop_app**: Windows runtime gate enables tmux when a prefix is configured; version preflight, runtime transitions, and the tmux session palette (list/rename/kill) run through the prefix; tmux settings group now visible on Windows with a new command-prefix text field
- **docs/website**: regenerated `configuration.md`; tmux sessions page gains a Windows (WSL) / remote-host section
- **macOS**: Swift settings-schema parity list updated (`just test-macos-config` green)

## Notes

- Prefix is whitespace-split; arguments with embedded spaces unsupported (documented)
- Working directory is intentionally not forwarded in prefix mode — host paths don't exist in the WSL distro / remote filesystem
- Local unix spawn path unchanged; `TmuxClient::from_streams()` unchanged

Closes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)