### PR TITLE
feat(ci): publish native macOS beta DMGs from a dedicated workflow

### DIFF
--- a/.github/workflows/macos-native-release.yml
+++ b/.github/workflows/macos-native-release.yml
@@ -1,0 +1,303 @@
+name: macOS Native Release
+
+# Builds and publishes the native macOS SwiftUI host from `macos/` for Apple
+# silicon and Intel. Deliberately separate from `release.yml`: the native host
+# is a public beta with its own tag, its own GitHub release, and its own gates,
+# so a native failure can never block or alter the product release.
+
+on:
+  push:
+    tags:
+      - "macos-native-v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version, e.g. 0.2.29 (a -preview.N suffix republishes the same app version)
+        required: true
+        type: string
+      publish:
+        description: Publish the GitHub release (uncheck to build and gate only)
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: macos-native-release-${{ github.event_name == 'push' && github.ref_name || inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    name: Resolve release version
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      tag: ${{ steps.resolve.outputs.tag }}
+      release_version: ${{ steps.resolve.outputs.release_version }}
+      app_version: ${{ steps.resolve.outputs.app_version }}
+      publish: ${{ steps.resolve.outputs.publish }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Resolve and validate version
+        id: resolve
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          TAG_REF: ${{ github.ref_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_PUBLISH: ${{ inputs.publish }}
+        run: |
+          if [[ "$EVENT_NAME" == "push" ]]; then
+            tag="$TAG_REF"
+            release_version="${tag#macos-native-v}"
+            publish=true
+          else
+            release_version="${INPUT_VERSION#v}"
+            tag="macos-native-v${release_version}"
+            publish="${INPUT_PUBLISH:-true}"
+          fi
+
+          [[ "$release_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]] || {
+            echo "Release version must be semver with an optional prerelease suffix: $release_version" >&2
+            exit 1
+          }
+
+          # The bundled app version stays numeric and authoritative. A tag may
+          # carry a -preview.N suffix to republish the same app version.
+          app_version="${release_version%%-*}"
+          source_version="$(awk '/^version = / { gsub(/"/, "", $3); print $3; exit }' crates/desktop_app/Cargo.toml)"
+          [[ "$app_version" == "$source_version" ]] || {
+            echo "App version $app_version does not match source version $source_version" >&2
+            exit 1
+          }
+
+          {
+            echo "tag=$tag"
+            echo "release_version=$release_version"
+            echo "app_version=$app_version"
+            echo "publish=$publish"
+          } >> "$GITHUB_OUTPUT"
+
+  verify:
+    name: Swift verification
+    needs: resolve
+    runs-on: macos-26
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      # The Swift host uses Swift 6.2 features (isolated conformances), but the
+      # runner image defaults to Xcode 16.x / Swift 6.1. Select the newest
+      # Xcode 26.x available on the image instead.
+      - name: Select Xcode with Swift 6.2
+        run: |
+          xcode_app="$(ls -d /Applications/Xcode_26*.app | sort -V | tail -n 1)"
+          echo "Selecting ${xcode_app}"
+          sudo xcode-select -s "${xcode_app}/Contents/Developer"
+          swift --version
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Build libtermy FFI
+        run: cargo build -p termy_ffi
+
+      - name: Build Swift app
+        run: TERMY_FFI_LIBRARY_PATH="$PWD/target/debug" swift build --package-path macos -Xswiftc -warnings-as-errors
+
+      - name: Swift test suite
+        run: TERMY_FFI_LIBRARY_PATH="$PWD/target/debug" swift test --package-path macos
+
+      - name: Static release readiness checks
+        run: ./macos/scripts/check-release-readiness.sh
+
+  build:
+    name: Build ${{ matrix.arch }} DMG
+    needs: [resolve, verify]
+    runs-on: macos-26
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arm64
+            target: aarch64-apple-darwin
+          - arch: x86_64
+            target: x86_64-apple-darwin
+    env:
+      APP_VERSION: ${{ needs.resolve.outputs.app_version }}
+      RELEASE_VERSION: ${{ needs.resolve.outputs.release_version }}
+      ARCH: ${{ matrix.arch }}
+      TARGET: ${{ matrix.target }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Select Xcode with Swift 6.2
+        run: |
+          xcode_app="$(ls -d /Applications/Xcode_26*.app | sort -V | tail -n 1)"
+          echo "Selecting ${xcode_app}"
+          sudo xcode-select -s "${xcode_app}/Contents/Developer"
+          swift --version
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+          targets: ${{ matrix.target }}
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      # Also runs check-release-readiness.sh against the finished DMG: Mach-O
+      # architecture, bundle manifest, read-only mount, and a usable-window
+      # launch of the mounted app.
+      - name: Build unsigned DMG
+        run: >-
+          ./macos/scripts/build-dmg.sh
+          --version "$APP_VERSION"
+          --arch "$ARCH"
+          --target "$TARGET"
+          --no-layout
+
+      - name: Verify isolated CLI install
+        run: ./macos/scripts/check-cli-install-smoke.sh --app "macos/.build/dmg-${ARCH}/Termy.app"
+
+      - name: Launch performance gate
+        run: >-
+          ./macos/scripts/check-launch-gate.sh
+          --app "macos/.build/dmg-${ARCH}/Termy.app"
+          --output "macos/dist/native-launch-${ARCH}.json"
+
+      - name: Soak gate
+        run: >-
+          ./macos/scripts/check-native-soak.sh
+          --app "macos/.build/dmg-${ARCH}/Termy.app"
+          --duration-seconds 30
+          --minimum-cycles 30
+          --output "macos/dist/native-soak-${ARCH}.json"
+
+      - name: Prove corruption gates
+        run: >-
+          ./macos/scripts/check-release-readiness-regressions.sh
+          --app "macos/.build/dmg-${ARCH}/Termy.app"
+          --arch "$ARCH"
+          --version "$APP_VERSION"
+
+      # Published under a `native` name so a downloaded preview DMG is never
+      # mistaken for the GPUI desktop artifact, which uses the same
+      # Termy-<version>-macos-<arch>.dmg pattern.
+      - name: Stage publishable assets
+        run: |
+          mkdir -p macos/dist/publish
+          built="macos/dist/Termy-${APP_VERSION}-macos-${ARCH}.dmg"
+          asset="Termy-native-${RELEASE_VERSION}-macos-${ARCH}.dmg"
+          cp "$built" "macos/dist/publish/${asset}"
+          (cd macos/dist/publish && shasum -a 256 "$asset" > "${asset}.sha256")
+          {
+            echo "source_commit=$GITHUB_SHA"
+            echo "release_version=$RELEASE_VERSION"
+            echo "app_version=$APP_VERSION"
+            echo "architecture=$ARCH"
+            echo "target=$TARGET"
+            echo "signed=false"
+            echo "rustc=$(rustc --version)"
+            echo "swift=$(swift --version | head -n 1)"
+            echo "xcode=$(xcodebuild -version | tr '\n' ' ')"
+          } > "macos/dist/publish/native-release-${ARCH}.metadata"
+          cat "macos/dist/publish/${asset}.sha256"
+
+      - name: Upload native release artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: termy-native-release-${{ matrix.arch }}
+          path: |
+            macos/dist/publish/Termy-native-*-macos-${{ matrix.arch }}.dmg
+            macos/dist/publish/Termy-native-*-macos-${{ matrix.arch }}.dmg.sha256
+            macos/dist/publish/native-release-${{ matrix.arch }}.metadata
+            macos/dist/native-launch-${{ matrix.arch }}.json
+            macos/dist/native-soak-${{ matrix.arch }}.json
+            macos/dist/native-soak-${{ matrix.arch }}.log
+          if-no-files-found: error
+          retention-days: 30
+
+  publish:
+    name: Publish native release
+    needs: [resolve, build]
+    if: needs.resolve.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Generate SHA256 checksums
+        run: |
+          cd dist
+          find . -maxdepth 1 -type f -name '*.dmg' -print0 \
+            | sort -z \
+            | xargs -0 sha256sum > checksums.txt
+          cat checksums.txt
+
+      - name: Write release notes
+        env:
+          RELEASE_VERSION: ${{ needs.resolve.outputs.release_version }}
+          APP_VERSION: ${{ needs.resolve.outputs.app_version }}
+        run: |
+          cat > release-notes.md <<EOF
+          Native macOS SwiftUI host built from \`macos/\`, backed by repo-local \`libtermy\`.
+          This is the public beta, published separately from the GPUI desktop app, which
+          ships from the \`Release\` workflow.
+
+          | Download | Macs |
+          | --- | --- |
+          | \`Termy-native-${RELEASE_VERSION}-macos-arm64.dmg\` | Apple silicon |
+          | \`Termy-native-${RELEASE_VERSION}-macos-x86_64.dmg\` | Intel |
+
+          App version \`${APP_VERSION}\`, built from \`${GITHUB_SHA}\`. Requires macOS 14 or newer.
+
+          **These builds are unsigned** — no Developer ID signature, no notarization.
+          After dragging Termy to Applications, clear the quarantine flag:
+
+          \`\`\`sh
+          xattr -dr com.apple.quarantine /Applications/Termy.app
+          \`\`\`
+
+          Both architectures passed, per architecture: unsigned release readiness
+          (Mach-O architecture, bundle manifest, read-only DMG mount, usable-window
+          launch), isolated CLI install smoke, launch performance budget, a 30-second
+          soak, and bundle/DMG corruption rejection. Per-file checksums are in
+          \`checksums.txt\` and alongside each DMG; build provenance is in the
+          \`.metadata\` files.
+          EOF
+          cat release-notes.md
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        with:
+          tag_name: ${{ needs.resolve.outputs.tag }}
+          name: Termy Native macOS ${{ needs.resolve.outputs.release_version }}
+          body_path: release-notes.md
+          prerelease: true
+          make_latest: false
+          files: |
+            dist/*.dmg
+            dist/*.dmg.sha256
+            dist/*.metadata
+            dist/checksums.txt
+          fail_on_unmatched_files: true
+          overwrite_files: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this is
 
-Termy is a terminal emulator built with GPUI (Zed's UI framework) and `alacritty_terminal`. It is a Rust workspace plus an experimental native macOS SwiftUI host (`macos/`) and a website (`website/`).
+Termy is a terminal emulator built with GPUI (Zed's UI framework) and `alacritty_terminal`. It is a Rust workspace plus a public-beta native macOS SwiftUI host (`macos/`) and a website (`website/`).
 
 ## Commands
 
@@ -43,7 +43,7 @@ Product surfaces:
 - `crates/desktop_app/` (`termy`): the GPUI desktop app — windows, chrome, settings, menus, command execution. The only crate that owns complete user-facing desktop workflows. `src/terminal_view/` owns the GPUI terminal experience (rendering, tabs, panes, command palette, search UI, input handling).
 - `crates/cli/` (`termy_cli`): `termy-cli` companion.
 - `crates/ffi/` (`termy_ffi`): C-compatible libtermy surface; must wrap `termy_core`, not copy desktop app behavior. Header at `crates/ffi/include/termy.h`.
-- `macos/`: experimental native SwiftUI host consuming libtermy via FFI. Swift tests live in `macos/Tests/TermySwiftTests/`; config schema parity between Rust and Swift is tested (`SettingsSchemaParityTests`).
+- `macos/`: public-beta native SwiftUI host consuming libtermy via FFI. Swift tests live in `macos/Tests/TermySwiftTests/`; config schema parity between Rust and Swift is tested (`SettingsSchemaParityTests`).
 
 Runtime and UI:
 - `crates/core/` (`termy_core`): headless terminal runtime/API for embedders. **Must stay free of GPUI and app UI code.**

--- a/docs/architecture/release-packaging.md
+++ b/docs/architecture/release-packaging.md
@@ -49,6 +49,12 @@ Browser tabs use Wry native webviews:
 - Keep platform-specific installer definitions under `scripts/installer/` unless a platform needs a larger packaging tree.
 - Do not restore obsolete `macos/` packaging paths without moving the scripts, docs, `justfile`, and release workflow together.
 
+## Native macOS Host (Public Beta)
+
+The Swift host in `macos/` is packaged on its own: `macos/scripts/build-dmg.sh` produces `macos/dist/Termy-<version>-macos-<arch>.dmg`, and `.github/workflows/macos-native-release.yml` publishes it as `Termy-native-<version>-macos-<arch>.dmg` on a `macos-native-v*` tag, in a prerelease of its own. See `macos/docs/native-release.md`.
+
+That tree is not product packaging. `scripts/` remains the only source of truth for the GPUI desktop app, and `.github/workflows/release.yml` must never reference `macos/scripts` or `macos/dist` — `scripts/check-boundaries.sh` enforces it.
+
 ## Validation
 
 Run these checks after packaging or release workflow changes:

--- a/macos/README.md
+++ b/macos/README.md
@@ -1,9 +1,12 @@
 # Termy
 
-Developer preview. The native host is feature-rich, but it is not yet the
-default production macOS build.
+Public beta. The native host is feature-rich and open to everyone, but it is not
+yet the default production macOS build.
 
 Native macOS 14+ SwiftUI terminal host backed by the repo-local `libtermy`.
+
+Beta builds are unsigned and ship from their own `macos-native-v*` tag, separate
+from the GPUI desktop app — see [Release](#release).
 
 See the [native production roadmap](road.md) for current blockers, exit gates,
 and release order.
@@ -70,4 +73,20 @@ Performance benchmark summaries from `cargo run -p xtask -- benchmark-compare` c
 
 ```sh
 ./scripts/check-performance-gates.sh --summary target/macos-performance-gate/summary.json
+```
+
+## Release
+
+Push a `macos-native-v<version>` tag (or dispatch the `macOS Native Release`
+workflow) to build arm64 and Intel DMGs, run the release gates, and publish them
+as their own public-beta prerelease — separate from the GPUI desktop app's
+`Release` workflow. See [native release](docs/native-release.md) for versioning
+rules, gates, and local reproduction, and [native candidate
+release](docs/native-candidate-release.md) for unpublished candidate builds.
+
+Beta DMGs carry no Developer ID signature or notarization, so first launch needs
+the quarantine flag cleared:
+
+```sh
+xattr -dr com.apple.quarantine /Applications/Termy.app
 ```

--- a/macos/docs/native-candidate-release.md
+++ b/macos/docs/native-candidate-release.md
@@ -36,4 +36,7 @@ shasum -a 256 "macos/dist/Termy-${version}-macos-${arch}.dmg"
 ```
 
 The workflow is intentionally unsigned. Developer ID signing, notarization,
-stapling, Gatekeeper validation, and publication remain the final release task.
+stapling, and Gatekeeper validation remain the final release task.
+
+To publish a candidate, tag it and let the `macOS Native Release` workflow build
+and attach both architectures — see [native release](native-release.md).

--- a/macos/docs/native-release.md
+++ b/macos/docs/native-release.md
@@ -1,0 +1,116 @@
+# Native macOS release
+
+The `macOS Native Release` workflow
+(`.github/workflows/macos-native-release.yml`) builds the native Swift/AppKit
+host from `macos/` for Apple silicon and Intel and publishes both DMGs to their
+own GitHub release.
+
+It is deliberately separate from the public `Release` workflow. The native host
+is a public beta: it ships on its own tag, with its own gates and its own
+release page, so a native failure can never block or alter the GPUI desktop
+artifacts, and the two DMGs never land in the same release.
+
+Related workflows:
+
+- [`macOS Native Candidates`](native-candidate-release.md) — unpublished,
+  30-day candidate artifacts. Use it to hand a build around before tagging.
+- `macOS Native Swift` — per-PR tests plus an unsigned build gate for both
+  architectures. Nothing is published.
+
+## Publishing
+
+Tag the candidate commit and push:
+
+```sh
+version="$(awk '/^version = / { gsub(/"/, "", $3); print $3; exit }' crates/desktop_app/Cargo.toml)"
+git tag "macos-native-v${version}"
+git push origin "macos-native-v${version}"
+```
+
+Or dispatch `macOS Native Release` manually with the same version. Clear the
+`publish` checkbox to run the full build and every gate without creating a
+release — the DMGs are still uploaded as Actions artifacts.
+
+## Versioning
+
+`crates/desktop_app/Cargo.toml` stays the authoritative version. The workflow
+refuses to build when the tag disagrees with it.
+
+A tag may carry a prerelease suffix — `macos-native-v0.2.29-preview.2` — to
+republish the same app version. The suffix travels into the release name and
+the DMG file names; the version inside the bundle stays numeric.
+
+## Artifacts
+
+Published to a prerelease GitHub release at the tag, never marked latest:
+
+- `Termy-native-<release version>-macos-arm64.dmg`
+- `Termy-native-<release version>-macos-x86_64.dmg`
+- a `.sha256` next to each DMG, plus a combined `checksums.txt`
+- `native-release-<arch>.metadata` — source commit, versions, target, Rust,
+  Swift, and Xcode versions
+
+The `native` infix is deliberate. `macos/scripts/build-dmg.sh` produces
+`Termy-<version>-macos-<arch>.dmg`, the same name the GPUI desktop app uses, so
+the published copy is renamed to keep a downloaded beta distinguishable from the
+product build once it leaves the release page. Both install as `Termy.app` with
+the same bundle identifier, so they overwrite each other in `/Applications`.
+
+The launch and soak JSON reports are kept as Actions artifacts for 30 days and
+are not attached to the release.
+
+## Gates
+
+`resolve` validates the version, then `verify` builds the Swift host with
+warnings as errors and runs the full `swift test` suite once. Each architecture
+then runs:
+
+| Gate | What it proves |
+| --- | --- |
+| `build-dmg.sh` (runs `check-release-readiness.sh --dmg`) | Bundle manifest, Mach-O architecture and load paths, read-only DMG contents, usable-window launch of the mounted app |
+| `check-cli-install-smoke.sh` | "Install Command Line Tool…" works against an isolated HOME and shell profile |
+| `check-launch-gate.sh` | Usable-window startup budget, settled CPU, one-tab and eight-pane RSS |
+| `check-native-soak.sh` (30s, 30 cycles) | No window, pane, or RSS leak across PTY/resize/split/tab cycles |
+| `check-release-readiness-regressions.sh` | The readiness gate actually rejects corrupted bundles and DMGs |
+
+Render performance is intentionally not gated here — it runs in
+`macOS Performance` where a threshold miss blocks a change instead of a
+release.
+
+## Signing
+
+These builds are unsigned: no Developer ID signature, no notarization, no
+stapling. Release notes tell downloaders to clear quarantine:
+
+```sh
+xattr -dr com.apple.quarantine /Applications/Termy.app
+```
+
+`macos/scripts/build-dmg.sh` already accepts `--sign-identity`, entitlements,
+and notary credentials, so signing this pipeline is wiring a certificate into
+the runner keychain and passing those flags — not new packaging work.
+
+## Local reproduction
+
+Same build and gates as one matrix leg:
+
+```sh
+version="$(awk '/^version = / { gsub(/"/, "", $3); print $3; exit }' crates/desktop_app/Cargo.toml)"
+arch="$(uname -m)"
+case "$arch" in
+  arm64) target="aarch64-apple-darwin" ;;
+  x86_64) target="x86_64-apple-darwin" ;;
+  *) echo "unsupported architecture: $arch" >&2; exit 1 ;;
+esac
+
+./macos/scripts/build-dmg.sh --version "$version" --arch "$arch" --target "$target" --no-layout
+./macos/scripts/check-cli-install-smoke.sh --app "macos/.build/dmg-${arch}/Termy.app"
+./macos/scripts/check-launch-gate.sh --app "macos/.build/dmg-${arch}/Termy.app"
+./macos/scripts/check-native-soak.sh --app "macos/.build/dmg-${arch}/Termy.app" \
+  --duration-seconds 30 --minimum-cycles 30
+./macos/scripts/check-release-readiness-regressions.sh \
+  --app "macos/.build/dmg-${arch}/Termy.app" --arch "$arch" --version "$version"
+```
+
+Cross-building the other architecture works from either host; the launch and
+soak gates run the foreign slice through Rosetta.

--- a/macos/roadmap.md
+++ b/macos/roadmap.md
@@ -2,7 +2,7 @@
 
 Status date: 2026-07-10
 
-The native SwiftUI/AppKit host is a **developer preview**. This document records
+The native SwiftUI/AppKit host is in **public beta**. This document records
 the implementation milestones that are already complete. It is not the active
 release checklist.
 


### PR DESCRIPTION
Adds `.github/workflows/macos-native-release.yml`: builds the native Swift host from `macos/` for Apple silicon and Intel and publishes both DMGs.

Nothing published the native host before. `macOS Native Swift` gates it per PR and `macOS Native Candidates` keeps builds as Actions artifacts — both by design.

## Shape

- **Separate from `release.yml`.** Own trigger (`macos-native-v*` tag or manual dispatch), own prerelease, never marked latest. A native failure can neither block nor alter the GPUI desktop artifacts, and the two DMGs never share a release.
- **Versioning.** `crates/desktop_app/Cargo.toml` stays authoritative and the build refuses a mismatched tag. A tag may carry `-preview.N` to republish the same app version; the version inside the bundle stays numeric.
- **Dry run.** Dispatch with `publish` unchecked to run the full build and every gate without creating a release.

## Jobs

| Job | Does |
| --- | --- |
| `resolve` | Parses the tag/input, validates semver, matches it against the source version — fails before any macOS runner starts |
| `verify` | Swift build with warnings-as-errors, full `swift test`, static readiness checks |
| `build` (arm64, x86_64) | Unsigned DMG + release gates, stages publishable assets |
| `publish` | Combined checksums, release notes, prerelease at the tag |

Per-architecture gates: unsigned release readiness via `build-dmg.sh` (Mach-O arch, bundle manifest, read-only DMG mount, usable-window launch), isolated CLI install smoke, launch performance budget, a 30-second soak, and bundle/DMG corruption rejection. Render performance stays in `macOS Performance`, where a threshold miss should block a change rather than a release.

## Artifacts

Published DMGs are renamed `Termy-native-<version>-macos-<arch>.dmg`. `macos/scripts/build-dmg.sh` emits `Termy-<version>-macos-<arch>.dmg`, the exact name the GPUI desktop app uses, so a downloaded file would otherwise carry no signal of which build it is — they install as the same `Termy.app` with the same bundle identifier. Each DMG ships a `.sha256`, a combined `checksums.txt`, and a `.metadata` file with source commit and toolchain versions. Launch/soak JSON reports stay as 30-day Actions artifacts.

Builds are unsigned; release notes carry the quarantine-clearing command. `build-dmg.sh` already accepts `--sign-identity` and notary credentials, so signing later is wiring, not packaging work.

## Beta status

Records the native host's move from developer preview to public beta in `macos/README.md`, `macos/roadmap.md`, and `CLAUDE.md`.

## Validation

- Workflow YAML parses; job graph is `resolve → verify → build (matrix) → publish`.
- Version-resolution logic exercised locally against tag push, dispatch, a `-preview.N` suffix, a malformed version, and a version that disagrees with `Cargo.toml` — accepts and rejects as intended.
- Asset staging (copy, bare-filename checksum, metadata) run locally.
- `./scripts/check-boundaries.sh` passes except a pre-existing `docs/configuration.md` drift on `main` (`theme_light` default documented as `termy`, source says `termy-light`) — untouched here.
- Untrusted inputs (`inputs.version`, `github.ref_name`) are passed through `env:` and only read as shell variables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)