### PR TITLE
Add Windows shell choices to new tab menu

### DIFF
--- a/crates/desktop_app/src/terminal_view/mod.rs
+++ b/crates/desktop_app/src/terminal_view/mod.rs
@@ -1212,8 +1212,8 @@ pub struct TerminalView {
     pending_cursor_move_preview: Option<PendingCursorMovePreview>,
     terminal_context_menu: Option<TerminalContextMenuState>,
     tab_context_menu: Option<TabContextMenuState>,
-    /// Window-space top-left of the "+" dropdown (terminal / browser tab
-    /// choice); `None` while closed. Only used when browser tabs are enabled.
+    /// Window-space top-left of the "+" dropdown for platform-specific tab
+    /// choices; `None` while closed.
     new_tab_menu_anchor: Option<(f32, f32)>,
     hovered_link: Option<HoveredLink>,
     hovered_toast: Option<u64>,

--- a/crates/desktop_app/src/terminal_view/render.rs
+++ b/crates/desktop_app/src/terminal_view/render.rs
@@ -2154,9 +2154,8 @@ impl TerminalView {
         }
     }
 
-    /// Dropdown under the tab strip's "+" button offering the tab kind.
-    /// Rendered only when browser tabs are enabled (plain "+" otherwise
-    /// creates a terminal tab directly).
+    /// Dropdown under the tab strip's "+" button offering available tab and
+    /// shell choices for the current platform.
     fn render_new_tab_menu_overlay(&mut self, cx: &mut Context<Self>) -> Option<AnyElement> {
         let (menu_x, menu_y) = self.new_tab_menu_anchor?;
         let overlay_style = self.overlay_style();
@@ -2189,6 +2188,12 @@ impl TerminalView {
                     }),
                 )
                 .child(label)
