### PR TITLE
fix: `tmux` native fallback

### DIFF
--- a/crates/desktop_app/src/main.rs
+++ b/crates/desktop_app/src/main.rs
@@ -126,6 +126,12 @@ fn preflight_tmux_runtime(config: &config::AppConfig) -> Result<(), StartupBlock
     ))
 }
 
+fn guard_tmux_startup(config: &mut config::AppConfig) -> Option<String> {
+    let blocker = preflight_tmux_runtime(config).err()?;
+    config.tmux_enabled = false;
+    Some(blocker.tmux_fallback_message())
+}
+
 fn normalized_startup_window_size(startup_config: &config::AppConfig) -> gpui::Size<Pixels> {
     let window_width = startup_config.window_width;
     let window_height = startup_config.window_height;
@@ -311,11 +317,9 @@ pub(crate) fn open_main_window_with_runtime_config_overrides(
     if let Some(working_dir) = working_dir {
         reopen_config.working_dir = Some(working_dir);
     }
-    if let Err(blocker) = preflight_tmux_runtime(&reopen_config) {
-        let message = blocker.message();
-        log::error!("Failed to reopen main window: {message}");
-        termy_toast::error(message.clone());
-        return Err(message);
+    if let Some(message) = guard_tmux_startup(&mut reopen_config) {
+        log::warn!("{message}");
+        termy_toast::warning(message);
     }
 
     open_main_window(cx, reopen_config).inspect_err(|error| {
@@ -521,8 +525,9 @@ fn main() {
             app_config.working_dir = Some(working_dir);
         }
         app_icon::apply_from_config(&app_config);
-        if let Err(blocker) = preflight_tmux_runtime(&app_config) {
-            blocker.present_and_exit();
+        if let Some(message) = guard_tmux_startup(&mut app_config) {
+            log::warn!("{message}");
+            termy_toast::warning(message);
         }
         // Keep startup menus/keybinds aligned with the active runtime capability set.
         let tmux_runtime_active = if cfg!(target_os = "windows") {
@@ -544,7 +549,7 @@ fn main() {
 mod tests {
     use super::{
         DeepLinkArgument, DeepLinkRoute, MIN_WINDOW_HEIGHT, MIN_WINDOW_WIDTH,
-        focus_or_open_main_window, handle_open_urls_with_main_window,
+        focus_or_open_main_window, guard_tmux_startup, handle_open_urls_with_main_window,
         normalized_startup_window_size, parse_startup_arguments, reopen_if_no_windows,
     };
     #[cfg(target_os = "windows")]
@@ -594,6 +599,38 @@ mod tests {
         let parsed = parse_startup_arguments(["termy://new?dir=%2Ftmp%2Fproject"]);
         assert_eq!(parsed.working_dir, None);
         assert_eq!(parsed.deeplinks, vec!["termy://new?dir=%2Ftmp%2Fproject"]);
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    #[test]
+    fn tmux_startup_guard_falls_back_to_native_when_binary_is_missing() {
+        let mut config = AppConfig {
+            tmux_enabled: true,
+            tmux_binary: "/termy-test-bin/tmux-does-not-exist".to_string(),
+            ..AppConfig::default()
+        };
+
+        let warning = guard_tmux_startup(&mut config).expect("missing tmux should be guarded");
+
+        assert!(!config.tmux_enabled);
+        assert!(warning.contains("starting in native mode"));
+        assert!(warning.contains("tmux preflight failed"));
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    #[test]
+    fn tmux_startup_guard_falls_back_in_bare_environment() {
+        let mut config = AppConfig {
+            tmux_enabled: true,
+            tmux_binary: "tmux".to_string(),
+            tmux_command_prefix: Some("env PATH=/termy-test-bin".to_string()),
+            ..AppConfig::default()
+        };
+
+        let warning = guard_tmux_startup(&mut config).expect("bare PATH should not contain tmux");
+
+        assert!(!config.tmux_enabled);
+        assert!(warning.contains("starting in native mode"));
     }
 
     #[gpui::test]

--- a/crates/desktop_app/src/startup.rs
+++ b/crates/desktop_app/src/startup.rs
@@ -3,12 +3,22 @@
 pub(crate) enum StartupBlocker {
     #[cfg_attr(target_os = "windows", allow(dead_code))]
     TmuxPreflight(String),
-    TmuxClientLaunch(String),
-    TmuxInitialSnapshot(String),
     MainWindowOpen(String),
 }
 
 impl StartupBlocker {
+    fn tmux_reason_and_error(&self) -> (&'static str, &str) {
+        match self {
+            Self::TmuxPreflight(error) => ("tmux preflight failed", error),
+            Self::MainWindowOpen(_) => unreachable!("main-window failures are not tmux failures"),
+        }
+    }
+
+    pub(crate) fn tmux_fallback_message(&self) -> String {
+        let (reason, error) = self.tmux_reason_and_error();
+        format!("tmux is unavailable ({reason}: {error}); starting in native mode")
+    }
+
     pub(crate) fn message(&self) -> String {
         if let Self::MainWindowOpen(error) = self {
             return format!(
@@ -16,30 +26,11 @@ impl StartupBlocker {
             );
         }
 
-        let (reason, error) = match self {
-            Self::TmuxPreflight(error) => ("tmux preflight failed", error.as_str()),
-            Self::TmuxClientLaunch(error) => {
-                ("failed to start tmux control runtime", error.as_str())
-            }
-            Self::TmuxInitialSnapshot(error) => {
-                ("failed to fetch initial tmux snapshot", error.as_str())
-            }
-            Self::MainWindowOpen(_) => unreachable!("handled above"),
-        };
+        let (reason, error) = self.tmux_reason_and_error();
 
         format!(
             "Termy cannot continue because {reason}.\n\nError:\n{error}\n\nRecovery:\n- Open your config and set tmux_enabled = false to start in native mode.\n- Finder/DMG launches use a minimal environment; set tmux_binary to an absolute path (for example /opt/homebrew/bin/tmux) if tmux is not on the default PATH.\n- If tmux integration is desired, ensure tmux 3.3 or newer is installed.\n- Save the config and restart Termy, then use tmux Sessions… when ready."
         )
-    }
-
-    pub(crate) fn present_and_exit(self) -> ! {
-        let message = self.message();
-        // Startup blockers can fire while GPUI holds internal borrows during app/window
-        // initialization. Triggering synchronous native modal dialogs in that state can
-        // re-enter GPUI and panic; keep this path side-effect free and terminate cleanly.
-        eprintln!("Termy startup blocked:\n{message}");
-        // Hard cutover: do not continue startup after tmux preflight/startup failures.
-        std::process::exit(1);
     }
 
     pub(crate) fn present_alert_and_exit(self) -> ! {
@@ -66,18 +57,11 @@ mod tests {
     }
 
     #[test]
-    fn startup_blocker_message_for_tmux_client_launch_includes_exact_error() {
-        let message = StartupBlocker::TmuxClientLaunch("socket unavailable".to_string()).message();
-        assert!(message.contains("failed to start tmux control runtime"));
-        assert!(message.contains("socket unavailable"));
-    }
-
-    #[test]
-    fn startup_blocker_message_for_initial_snapshot_includes_exact_error() {
-        let message =
-            StartupBlocker::TmuxInitialSnapshot("list-windows failed".to_string()).message();
-        assert!(message.contains("failed to fetch initial tmux snapshot"));
-        assert!(message.contains("list-windows failed"));
+    fn tmux_fallback_message_explains_native_recovery() {
+        let message = StartupBlocker::TmuxPreflight("tmux executable was not found".to_string())
+            .tmux_fallback_message();
+        assert!(message.contains("tmux executable was not found"));
+        assert!(message.contains("starting in native mode"));
     }
 
     #[test]

--- a/crates/desktop_app/src/terminal_view/runtime/mod.rs
+++ b/crates/desktop_app/src/terminal_view/runtime/mod.rs
@@ -3,8 +3,6 @@ use std::time::Instant;
 use flume::Sender;
 use termy_terminal_ui::{TmuxClient, TmuxLaunchTarget, TmuxRuntimeConfig, TmuxSnapshot};
 
-use crate::startup::StartupBlocker;
-
 use super::*;
 
 mod tmux;
@@ -18,20 +16,8 @@ pub(super) enum RuntimeKind {
     Tmux,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum TmuxStartupSnapshotCleanupDecision {
-    ContinueToFatalExit,
-    EmitCleanupWarningAndExit,
-}
-
-fn tmux_startup_snapshot_cleanup_decision(
-    cleanup_succeeded: bool,
-) -> TmuxStartupSnapshotCleanupDecision {
-    if cleanup_succeeded {
-        TmuxStartupSnapshotCleanupDecision::ContinueToFatalExit
-    } else {
-        TmuxStartupSnapshotCleanupDecision::EmitCleanupWarningAndExit
-    }
+fn tmux_startup_fallback_message(reason: &str, error: &anyhow::Error) -> String {
+    format!("tmux is unavailable ({reason}: {error:#}); starting in native mode")
 }
 
 impl RuntimeKind {
@@ -155,6 +141,28 @@ impl TerminalView {
         initial_cols: u16,
         initial_rows: u16,
     ) -> (RuntimeState, Option<TmuxSnapshot>, Option<Terminal>) {
+        let start_native = || {
+            let native_terminal = match Terminal::new_native(
+                TerminalSize {
+                    cols: initial_cols,
+                    rows: initial_rows,
+                    ..TerminalSize::default()
+                },
+                configured_working_dir,
+                Some(native_terminal_wakeup_router),
+                Some(tab_shell_integration),
+                Some(terminal_runtime),
+                startup_command,
+            ) {
+                Ok(terminal) => terminal,
+                Err(error) => {
+                    eprintln!("Termy startup blocked: failed to start native runtime: {error}");
+                    std::process::exit(1);
+                }
+            };
+            (RuntimeState::Native, None, Some(native_terminal))
+        };
+
         match RuntimeKind::from_app_config(config) {
             RuntimeKind::Tmux => {
                 let tmux_runtime = Self::tmux_runtime_from_app_config(config);
@@ -172,29 +180,31 @@ impl TerminalView {
                 ) {
                     Ok(client) => client,
                     Err(error) => {
-                        StartupBlocker::TmuxClientLaunch(format!("{error:#}")).present_and_exit()
+                        let message = tmux_startup_fallback_message(
+                            "failed to start tmux control runtime",
+                            &error,
+                        );
+                        log::warn!("{message}");
+                        termy_toast::warning(message);
+                        return start_native();
                     }
                 };
                 let initial_snapshot = match tmux_client.refresh_snapshot() {
                     Ok(snapshot) => snapshot,
                     Err(error) => {
-                        // `present_and_exit` terminates the process without running
-                        // destructors. Explicit shutdown avoids leaking a control
-                        // client when startup fails after tmux launch succeeds.
-                        let cleanup_result = tmux_client.shutdown_default();
-                        if matches!(
-                            tmux_startup_snapshot_cleanup_decision(cleanup_result.is_ok()),
-                            TmuxStartupSnapshotCleanupDecision::EmitCleanupWarningAndExit
-                        ) {
-                            let cleanup_error = cleanup_result.expect_err(
-                                "cleanup error must be present when startup decision emits warning",
-                            );
+                        if let Err(cleanup_error) = tmux_client.shutdown_default() {
                             eprintln!(
                                 "Termy startup warning: failed to cleanup tmux client after \
                                  snapshot startup failure: {cleanup_error}"
                             );
                         }
-                        StartupBlocker::TmuxInitialSnapshot(format!("{error:#}")).present_and_exit()
+                        let message = tmux_startup_fallback_message(
+                            "failed to fetch initial tmux snapshot",
+                            &error,
+                        );
+                        log::warn!("{message}");
+                        termy_toast::warning(message);
+                        return start_native();
                     }
                 };
                 (
@@ -209,27 +219,7 @@ impl TerminalView {
                     None,
                 )
             }
-            RuntimeKind::Native => {
-                let native_terminal = match Terminal::new_native(
-                    TerminalSize {
-                        cols: initial_cols,
-                        rows: initial_rows,
-                        ..TerminalSize::default()
-                    },
-                    configured_working_dir,
-                    Some(native_terminal_wakeup_router),
-                    Some(tab_shell_integration),
-                    Some(terminal_runtime),
-                    startup_command,
-                ) {
-                    Ok(terminal) => terminal,
-                    Err(error) => {
-                        eprintln!("Termy startup blocked: failed to start native runtime: {error}");
-                        std::process::exit(1);
-                    }
-                };
-                (RuntimeState::Native, None, Some(native_terminal))
-            }
+            RuntimeKind::Native => start_native(),
         }
     }
 }
@@ -259,14 +249,10 @@ mod tests {
     }
 
     #[test]
-    fn startup_snapshot_cleanup_decision_only_warns_when_cleanup_fails() {
-        assert_eq!(
-            tmux_startup_snapshot_cleanup_decision(true),
-            TmuxStartupSnapshotCleanupDecision::ContinueToFatalExit
-        );
-        assert_eq!(
-            tmux_startup_snapshot_cleanup_decision(false),
-            TmuxStartupSnapshotCleanupDecision::EmitCleanupWarningAndExit
-        );
+    fn tmux_startup_fallback_message_preserves_error_and_recovery() {
+        let error = anyhow::anyhow!("tmux executable was not found");
+        let message = tmux_startup_fallback_message("failed to start tmux", &error);
+        assert!(message.contains("tmux executable was not found"));
+        assert!(message.contains("starting in native mode"));
     }
 }


### PR DESCRIPTION
termy startup will fallback to native instead of tmux runtime, if tmux cannot start (not installed, error code, etc)