### PR TITLE
Fix Windows release build and bump to v0.2.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8616,7 +8616,7 @@ dependencies = [
 
 [[package]]
 name = "termy"
-version = "0.2.21"
+version = "0.2.23"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
@@ -8701,7 +8701,7 @@ dependencies = [
 
 [[package]]
 name = "termy_cli"
-version = "0.2.21"
+version = "0.2.23"
 dependencies = [
  "clap",
  "core-foundation 0.10.0",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "termy_cli"
-version = "0.2.22"
+version = "0.2.23"
 edition = "2024"
 
 [lints]

--- a/crates/desktop_app/Cargo.toml
+++ b/crates/desktop_app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "termy"
-version = "0.2.22"
+version = "0.2.23"
 edition = "2024"
 
 [package.metadata.bundle]

--- a/crates/desktop_app/src/main.rs
+++ b/crates/desktop_app/src/main.rs
@@ -32,7 +32,7 @@ use gpui::{
 };
 use startup::StartupBlocker;
 use terminal_view::{TerminalView, initial_window_background_appearance};
-#[cfg(any(target_os = "macos", target_os = "linux"))]
+#[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
 use termy_terminal_ui::TmuxClient;
 
 pub(crate) const APP_VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/desktop_app/src/settings_view/sections.rs
+++ b/crates/desktop_app/src/settings_view/sections.rs
@@ -412,7 +412,6 @@ impl SettingsWindow {
         self.render_settings_group("Shell environment", rows)
     }
 
-    #[cfg(not(target_os = "windows"))]
     pub(super) fn render_terminal_tmux_group(&mut self, cx: &mut Context<Self>) -> AnyElement {
         let binary_meta = Self::setting_metadata_or_fallback("tmux_binary");
         let command_prefix_meta = Self::setting_metadata_or_fallback("tmux_command_prefix");

--- a/crates/terminal_ui/src/tmux/launch.rs
+++ b/crates/terminal_ui/src/tmux/launch.rs
@@ -1,11 +1,15 @@
 #![cfg_attr(not(unix), allow(dead_code))]
 
-use anyhow::{Context, Result, anyhow};
+#[cfg(unix)]
+use anyhow::anyhow;
+use anyhow::{Context, Result};
 #[cfg(unix)]
 use std::fs::File;
 #[cfg(unix)]
 use std::os::fd::{FromRawFd, IntoRawFd};
-use std::process::{Command, Stdio};
+#[cfg(unix)]
+use std::process::Command;
+use std::process::Stdio;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 #[cfg(unix)]


### PR DESCRIPTION
## What changed

- Fixed the Windows release build by compiling the tmux client import and settings group on Windows.
- Cleaned Windows-only unused tmux imports.
- Bumped the desktop app and CLI to `0.2.23` with `just set-version 0.2.23`.

## Root cause

The Windows tmux support added in v0.2.22 called code that remained behind non-Windows compile gates.

## Validation

- `cargo fmt --all -- --check`
- `cargo metadata --locked --no-deps --format-version 1`
- `cargo check -p termy -p termy_cli`
- `cargo check -p termy -p termy_cli --target x86_64-pc-windows-gnu`

The MSVC cross-check reached GPUI and then stopped because GPUI release shader generation requires Windows `fxc.exe`; the original Termy compiler errors were resolved.