### PR TITLE
Bump version to 0.2.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8616,7 +8616,7 @@ dependencies = [
 
 [[package]]
 name = "termy"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
@@ -8701,7 +8701,7 @@ dependencies = [
 
 [[package]]
 name = "termy_cli"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "clap",
  "core-foundation 0.10.0",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "termy_cli"
-version = "0.2.23"
+version = "0.2.24"
 edition = "2024"
 
 [lints]

--- a/crates/desktop_app/Cargo.toml
+++ b/crates/desktop_app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "termy"
-version = "0.2.23"
+version = "0.2.24"
 edition = "2024"
 
 [package.metadata.bundle]


### PR DESCRIPTION
## What changed

- bumped the desktop app from `0.2.23` to `0.2.24`
- bumped the CLI from `0.2.23` to `0.2.24`
- updated the matching local package versions in `Cargo.lock`

The manifest changes were made with:

```sh
just set-version 0.2.24
```

## Release contents

This release includes the plugin runtime PATH fix from #355, so Bun plugin commands can resolve executables installed under Bun, Homebrew, and standard system paths when Termy starts with a stripped macOS GUI environment.

## Validation

- `cargo check -p termy -p termy_cli --jobs 1`
- `cargo test -p termy_plugin_runtime`
- `cargo fmt --all -- --check`
- `cargo metadata --locked --no-deps --format-version 1`

`just check-boundaries` still reports pre-existing oversized files already present on `main`; this version-only change adds no lines.