### PR TITLE
Fix plugin runtime PATH resolution

### DIFF
--- a/crates/plugin_runtime/src/lib.rs
+++ b/crates/plugin_runtime/src/lib.rs
@@ -6,6 +6,7 @@ use serde_json::Value;
 use sha2::{Digest, Sha256};
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    ffi::OsString,
     fs,
     io::{BufRead, BufReader, Read, Write},
     net::{Shutdown, TcpListener, TcpStream},
@@ -2064,7 +2065,7 @@ impl HostConnection {
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::inherit());
-        copy_safe_environment(&mut command);
+        copy_safe_environment(&mut command, &bun);
         let child = command
             .spawn()
             .map_err(|error| format!("Failed to start Bun plugin runtime: {error}"))?;
@@ -2985,11 +2986,44 @@ fn is_executable_file(path: &Path) -> bool {
     }
 }
 
-fn copy_safe_environment(command: &mut Command) {
+fn plugin_path_env(bun: &Path) -> Option<OsString> {
+    let mut entries = Vec::new();
+    let mut push = |entry: PathBuf| {
+        if !entry.as_os_str().is_empty() && !entries.contains(&entry) {
+            entries.push(entry);
+        }
+    };
+
+    if let Some(path) = std::env::var_os("PATH") {
+        for entry in std::env::split_paths(&path) {
+            push(entry);
+        }
+    }
+    if let Some(parent) = bun.parent() {
+        push(parent.to_path_buf());
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    for entry in [
+        "/opt/homebrew/bin",
+        "/opt/homebrew/sbin",
+        "/usr/local/bin",
+        "/usr/local/sbin",
+        "/usr/bin",
+        "/bin",
+        "/usr/sbin",
+        "/sbin",
+    ] {
+        push(PathBuf::from(entry));
+    }
+
+    std::env::join_paths(entries).ok()
+}
+
+fn copy_safe_environment(command: &mut Command, bun: &Path) {
     for key in [
         "HOME",
         "USERPROFILE",
-        "PATH",
         "SHELL",
         "TMPDIR",
         "TMP",
@@ -3001,6 +3035,9 @@ fn copy_safe_environment(command: &mut Command) {
         if let Some(value) = std::env::var_os(key) {
             command.env(key, value);
         }
+    }
+    if let Some(path) = plugin_path_env(bun) {
+        command.env("PATH", path);
     }
     #[cfg(target_os = "windows")]
     for key in ["SYSTEMROOT", "WINDIR", "COMSPEC", "PATHEXT"] {

--- a/crates/plugin_runtime/src/tests.rs
+++ b/crates/plugin_runtime/src/tests.rs
@@ -30,6 +30,99 @@ fn bun_is_available() -> bool {
     }
 }
 
+#[cfg(unix)]
+#[test]
+fn plugin_host_environment_restores_gui_missing_path_entries() {
+    const CHILD_MARKER: &str = "TERMY_PLUGIN_PATH_TEST_CHILD";
+
+    if std::env::var_os(CHILD_MARKER).is_none() {
+        let Some(bun) = resolve_bun_binary().expect("resolve Bun") else {
+            if std::env::var_os("CI").is_some() {
+                panic!("Bun is required for plugin runtime tests in CI");
+            }
+            return;
+        };
+        let empty_path = TempDir::new().expect("empty PATH directory");
+        let output = Command::new(std::env::current_exe().expect("current test executable"))
+            .arg("--exact")
+            .arg("tests::plugin_host_environment_restores_gui_missing_path_entries")
+            .arg("--nocapture")
+            .env(CHILD_MARKER, "1")
+            .env("TERMY_BUN_PATH", bun)
+            .env("PATH", empty_path.path())
+            .output()
+            .expect("run isolated plugin PATH test");
+        assert!(
+            output.status.success(),
+            "plugin host did not restore Bun's directory to PATH\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+        return;
+    }
+
+    let temp = TempDir::new().expect("temp dir");
+    let config_path = temp.path().join("config.txt");
+    fs::write(&config_path, "").expect("write config");
+    let plugins = temp.path().join("plugins");
+    write_plugin(
+        &plugins,
+        "path-check",
+        "PATH Check",
+        r#"
+export default definePlugin({
+  commands: [{
+    id: "run",
+    title: "PATH Check: Run",
+    run() {
+      const pathEntries = (process.env.PATH || "").split(":");
+      if (process.platform === "darwin" && !pathEntries.includes("/opt/homebrew/bin")) {
+        throw new Error("/opt/homebrew/bin is missing from PATH");
+      }
+      const result = Bun.spawnSync(["bun", "--version"], {
+        env: process.env,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      if (result.exitCode !== 0) {
+        throw new Error(result.stderr.toString() || "bun failed");
+      }
+      return {
+        type: "toast",
+        level: "success",
+        message: result.stdout.toString().trim(),
+      };
+    },
+  }],
+});
+"#,
+    );
+
+    let runtime = PluginRuntime::new(Some(&config_path));
+    let refresh = runtime.refresh_if_changed();
+    assert!(refresh.errors.is_empty(), "errors: {:?}", refresh.errors);
+    let revision = runtime
+        .command_with_revision("path-check", "run")
+        .expect("PATH check command")
+        .1;
+    let actions = runtime
+        .invoke(
+            "path-check",
+            "run",
+            &revision,
+            BTreeMap::new(),
+            test_plugin_context(),
+        )
+        .expect("plugin should resolve Bun by name");
+    assert!(matches!(
+        actions.as_slice(),
+        [PluginAction::Toast {
+            level: PluginToastLevel::Success,
+            message,
+        }] if !message.is_empty()
+    ));
+}
+
 #[test]
 fn tsx_views_render_and_round_trip_actions() {
     if !bun_is_available() {


### PR DESCRIPTION
## What changed

- preserve the existing plugin host PATH
- add the resolved Bun binary directory
- add standard Homebrew and system executable directories on Unix
- cover stripped GUI app environments with a regression test

## Why

macOS GUI applications can start with a minimal PATH that excludes locations such as /opt/homebrew/bin and ~/.bun/bin. Termy resolved Bun by absolute path, but then passed the stripped PATH into plugin workers. Commands launched from plugins through Bun.spawn or Bun.spawnSync therefore failed with executable-not-found errors even when the executable was installed normally.

The plugin environment remains allowlisted and env_clear remains in place; only PATH construction changes.

## Validation

- cargo test -p termy_plugin_runtime
- cargo clippy -p termy_plugin_runtime --tests -- -D warnings
- cargo check -p termy --jobs 1
- cargo fmt --all -- --check
- git diff --check