+        };
+
+        let default_terminal_label = if cfg!(target_os = "windows") {
+            "Default Shell"
+        } else {
+            "New Terminal Tab"
         };
 
         Some(
@@ -2227,10 +2232,57 @@ impl TerminalView {
                         )
                         .child(menu_row(
                             "new-tab-menu-terminal",
-                            "New Terminal Tab",
+                            default_terminal_label,
                             cx,
                             |view, cx| view.add_tab(cx),
                         ))
+                        .when(cfg!(target_os = "windows"), |panel| {
+                            panel
+                                .child(menu_row(
+                                    "new-tab-menu-command-prompt",
+                                    "Command Prompt",
+                                    cx,
+                                    |view, cx| {
+                                        view.add_tab_with_windows_shell(
+                                            RuntimeWindowsShell::Cmd,
+                                            cx,
+                                        );
+                                    },
+                                ))
+                                .child(menu_row(
+                                    "new-tab-menu-windows-powershell",
+                                    "Windows PowerShell",
+                                    cx,
+                                    |view, cx| {
+                                        view.add_tab_with_windows_shell(
+                                            RuntimeWindowsShell::PowerShell,
+                                            cx,
+                                        );
+                                    },
+                                ))
+                                .child(menu_row(
+                                    "new-tab-menu-powershell-core",
+                                    "PowerShell 7",
+                                    cx,
+                                    |view, cx| {
+                                        view.add_tab_with_windows_shell(
+                                            RuntimeWindowsShell::PowerShellCore,
+                                            cx,
+                                        );
+                                    },
+                                ))
+                                .child(menu_row(
+                                    "new-tab-menu-git-bash",
+                                    "Git Bash",
+                                    cx,
+                                    |view, cx| {
+                                        view.add_tab_with_windows_shell(
+                                            RuntimeWindowsShell::GitBash,
+                                            cx,
+                                        );
+                                    },
+                                ))
+                        })
                         .when(self.browser_tabs_available(), |panel| {
                             panel.child(menu_row(
                                 "new-tab-menu-browser",

--- a/crates/desktop_app/src/terminal_view/tab_strip/constants.rs
+++ b/crates/desktop_app/src/terminal_view/tab_strip/constants.rs
@@ -51,7 +51,7 @@ pub(crate) const TAB_DRAG_AUTOSCROLL_MAX_STEP: f32 = 24.0;
 #[cfg(not(target_os = "windows"))]
 pub(crate) const TABBAR_ACTION_RAIL_WIDTH: f32 = 28.0;
 pub(crate) const TABBAR_NEW_TAB_BUTTON_SIZE: f32 = TAB_ITEM_HEIGHT;
-// Dropdown under the "+" button choosing between terminal and browser tabs.
+// Dropdown under the "+" button for platform-specific tab and shell choices.
 pub(crate) const NEW_TAB_MENU_WIDTH: f32 = 190.0;
 
 // Vertical tab sidebar (tab_bar_position = right).

--- a/crates/desktop_app/src/terminal_view/tabs/lifecycle.rs
+++ b/crates/desktop_app/src/terminal_view/tabs/lifecycle.rs
@@ -1,6 +1,24 @@
 use super::*;
 use std::cmp::Reverse;
 
+fn should_show_new_tab_menu(
+    browser_tabs_available: bool,
+    runtime_kind: RuntimeKind,
+    windows_shell_menu_available: bool,
+) -> bool {
+    runtime_kind == RuntimeKind::Native && (browser_tabs_available || windows_shell_menu_available)
+}
+
+fn runtime_config_for_windows_shell(
+    base: &TerminalRuntimeConfig,
+    windows_shell: RuntimeWindowsShell,
+) -> TerminalRuntimeConfig {
+    let mut runtime = base.clone();
+    runtime.shell = None;
+    runtime.windows_shell = windows_shell;
+    runtime
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ClosePaneOrTabTarget {
     ClosePane,
@@ -316,10 +334,14 @@ impl TerminalView {
         let _ = self.add_tab_with_working_dir(None, cx);
     }
 
-    /// "+" button entry point: with browser tabs enabled it opens a dropdown
-    /// to choose the tab kind; otherwise it creates a terminal tab directly.
+    /// "+" button entry point: opens a dropdown when the platform has extra
+    /// tab choices; otherwise it creates a terminal tab directly.
     pub(crate) fn handle_new_tab_button(&mut self, anchor: (f32, f32), cx: &mut Context<Self>) {
-        if self.browser_tabs_available() && self.runtime_kind() == RuntimeKind::Native {
+        if should_show_new_tab_menu(
+            self.browser_tabs_available(),
+            self.runtime_kind(),
+            cfg!(target_os = "windows"),
+        ) {
             self.toggle_new_tab_menu(anchor, cx);
         } else {
             self.add_tab(cx);
@@ -349,6 +371,23 @@ impl TerminalView {
         working_dir: Option<&str>,
         cx: &mut Context<Self>,
     ) -> bool {
+        self.add_tab_with_working_dir_and_windows_shell(working_dir, None, cx)
+    }
+
+    pub(crate) fn add_tab_with_windows_shell(
+        &mut self,
+        windows_shell: RuntimeWindowsShell,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        self.add_tab_with_working_dir_and_windows_shell(None, Some(windows_shell), cx)
+    }
+
+    fn add_tab_with_working_dir_and_windows_shell(
+        &mut self,
+        working_dir: Option<&str>,
+        windows_shell: Option<RuntimeWindowsShell>,
+        cx: &mut Context<Self>,
+    ) -> bool {
         match self.runtime_kind() {
             RuntimeKind::Tmux => {
                 let added = self.tmux_add_tab(working_dir, cx);
@@ -365,12 +404,15 @@ impl TerminalView {
                     .unwrap_or_default();
                 let preferred_working_dir =
                     self.preferred_working_dir_for_new_session(working_dir, cx);
+                let terminal_runtime = windows_shell
+                    .map(|shell| runtime_config_for_windows_shell(&self.terminal_runtime, shell));
+                let terminal_runtime = terminal_runtime.as_ref().unwrap_or(&self.terminal_runtime);
                 let terminal = match Terminal::new_native(
                     size,
                     preferred_working_dir.as_deref(),
                     Some(&self.native_terminal_wakeup_router),
                     Some(&self.tab_shell_integration),
-                    Some(&self.terminal_runtime),
+                    Some(terminal_runtime),
                     None,
                 ) {
                     Ok(terminal) => terminal,
@@ -1767,6 +1809,29 @@ mod tests {
     fn adjacent_tab_index_moves_middle_tab_left_and_right() {
         assert_eq!(TerminalView::adjacent_tab_index(2, 5, false), Some(1));
         assert_eq!(TerminalView::adjacent_tab_index(2, 5, true), Some(3));
+    }
+
+    #[test]
+    fn windows_shell_choices_open_the_new_tab_menu_without_browser_tabs() {
+        assert!(should_show_new_tab_menu(false, RuntimeKind::Native, true));
+        assert!(!should_show_new_tab_menu(false, RuntimeKind::Native, false));
+        assert!(!should_show_new_tab_menu(true, RuntimeKind::Tmux, true));
+    }
+
+    #[test]
+    fn selected_windows_shell_overrides_a_custom_shell_for_the_new_tab() {
+        let base = TerminalRuntimeConfig {
+            shell: Some(r"C:\tools\custom-shell.exe".to_string()),
+            windows_shell: RuntimeWindowsShell::Cmd,
+            term: "termy-test".to_string(),
+            ..TerminalRuntimeConfig::default()
+        };
+
+        let runtime = runtime_config_for_windows_shell(&base, RuntimeWindowsShell::PowerShellCore);
+
+        assert_eq!(runtime.shell, None);
+        assert_eq!(runtime.windows_shell, RuntimeWindowsShell::PowerShellCore);
+        assert_eq!(runtime.term, "termy-test");
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- Open a shell picker from the new-tab button on Windows.
- Add choices for the configured default shell, Command Prompt, Windows PowerShell, PowerShell 7, and Git Bash.
- Preserve the existing macOS browser-tab menu and Linux one-click behavior.

## Why

Windows users often switch between several shells. New tabs can now launch the requested shell directly without changing the global configuration.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p termy`
- `cargo test -p termy windows_shell`
- `cargo check -p termy --target x86_64-pc-windows-gnu`