### PR TITLE
Expose the buffer as text, scrollback included

### DIFF
--- a/crates/core/src/runtime.rs
+++ b/crates/core/src/runtime.rs
@@ -18,7 +18,7 @@ use crate::shell_integration::ProgressState;
 use alacritty_terminal::{
     event::{Event as AlacEvent, EventListener, OnResize, WindowSize},
     grid::{Dimensions, Scroll},
-    index::{Column, Line},
+    index::{Column, Line, Point},
     sync::FairMutex,
     term::{Config as TermConfig, LineDamageBounds, Term, TermDamage, TermMode, cell::Flags},
     thread,
@@ -2478,6 +2478,34 @@ impl Terminal {
     /// Capture a renderer-neutral snapshot of the visible terminal frame.
     pub fn snapshot(&self) -> TermyFrame {
         self.with_term(|term| snapshot_from_term(term, self.size, self.query_colors))
+    }
+
+    /// The buffer as plain text, scrollback included.
+    ///
+    /// Frames only ever describe the viewport, so an embedder that wants the
+    /// whole buffer — to persist a session, or to render a thumbnail of a pane
+    /// it is not currently showing — cannot reach the scrollback through
+    /// [`Self::snapshot`] at any scroll position.
+    ///
+    /// With `scrollback_only`, returns just the rows above the viewport. That
+    /// is empty both for an unscrolled primary screen and for an alternate
+    /// screen, which together let a caller tell a shell at its prompt from a
+    /// full-screen TUI.
+    pub fn buffer_text(&self, scrollback_only: bool) -> String {
+        self.with_term(|term| {
+            let topmost = term.topmost_line();
+            let last_line = if scrollback_only {
+                Line(-1)
+            } else {
+                term.bottommost_line()
+            };
+            if last_line < topmost {
+                return String::new();
+            }
+            let start = Point::new(topmost, Column(0));
+            let end = Point::new(last_line, term.last_column());
+            term.bounds_to_string(start, end)
+        })
     }
 
     /// Capture a damage-scoped visible-frame update for incremental renderers.

--- a/crates/core/tests/buffer_text.rs
+++ b/crates/core/tests/buffer_text.rs
@@ -1,0 +1,54 @@
+use termy_core::{Terminal, TerminalSize};
+
+fn size(cols: u16, rows: u16) -> TerminalSize {
+    TerminalSize {
+        cols,
+        rows,
+        cell_width: 9.0,
+        cell_height: 18.0,
+    }
+}
+
+/// Frames only ever describe the viewport, so the point of `buffer_text` is
+/// reaching rows that have already scrolled off it.
+#[test]
+fn buffer_text_includes_rows_scrolled_out_of_the_viewport() {
+    let terminal = Terminal::new_display(size(20, 4), None);
+    for line in 0..12 {
+        terminal.feed_output(format!("line{line}\r\n").as_bytes());
+    }
+
+    let text = terminal.buffer_text(false);
+
+    // Long gone from the viewport, still in the buffer.
+    assert!(text.contains("line0"), "missing scrolled-off row: {text:?}");
+    assert!(text.contains("line11"), "missing latest row: {text:?}");
+}
+
+#[test]
+fn scrollback_only_omits_the_viewport() {
+    let terminal = Terminal::new_display(size(20, 4), None);
+    for line in 0..12 {
+        terminal.feed_output(format!("line{line}\r\n").as_bytes());
+    }
+
+    let scrollback = terminal.buffer_text(true);
+
+    assert!(scrollback.contains("line0"));
+    // line11 is on screen, so it is not scrollback.
+    assert!(
+        !scrollback.contains("line11"),
+        "viewport leaked into scrollback: {scrollback:?}"
+    );
+}
+
+/// Empty scrollback is how a caller tells a shell sitting at its prompt from a
+/// full-screen TUI, so it must not report the visible rows.
+#[test]
+fn scrollback_only_is_empty_before_anything_scrolls() {
+    let terminal = Terminal::new_display(size(20, 8), None);
+    terminal.feed_output(b"just one line\r\n");
+
+    assert!(terminal.buffer_text(true).trim().is_empty());
+    assert!(terminal.buffer_text(false).contains("just one line"));
+}

--- a/crates/ffi/include/termy.h
+++ b/crates/ffi/include/termy.h
@@ -532,6 +532,13 @@ TermyFfiStatus termy_terminal_set_scrollback_history(
 TermyFfiStatus termy_terminal_bracketed_paste_mode(
     TermyFfiTerminal *terminal,
     bool *out_enabled);
+/* The buffer as plain UTF-8 text, scrollback included. With scrollback_only,
+ * just the rows above the viewport — empty for both an unscrolled primary
+ * screen and an alternate screen. Free with termy_buffer_free. */
+TermyFfiStatus termy_terminal_buffer_text(
+    TermyFfiTerminal *terminal,
+    bool scrollback_only,
+    TermyFfiBytes *out_bytes);
 TermyFfiStatus termy_terminal_snapshot(
     TermyFfiTerminal *terminal,
     TermyFfiFrame *out_frame);

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -2973,6 +2973,30 @@ pub unsafe extern "C" fn termy_terminal_bracketed_paste_mode(
     })
 }
 
+/// The buffer as plain UTF-8 text, scrollback included. With
+/// `scrollback_only`, just the rows above the viewport — empty for both an
+/// unscrolled primary screen and an alternate screen.
+///
+/// Free the result with `termy_buffer_free`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn termy_terminal_buffer_text(
+    terminal: *mut TermyFfiTerminal,
+    scrollback_only: bool,
+    out_bytes: *mut TermyFfiBytes,
+) -> TermyFfiStatus {
+    ffi_status_guard(|| {
+        if terminal.is_null() || out_bytes.is_null() {
+            return TermyFfiStatus::Null;
+        }
+
+        unsafe {
+            let text = (*terminal).terminal.buffer_text(scrollback_only);
+            *out_bytes = ffi_bytes_from_string(text);
+        }
+        TermyFfiStatus::Ok
+    })
+}
+
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn termy_terminal_snapshot(
     terminal: *mut TermyFfiTerminal,


### PR DESCRIPTION
`TermyFrame` only ever describes the viewport, so an embedder has no way to reach rows that have scrolled off it — not at any scroll position, since `snapshot` always returns the visible frame.

That rules out two things a host reasonably wants:

- **Persisting a session.** Saving a pane's scrollback to restore on relaunch.
- **Thumbnailing an off-screen pane.** Rendering a preview of a pane you aren't currently displaying — there's no frame to read, and scrolling a pane you aren't showing to harvest it isn't reasonable.

I hit both embedding libtermy in a macOS terminal workspace: session restore and the tab-switcher previews had nowhere to get their text.

## Change

`Terminal::buffer_text(scrollback_only)` plus the matching `termy_terminal_buffer_text` FFI entry point, built on alacritty's `bounds_to_string` over `topmost_line()..=bottommost_line()`.

`scrollback_only` returns just the rows above the viewport. It's empty both for an unscrolled primary screen and for an alternate screen — together that lets a caller tell a shell sitting at its prompt from a full-screen TUI, which is what you want when deciding whether a captured buffer is worth persisting at all.

Additive: no existing behaviour changes.

## Tests

`crates/core/tests/buffer_text.rs` — 3 tests:

- rows scrolled out of the viewport are still returned
- `scrollback_only` excludes the visible rows
- `scrollback_only` is empty before anything has scrolled

All pass. Note the pre-existing, unrelated failure in `crates/core/tests/resize_clear.rs::clear_keeps_scrollback_hidden_while_resizing`, which is also red on `main` at c3d80b1 without this change.

Independent of #366 — both branch off `main` and touch different code, so they can land in either order.
