### PR TITLE
Refresh ROADMAP.md for current product state

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,205 +1,74 @@
 # Termy roadmap
 
-Unified plan for **shipping v1.0** and **sustaining a 10/10 codebase**. Two tracks run in parallel; both must be healthy at launch, but only engineering **E0** is a hard gate for the v1.0 tag.
+Ship a terminal people trust — then keep changing it cheap.
 
-> **Baseline (2026-06-01):** app **0.3.0** · ~95k lines Rust · **1,107** `#[test]` functions · **17** workspace crates · CI: Clippy + boundaries + macOS perf/native (path-filtered)
+**Today:** `0.2.29` · 21 crates · ~127k lines Rust · ~1,400 tests
 
----
 
 ## North star
 
-| | Product | Engineering |
-|---|---------|-------------|
-| **Goal** | A trustworthy, cross-platform terminal users recommend | Every change is cheap, safe, and reviewable |
-| **v1.0 means** | Signed builds, platform parity, expected terminal features | CI runs tests + fmt; boundaries hold; debt is scheduled not ignored |
-| **10/10 means** | Polished docs, migration guides, stable releases | Scorecard gates met; no god-files; tmux/FFI/perf protected by automation |
+A fast native terminal on macOS, Linux, and Windows — tabs, splits, search, themes, tmux — without turning into a control panel.
 
----
+**v1.0** means signed builds, solid docs, and the quality gates in [docs/engineering/](docs/engineering/).
 
-## How to read this document
 
-| Track | Document | Audience |
-|-------|----------|----------|
-| **Product** | This file — Phases 1–5 below | Users, PM, feature owners |
-| **Engineering** | [docs/engineering/roadmap.md](docs/engineering/roadmap.md) | Contributors, reviewers |
-| **Gates** | [docs/engineering/quality-scorecard.md](docs/engineering/quality-scorecard.md) | Monthly health check |
+## Already solid
 
-```mermaid
-flowchart TB
-  subgraph eng [Engineering E0-E4]
-    E0[E0 Pipeline trust]
-    E1[E1 Modularity]
-    E2[E2 Confidence]
-    E3[E3 Operability]
-  end
-  subgraph prod [Product Phases 1-5]
-    P1[Phase 1 Blockers]
-    P2[Phase 2 Parity]
-    P3[Phase 3 Features]
-    P4[Phase 4 Hardening]
-    P5[Phase 5 Launch]
-  end
-  E0 --> v1[v1.0 tag]
-  P1 --> v1
-  P4 --> v1
-  P5 --> v1
-  E1 --> P3
-  E2 --> P4
-```
+Defend these; don’t reopen them casually.
 
----
+- Tabs, splits, pinning, search, command palette
+- Config + live reload, themes, deeplinks
+- OSC escapes and Kitty graphics
+- Optional tmux control-mode sessions
+- Plugins, SSH hosts, auto-update
+- CLI companion, website docs, AUR + AppImage
+- Crate boundaries, CI tests/fmt, `just validate`
 
-## Engineering track (summary)
+Native macOS (Swift) is a strong preview — production cutover lives in [macos/road.md](macos/road.md).
 
-Full detail: **[docs/engineering/roadmap.md](docs/engineering/roadmap.md)**
 
-| Phase | Target | Theme | v1.0 gate? |
-|-------|--------|-------|------------|
-| **E0** | 2026 Q2 | CI tests + fmt + `just validate` + PR checklist | **Yes** |
-| **E1** | 2026 Q2–Q4 | File budgets; `terminal_view` decomposition | No (continue post-v1) |
-| **E2** | 2026 Q3–2027 Q1 | Tmux CI, FFI/Swift contracts, test pyramid | Partial (E2.1 before v1 if tmux is flagship) |
-| **E3** | 2026 Q4–2027 Q1 | Crash logs, perf budgets, audits | Aligns with Phase 4 |
-| **E4** | Post-v1 | ADRs, CODEOWNERS | Optional |
+## Path to v1.0
 
-**Scorecard:** [docs/engineering/quality-scorecard.md](docs/engineering/quality-scorecard.md)
+### Trust
 
