### PR TITLE
Bump version to 0.2.22 in Cargo.toml

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "termy_cli"
-version = "0.2.21"
+version = "0.2.22"
 edition = "2024"
 
 [lints]

--- a/crates/desktop_app/Cargo.toml
+++ b/crates/desktop_app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "termy"
-version = "0.2.21"
+version = "0.2.22"
 edition = "2024"
 
 [package.metadata.bundle]


### PR DESCRIPTION
This pull request updates the version numbers for both the CLI and desktop app packages from 0.2.21 to 0.2.22. No other changes are included. 

- Bumped the version of `termy_cli` in `crates/cli/Cargo.toml` from 0.2.21 to 0.2.22.
- Bumped the version of `termy` in `crates/desktop_app/Cargo.toml` from 0.2.21 to 0.2.22.