----
+- Sign and notarize macOS releases (tooling exists; builds still ship unsigned)
+- Sign Windows installers
+- Keep crash logs and startup failures visible
 
-## Product Phase 1 — Release blockers
+### Platforms
 
-**Target:** 2026 Q2 · **Must complete before v1.0**
+- Finish Linux parity where it still feels thin (native menus, file drop)
+- Linux ARM64 release artifacts
+- Prefer measurable gates over packaging sprawl (Flatpak/Copr only if someone owns them)
 
-### Distribution & trust
+### Product
 
-| Item | Platform | Eng dep | Reference |
-|------|----------|---------|-----------|
-| macOS code signing + notarization | macOS | E3 release scripts | [#225](https://github.com/termy-org/termy/issues/225) |
-| Windows code signing (EV certificate) | Windows | E3 | — |
-| Replace placeholder bundle ID (`com.example.termy`) | All | — | — |
+- Multiple GPUI windows
+- MRU tab switching (issue closed; behavior not in tree yet)
+- Optional font ligatures
+- Accessibility pass on the GPUI app
 
-### Critical bugs
 
-| Item | Platform | Eng dep | Reference |
-|------|----------|---------|-----------|
-| Theme deeplink not working on Windows | Windows | — | [#288](https://github.com/termy-org/termy/issues/288) |
-| Settings close button on Appearance tab | Windows | — | [#281](https://github.com/termy-org/termy/issues/281) |
+## After v1.0
 
-### Terminal correctness
+Polish, not blockers.
 
-| Item | Platform | Eng dep | Reference |
-|------|----------|---------|-----------|
-| ~~Proper OSC sequence support~~ ✅ Done — incl. OSC 8 hyperlinks in both apps | All | E2 tests for escapes | [#149](https://github.com/termy-org/termy/issues/149) (closed) |
+- Migration guides (Ghostty, Alacritty, iTerm2, Windows Terminal)
+- Broader image-protocol coverage if needed beyond Kitty
+- Perf budgets that stay green without babysitting
+- ADRs / CODEOWNERS when contributor volume warrants it
 
----
 
-## Product Phase 2 — Platform parity
+## Engineering
 
-**Target:** 2026 Q3
+Pipeline trust (E0) is landed. Ongoing work — file budgets, `terminal_view` decomposition, tmux/FFI confidence, operability — lives here:
 
-| Area | Items | Eng dep |
-|------|-------|---------|
-| **Windows** | Agent sidebar (`agents_windows.rs`); auto-update/deeplink/installer CI | E2.4 when touching config |
-| **Linux** | Context menus; file drop; ARM64 CI; Flatpak/Copr | Native SDK boundaries |
+- [Engineering roadmap](docs/engineering/roadmap.md)
+- [Quality scorecard](docs/engineering/quality-scorecard.md) (~9/12 · target 10/12 for v1.0)
 
----
-
-## Product Phase 3 — Feature completion
-
-**Target:** 2026 Q3–Q4
-
-### Core
-
-| Item | Eng dep | Reference |
-|------|---------|-----------|
-| Multiple window support | **E1 tranche 1** (session/window glue) | — |
-| MRU tab switching | **E1 tranche 2** | [#240](https://github.com/termy-org/termy/issues/240) |
-| Ghostty config compatibility | Config tests + doc gen | [#290](https://github.com/termy-org/termy/issues/290) |
-| Font ligatures | Render path | — |
-| Sixel / image protocols | **E1 tranche 4** (render/) | — |
-
-### Agent workspace
-
-| Item | Eng dep | Reference |
-|------|---------|-----------|
-| Agent workspace feedback | Crate boundary decision | [#286](https://github.com/termy-org/termy/issues/286) |
-| `crates/agents` — implement or remove | `check-boundaries` | — |
-
----
-
-## Product Phase 4 — Production hardening
-
-**Target:** 2026 Q4 · **Overlaps engineering E2–E3**
-
-| Area | Items | Eng phase |
-|------|-------|-----------|
-| **Stability** | Crash log on panic; graceful startup errors; tab/tmux/scrollback stress | E3.1–E3.2, E2.6 |
-| **Performance** | CI benchmark suite; 100k+ scrollback validation | E3.3–E3.4 |
-| **Accessibility** | Screen reader labels; keyboard nav; high contrast | — |
-| **Cleanup** | Sync sub-crate versions; optional `termy_api` extract | E4 |
-
----
-
-## Product Phase 5 — Launch
-
-**Target:** 2027 Q1 · **v1.0 tag**
-
-- User docs: config, keybinds, themes, CLI (website + generated repo docs)
-- Migration guides: Ghostty, Alacritty, iTerm2, Windows Terminal
-- v1 changelog; license audit; termy.sh polish
-- **Gate:** E0 complete; scorecard ≥10/12; Phase 1 closed
-
----
-
-## Priority matrix
-
-| Priority | Product | Engineering |
-|----------|---------|-------------|
-| **P0** | Signing, bundle ID, OSC, open Windows bugs | **E0** (CI tests, fmt, validate) |
-| **P1** | Windows agent, Linux menus, multi-window, crash reporting | **E1** tranche 1–2, **E2.1** tmux CI |
-| **P2** | MRU, Ghostty compat, Linux packaging, benchmarks | **E1** tranche 3–4, **E3** perf |
-| **P3** | A11y, image protocols, ligatures, launch docs | **E4** scale |
-
----
-
-## Milestones
-
-| Milestone | Product criteria | Engineering criteria | Target |
-|-----------|------------------|----------------------|--------|
-| **M0 — Trust pipeline** | — | G3, G4, G5, G12 met | 2026 Q2 |
-| **M1 — Beta quality** | Phase 1 done; Phase 2 started | E1 tranche 1 done; G7 reliable | 2026 Q3 |
-| **M2 — Feature complete** | Phase 3 core items done | `mod.rs` &lt; 2k lines | 2026 Q4 |
-| **M3 — v1.0** | Phase 5 | Scorecard 10/12; E0–E3 core met | 2027 Q1 |
-
----
-
-## Already solid (defend with gates)
-
-These areas are production-ready—**keep them that way** via existing automation:
-
-| Capability | Defended by |
-|--------------|-------------|
-| Tabs, drag-reorder, pinning | Tests in `tabs/`, `tab_strip/` |
-| tmux splits & sessions | `test-tmux-integration` (E2.1: always run in CI) |
-| Theme store & deeplink | `deeplink` tests; platform QA |
-| Auto-update | `auto_update` crate tests; release scripts |
-| Config + live reload | `config_core` parser tests; generated doc `--check` |
-| Command palette & search | `command_core` + `search` tests |
-| Settings UI | `settings_view` tests |
-| CLI companion | `termy_cli` tests |
-| Crate boundaries | `just check-boundaries` |
-
----
-
-## Reviews
-
-- **Monthly:** Update [quality-scorecard.md](docs/engineering/quality-scorecard.md)
-- **Quarterly:** Adjust phases, defer stale items, refresh baseline stats in this file
-- **Per release:** One engineering tranche *or* one test/CI hardening item
-
----
 
 ## Related
 
 - [CONTRIBUTING.md](CONTRIBUTING.md)
-- [docs/architecture/project-layout.md](docs/architecture/project-layout.md)
-- [docs/engineering/](docs/engineering/)
+- [Project layout](docs/architecture/project-layout.md)
+- [Native macOS production](macos/road.md)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rewrites the product roadmap to match the codebase as of `0.2.29`.

### Why
The old roadmap still listed closed Phase 1 bugs, a placeholder bundle ID, an agents crate, and a `0.3.0` / 17-crate baseline. A lot of that no longer matches the tree.

### What changed
- Shorter, airier structure: north star → solid → path to v1.0 → after → engineering links
- Baseline updated (`0.2.29`, 21 crates, ~127k LOC, ~1,400 tests)
- Done items removed from the active plan (OSC, deeplink, settings close, Ghostty-style config, Kitty graphics, plugins/SSH, etc.)
- Remaining v1.0 focus: signing/notarization, platform gaps, multi-window, MRU, ligatures, a11y
- Engineering detail stays in `docs/engineering/`; native cutover points at `macos/road.md`

No code or CI changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb029fcc-3f7e-4bfc-8757-66989c22286c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb029fcc-3f7e-4bfc-8757-66989c22286c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

