### PR TITLE
Refresh command palette and expand plugin surfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8616,7 +8616,7 @@ dependencies = [
 
 [[package]]
 name = "termy"
-version = "0.2.30"
+version = "0.2.31"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
@@ -8702,7 +8702,7 @@ dependencies = [
 
 [[package]]
 name = "termy_cli"
-version = "0.2.30"
+version = "0.2.31"
 dependencies = [
  "clap",
  "core-foundation 0.10.0",

--- a/crates/desktop_app/src/terminal_view/command_palette/fuzzy.rs
+++ b/crates/desktop_app/src/terminal_view/command_palette/fuzzy.rs
@@ -1,0 +1,389 @@
+//! Fuzzy subsequence matching and scoring for command palette rows.
+//!
+//! A query matches a row when its characters appear in order somewhere in the
+//! row text ("nwtb" finds "New Tab"). Scoring favours matches that start on
+//! word boundaries, run consecutively, and sit near the start of the text, so
+//! callers can rank rows by relevance instead of catalog order.
+//!
+//! The matcher also reports which byte ranges of the text were matched so the
+//! renderer can highlight them.
+
+use std::ops::Range;
+
+const MATCH_SCORE: i32 = 16;
+const CONSECUTIVE_BONUS: i32 = 12;
+const WORD_START_BONUS: i32 = 14;
+/// Charged per text character skipped between two matched characters.
+const GAP_PENALTY: i32 = 2;
+/// Charged per text character skipped before the first matched character.
+const LEADING_GAP_PENALTY: i32 = 1;
+const LEADING_GAP_PENALTY_LIMIT: i32 = 12;
+const PREFIX_BONUS: i32 = 8;
+const EXACT_BONUS: i32 = 32;
+/// Unordered term matches ("tab close" against "Close Tab") stay usable but
+/// always rank below an ordered subsequence match.
+const UNORDERED_PENALTY: i32 = 20;
+/// Long titles lose a little score so concise rows win otherwise-equal matches.
+const LENGTH_PENALTY_DIVISOR: i32 = 8;
+const LENGTH_PENALTY_LIMIT: i32 = 64;
+/// Bounds the O(query x text) scoring table for pathological inputs.
+const MAX_TEXT_CHARS: usize = 256;
+const NEG: i32 = i32::MIN / 4;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct FuzzyQuery {
+    /// Whole query, lowercased with separators stripped, matched in order.
+    joined: Vec<char>,
+    /// Individual terms, used for unordered fallback matching.
+    terms: Vec<Vec<char>>,
+}
+
+impl FuzzyQuery {
+    /// Returns `None` when the query has no searchable characters, which
+    /// callers treat as "match everything".
+    pub(super) fn new(query: &str) -> Option<Self> {
+        let terms: Vec<Vec<char>> = query
+            .split(|ch: char| !ch.is_alphanumeric())
+            .filter(|term| !term.is_empty())
+            .map(|term| term.chars().map(lowercase_char).collect())
+            .collect();
+
+        if terms.is_empty() {
+            return None;
+        }
+
+        let joined: Vec<char> = terms.iter().flatten().copied().collect();
+        Some(Self { joined, terms })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct FuzzyMatch {
+    pub(super) score: i32,
+    /// Matched byte ranges into the searched text, ascending and disjoint.
+    pub(super) ranges: Vec<Range<usize>>,
+}
+
+/// Scores `text` against `query`, returning `None` when it does not match.
+pub(super) fn match_text(text: &str, query: &FuzzyQuery) -> Option<FuzzyMatch> {
+    let candidate = Candidate::new(text);
+
+    if let Some(matched) = candidate.best_match(&query.joined) {
+        return Some(candidate.finish(matched, &query.joined));
+    }
+
+    if query.terms.len() < 2 {
+        return None;
+    }
+
+    // Ordered matching failed, so fall back to matching each term on its own.
+    // This keeps word-order-insensitive queries working.
+    let mut score = 0;
+    let mut positions = Vec::new();
+    for term in &query.terms {
+        let matched = candidate.best_match(term)?;
+        score += candidate.score_of(&matched, term);
+        positions.extend(matched.positions);
+    }
+    positions.sort_unstable();
+    positions.dedup();
+
+    Some(FuzzyMatch {
+        score: score - UNORDERED_PENALTY - candidate.length_penalty(),
+        ranges: candidate.byte_ranges(&positions),
+    })
+}
+
+struct MatchedPositions {
+    positions: Vec<usize>,
+    score: i32,
+}
+
+/// Precomputed per-character data for one searchable string.
+struct Candidate {
+    chars: Vec<char>,
+    lowered: Vec<char>,
+    /// Byte offset of each character, plus a trailing end offset.
+    offsets: Vec<usize>,
+    /// Word-start bonus for each character position.
+    bonuses: Vec<i32>,
+}
+
+impl Candidate {
+    fn new(text: &str) -> Self {
+        let chars: Vec<char> = text.chars().take(MAX_TEXT_CHARS).collect();
+        let lowered: Vec<char> = chars.iter().copied().map(lowercase_char).collect();
+
+        let mut offsets = Vec::with_capacity(chars.len() + 1);
+        let mut offset = 0;
+        for ch in &chars {
+            offsets.push(offset);
+            offset += ch.len_utf8();
+        }
+        offsets.push(offset);
+
+        let bonuses = chars
+            .iter()
+            .enumerate()
+            .map(|(index, ch)| {
+                if index == 0 {
+                    return WORD_START_BONUS;
+                }
+                let previous = chars[index - 1];
+                let word_start = !previous.is_alphanumeric()
+                    || (ch.is_uppercase() && previous.is_lowercase())
+                    || (ch.is_numeric() && !previous.is_numeric());
+                if word_start { WORD_START_BONUS } else { 0 }
+            })
+            .collect();
+
+        Self {
+            chars,
+            lowered,
+            offsets,
+            bonuses,
+        }
+    }
+
+    /// Dynamic-programming search for the highest-scoring subsequence match.
+    fn best_match(&self, query: &[char]) -> Option<MatchedPositions> {
+        let query_len = query.len();
+        let text_len = self.chars.len();
+        if query_len == 0 || query_len > text_len {
+            return None;
+        }
+
+        // `table[i][j]` is the best score for matching `query[..=i]` with the
+        // final character landing on text position `j`.
+        let mut table: Vec<Vec<i32>> = Vec::with_capacity(query_len);
+        let mut previous_row: Vec<i32> = Vec::new();
+
+        for (i, query_char) in query.iter().enumerate() {
+            let mut row = vec![NEG; text_len];
+            // Best score for the preceding query prefix ending before `j`,
+            // already decayed by the gap penalty.
+            let mut carry = NEG;
+            for j in 0..text_len {
+                if i == 0 {
+                    carry = -(LEADING_GAP_PENALTY * j as i32).min(LEADING_GAP_PENALTY_LIMIT);
+                } else if j > 0 {
+                    carry = (carry - GAP_PENALTY).max(previous_row[j - 1]);
+                }
+
+                if *query_char != self.lowered[j] {
+                    continue;
+                }
+
+                let mut base = carry;
+                if i > 0 && j > 0 && previous_row[j - 1] > NEG / 2 {
+                    base = base.max(previous_row[j - 1] + CONSECUTIVE_BONUS);
+                }
+                if base > NEG / 2 {
+                    row[j] = base + MATCH_SCORE + self.bonuses[j];
+                }
+            }
+
+            previous_row = row.clone();
+            table.push(row);
+        }
+
+        let last_row = table.last()?;
+        let (best_index, best_score) = last_row
+            .iter()
+            .enumerate()
+            .filter(|(_, score)| **score > NEG / 2)
+            .max_by_key(|(_, score)| **score)
+            .map(|(index, score)| (index, *score))?;
+
+        Some(MatchedPositions {
+            positions: backtrack(&table, self, best_index),
+            score: best_score,
+        })
+    }
+
+    fn score_of(&self, matched: &MatchedPositions, query: &[char]) -> i32 {
+        let mut score = matched.score;
+        if matched.positions.first() == Some(&0) {
+            score += PREFIX_BONUS;
+        }
+        if query.len() == self.chars.len() {
+            score += EXACT_BONUS;
+        }
+        score
+    }
+
+    fn length_penalty(&self) -> i32 {
+        (self.chars.len() as i32).min(LENGTH_PENALTY_LIMIT) / LENGTH_PENALTY_DIVISOR
+    }
+
+    fn finish(&self, matched: MatchedPositions, query: &[char]) -> FuzzyMatch {
+        let score = self.score_of(&matched, query) - self.length_penalty();
+        FuzzyMatch {
+            score,
+            ranges: self.byte_ranges(&matched.positions),
+        }
+    }
+
+    /// Collapses matched character positions into ascending byte ranges.
+    fn byte_ranges(&self, positions: &[usize]) -> Vec<Range<usize>> {
+        let mut ranges: Vec<Range<usize>> = Vec::new();
+        for position in positions {
+            let start = self.offsets[*position];
+            let end = self.offsets[position + 1];
+            match ranges.last_mut() {
+                Some(last) if last.end == start => last.end = end,
+                _ => ranges.push(start..end),
+            }
+        }
+        ranges
+    }
+}
+
+/// Walks the scoring table backwards to recover the matched positions.
+fn backtrack(table: &[Vec<i32>], candidate: &Candidate, best_index: usize) -> Vec<usize> {
+    let mut positions = vec![0usize; table.len()];
+    let mut column = best_index;
+
+    for row in (0..table.len()).rev() {
+        positions[row] = column;
+        if row == 0 {
+            break;
+        }
+
+        let target = table[row][column] - MATCH_SCORE - candidate.bonuses[column];
+        let previous = &table[row - 1];
+        let mut chosen = None;
+
+        if column > 0
+            && previous[column - 1] > NEG / 2
+            && previous[column - 1] + CONSECUTIVE_BONUS == target
+        {
+            chosen = Some(column - 1);
+        }
+
+        if chosen.is_none() {
+            for k in (0..column).rev() {
+                if previous[k] > NEG / 2
+                    && previous[k] - GAP_PENALTY * (column - 1 - k) as i32 == target
+                {
+                    chosen = Some(k);
+                    break;
+                }
+            }
+        }
+
+        column = chosen.unwrap_or_else(|| column.saturating_sub(1));
+    }
+
+    positions
+}
+
+fn lowercase_char(ch: char) -> char {
+    ch.to_lowercase().next().unwrap_or(ch)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn score(text: &str, query: &str) -> Option<i32> {
+        let query = FuzzyQuery::new(query)?;
+        match_text(text, &query).map(|matched| matched.score)
+    }
+
+    fn ranges(text: &str, query: &str) -> Vec<Range<usize>> {
+        let query = FuzzyQuery::new(query).expect("query");
+        match_text(text, &query).expect("match").ranges
+    }
+
+    #[test]
+    fn blank_query_has_no_matcher() {
+        assert!(FuzzyQuery::new("").is_none());
+        assert!(FuzzyQuery::new("   -- ").is_none());
+    }
+
+    #[test]
+    fn matches_initials_across_words() {
+        assert!(score("New Tab", "nt").is_some());
+        assert!(score("Split Pane Right", "spr").is_some());
+        assert!(score("Split Pane Right", "sprx").is_none());
+    }
+
+    #[test]
+    fn prefix_beats_scattered_subsequence() {
+        let prefix = score("Restart App", "re").expect("prefix match");
+        let scattered = score("Check for Updates", "re").expect("scattered match");
+        assert!(
+            prefix > scattered,
+            "prefix {prefix} should outrank scattered {scattered}"
+        );
+    }
+
+    #[test]
+    fn word_start_beats_mid_word_match() {
+        let word_start = score("Close Tab", "ct").expect("word start match");
+        let mid_word = score("Character Count", "ct").expect("mid word match");
+        assert!(
+            word_start > mid_word,
+            "word start {word_start} should outrank mid word {mid_word}"
+        );
+    }
+
+    #[test]
+    fn shorter_title_wins_equal_matches() {
+        let short = score("New Tab", "new").expect("short match");
+        let long = score("New Browser Tab Somewhere", "new").expect("long match");
+        assert!(short > long, "short {short} should outrank long {long}");
+    }
+
+    #[test]
+    fn separators_in_query_are_ignored() {
+        assert!(score("Tokyo Night", "tokyo-night").is_some());
+        assert!(score("Tokyo Night", "tokyonight").is_some());
+    }
+
+    #[test]
+    fn unordered_terms_match_below_ordered_terms() {
+        let ordered = score("Close Tab", "close tab").expect("ordered match");
+        let unordered = score("Close Tab", "tab close").expect("unordered match");
+        assert!(
+            ordered > unordered,
+            "ordered {ordered} should outrank unordered {unordered}"
+        );
+    }
+
+    #[test]
+    fn ranges_cover_matched_characters() {
+        assert_eq!(ranges("New Tab", "nt"), vec![0..1, 4..5]);
+        assert_eq!(ranges("New Tab", "new"), vec![0..3]);
+    }
+
+    #[test]
+    fn ranges_stay_on_char_boundaries_for_multibyte_text() {
+        let text = "Café Ø Tab";
+        let matched = ranges(text, "cøt");
+        for range in &matched {
+            assert!(text.is_char_boundary(range.start));
+            assert!(text.is_char_boundary(range.end));
+        }
+        let highlighted: String = matched
+            .iter()
+            .map(|range| &text[range.clone()])
+            .collect::<Vec<_>>()
+            .concat();
+        assert_eq!(highlighted, "CØT");
+    }
+
+    #[test]
+    fn case_insensitive_matching() {
+        assert!(score("Toggle Fullscreen", "FULL").is_some());
+        assert!(score("TOGGLE FULLSCREEN", "full").is_some());
+    }
+
+    #[test]
+    fn exact_title_outranks_longer_container() {
+        let exact = score("nord", "nord").expect("exact match");
+        let container = score("nord light variant", "nord").expect("container match");
+        assert!(exact > container);
+    }
+}

--- a/crates/desktop_app/src/terminal_view/command_palette/mod.rs
+++ b/crates/desktop_app/src/terminal_view/command_palette/mod.rs
@@ -1,13 +1,18 @@
 use super::*;
 use crate::theme_store;
+use gpui::Modifiers;
 use gpui::point;
 use state::{
     CommandPaletteCommandIntent, CommandPaletteItem, CommandPaletteItemKind,
-    command_palette_next_scroll_y, command_palette_target_scroll_y, ordered_theme_ids_for_palette,
+    CommandPaletteScrollDirection, command_palette_next_scroll_y, command_palette_target_scroll_y,
+    ordered_theme_ids_for_palette,
 };
 use termy_command_core::{CommandAvailability, CommandCapabilities, CommandUnavailableReason};
 
+mod fuzzy;
 mod plugins;
+mod presentation;
+mod recents;
 mod render;
 mod state;
 mod state_layouts;
@@ -19,90 +24,6 @@ pub(super) use plugins::PluginLifecycleState;
 pub(super) use state::{CommandPaletteMode, CommandPaletteState, TaskIntent};
 pub(super) use state_layouts::SavedLayoutIntent;
 pub(super) use state_tmux::TmuxSessionIntent;
-
-fn command_icon_path(id: termy_command_core::CommandId) -> &'static str {
-    use termy_command_core::CommandId::*;
-    match id {
-        NewTab => "icons/command_palette/new-tab.svg",
-        NewBrowserTab => "icons/command_palette/new-tab.svg",
-        CloseTab | ClosePane | ClosePaneOrTab => "icons/command_palette/close-tab.svg",
-        MoveTabLeft | SwitchTabLeft => "icons/command_palette/tab-left.svg",
-        MoveTabRight | SwitchTabRight | CycleTabs => "icons/command_palette/tab-right.svg",
-        SwitchToTab1 | SwitchToTab2 | SwitchToTab3 | SwitchToTab4 | SwitchToTab5 | SwitchToTab6
-        | SwitchToTab7 | SwitchToTab8 | SwitchToTab9 => "icons/command_palette/tab-right.svg",
-        RenameTab => "icons/command_palette/rename.svg",
-        SplitPaneVertical => "icons/command_palette/split-right.svg",
-        SplitPaneHorizontal => "icons/command_palette/split-down.svg",
-        FocusPaneLeft | FocusPaneRight | FocusPaneUp | FocusPaneDown | FocusPaneNext
-        | FocusPanePrevious => "icons/command_palette/focus-pane.svg",
-        ResizePaneLeft | ResizePaneRight | ResizePaneUp | ResizePaneDown => {
-            "icons/command_palette/resize-pane.svg"
-        }
-        TogglePaneZoom => "icons/command_palette/zoom-pane.svg",
-        MinimizeWindow => "icons/command_palette/minimize.svg",
-        ManageTmuxSessions => "icons/settings/terminal.svg",
-        ManageSavedLayouts => "icons/command_palette/layout.svg",
-        RunTask => "icons/command_palette/play.svg",
-        AppInfo => "icons/command_palette/info.svg",
-        RestartApp => "icons/command_palette/restart.svg",
-        OpenConfig | PrettifyConfig | OpenSettings => "icons/settings/advanced.svg",
-        ImportColors => "icons/settings/colors.svg",
-        SwitchTheme => "icons/settings/themes.svg",
-        ZoomIn => "icons/command_palette/zoom-in.svg",
-        ZoomOut => "icons/command_palette/zoom-out.svg",
-        ZoomReset => "icons/command_palette/zoom-reset.svg",
-        OpenSearch
-        | CloseSearch
-        | SearchNext
-        | SearchPrevious
-        | ToggleSearchCaseSensitive
-        | ToggleSearchRegex => "icons/settings/search.svg",
-        CheckForUpdates => "icons/command_palette/check-update.svg",
-        Quit => "icons/command_palette/power.svg",
-        ToggleCommandPalette => "icons/command_palette/command.svg",
-        Copy | Paste | SelectAll => "icons/command_palette/clipboard.svg",
-        InstallCli => "icons/command_palette/cli.svg",
-        ToggleTabBarVisibility | ToggleWorkspaceSidebar => "icons/command_palette/sidebar.svg",
-        ToggleInspector => "icons/command_palette/info.svg",
-    }
-}
-
-fn palette_item_icon_path(item: &CommandPaletteItem) -> &'static str {
-    match &item.kind {
-        CommandPaletteItemKind::Command(action) => command_icon_path(action.to_command_id()),
-        CommandPaletteItemKind::PluginCommand { icon, .. }
-        | CommandPaletteItemKind::PluginInputSubmit { icon }
-        | CommandPaletteItemKind::PluginInputOption { icon, .. } => {
-            plugins::plugin_icon_path(*icon)
-        }
-        CommandPaletteItemKind::Theme(_) => "icons/settings/themes.svg",
-        CommandPaletteItemKind::TmuxSessionAttachOrSwitch { .. }
-        | CommandPaletteItemKind::TmuxSessionCreateAndAttach { .. }
-        | CommandPaletteItemKind::TmuxSessionDetachCurrent
-        | CommandPaletteItemKind::TmuxSessionOpenRenameMode
-        | CommandPaletteItemKind::TmuxSessionOpenKillMode
-        | CommandPaletteItemKind::TmuxSessionRenameSelect { .. }
-        | CommandPaletteItemKind::TmuxSessionRenameApply { .. }
-        | CommandPaletteItemKind::TmuxSessionKill { .. } => "icons/settings/terminal.svg",
-        CommandPaletteItemKind::SavedLayoutOpen { .. }
-        | CommandPaletteItemKind::SavedLayoutOpenTasksMode { .. }
-        | CommandPaletteItemKind::SavedLayoutOpenSaveMode
-        | CommandPaletteItemKind::SavedLayoutSaveAs { .. }
-        | CommandPaletteItemKind::SavedLayoutOpenRenameMode
-        | CommandPaletteItemKind::SavedLayoutRenameSelect { .. }
-        | CommandPaletteItemKind::SavedLayoutRenameApply { .. }
-        | CommandPaletteItemKind::SavedLayoutOpenDeleteMode
-        | CommandPaletteItemKind::SavedLayoutDelete { .. } => "icons/command_palette/layout.svg",
-        CommandPaletteItemKind::TaskOpenCreateGlobalMode
-        | CommandPaletteItemKind::TaskOpenCreateLayoutMode { .. }
-        | CommandPaletteItemKind::TaskOpenSaveCurrentCommandGlobalMode
-        | CommandPaletteItemKind::TaskOpenSaveCurrentCommandLayoutMode { .. }
-        | CommandPaletteItemKind::TaskCreate { .. }
-        | CommandPaletteItemKind::Task { .. } => "icons/command_palette/play.svg",
-        CommandPaletteItemKind::AppInfoEntry { .. } => "icons/command_palette/info.svg",
-        CommandPaletteItemKind::AppInfoCopyAll { .. } => "icons/command_palette/clipboard.svg",
-    }
-}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum CommandPaletteEscapeAction {
@@ -120,6 +41,10 @@ enum CommandPaletteNavKey {
     Enter,
     Up,
     Down,
+    PageUp,
+    PageDown,
+    First,
+    Last,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -135,12 +60,40 @@ enum CommandPaletteNotifyEvent {
 }
 
 impl CommandPaletteNavKey {
-    fn parse(key: &str) -> Option<Self> {
+    /// `home`/`end` are deliberately absent: they belong to the query field,
+    /// which binds them to move-to-start/move-to-end. The platform modifier
+    /// pairs cover jumping to the ends of the list instead.
+    fn parse(key: &str, modifiers: Modifiers) -> Option<Self> {
+        let control_only =
+            modifiers.control && !modifiers.platform && !modifiers.alt && !modifiers.shift;
+        let platform_only =
+            modifiers.platform && !modifiers.control && !modifiers.alt && !modifiers.shift;
+
+        if control_only {
+            match key {
+                "n" | "j" => return Some(Self::Down),
+                "p" | "k" => return Some(Self::Up),
+                _ => {}
+            }
+        }
+
+        if platform_only {
+            match key {
+                "up" => return Some(Self::First),
+                "down" => return Some(Self::Last),
+                _ => {}
+            }
+        }
+
         match key {
             "escape" => Some(Self::Escape),
             "enter" => Some(Self::Enter),
             "up" => Some(Self::Up),
             "down" => Some(Self::Down),
+            "pageup" => Some(Self::PageUp),
+            "pagedown" => Some(Self::PageDown),
+            "home" if control_only => Some(Self::First),
+            "end" if control_only => Some(Self::Last),
             _ => None,
         }
     }
@@ -704,6 +657,9 @@ impl TerminalView {
 
         let _ = self.close_terminal_context_menu(cx);
         let was_open = self.command_palette.is_open();
+        if !was_open {
+            self.command_palette.reload_recents();
+        }
         self.command_palette.open(mode);
         let notify_event = if was_open {
             CommandPaletteNotifyEvent::InteractionOnly
@@ -738,6 +694,7 @@ impl TerminalView {
             return;
         }
 
+        self.dismiss_command_palette_plugin_ui(cx);
         self.command_palette.close();
         self.inline_input_selecting = false;
         self.reset_cursor_blink_phase();
@@ -820,8 +777,12 @@ impl TerminalView {
         let offset = scroll_handle.offset();
         let current_y = -Into::<f32>::into(offset.y);
         let selected_index = self.command_palette.selected_filtered_index().unwrap_or(0);
-        let Some(target_y) = command_palette_target_scroll_y(current_y, selected_index, item_count)
-        else {
+        let Some(target_y) = command_palette_target_scroll_y(
+            current_y,
+            selected_index,
+            item_count,
+            self.command_palette.visible_rows(),
+        ) else {
             self.command_palette.reset_scroll_animation_state();
             return;
         };
@@ -904,61 +865,39 @@ impl TerminalView {
     pub(super) fn handle_command_palette_key_down(
         &mut self,
         key: &str,
+        modifiers: Modifiers,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> bool {
-        let Some(nav_key) = CommandPaletteNavKey::parse(key) else {
+        if self.command_palette_plugin_ui(cx).is_some() {
+            let nav_key = CommandPaletteNavKey::parse(key, modifiers);
+            if nav_key == Some(CommandPaletteNavKey::Escape) {
+                self.dismiss_command_palette_plugin_ui(cx);
+            }
+            return nav_key.is_some();
+        }
+
+        if key == "backspace"
+            && modifiers == Modifiers::default()
+            && self.pop_command_palette_mode_from_empty_query(cx)
+        {
+            return true;
+        }
+
+        let Some(nav_key) = CommandPaletteNavKey::parse(key, modifiers) else {
             return false;
         };
 
         match nav_key {
             CommandPaletteNavKey::Escape => {
-                match Self::command_palette_escape_action(
+                let escape_action = Self::command_palette_escape_action(
                     self.command_palette.mode(),
                     self.command_palette.tmux_session_intent(),
                     self.command_palette.command_intent(),
                     self.command_palette.saved_layout_intent(),
                     self.command_palette.task_intent(),
-                ) {
-                    CommandPaletteEscapeAction::ClosePalette => self.close_command_palette(cx),
-                    CommandPaletteEscapeAction::BackToCommands => {
-                        self.set_command_palette_mode(CommandPaletteMode::Commands, false, cx);
-                    }
-                    CommandPaletteEscapeAction::BackToTmuxRenameSelect => {
-                        if self.command_palette.back_from_tmux_rename_input() {
-                            self.apply_command_palette_mode_setup(
-                                CommandPaletteMode::TmuxSessions,
-                                false,
-                                CommandPaletteNotifyEvent::InteractionOnly,
-                                cx,
-                            );
-                        }
-                    }
-                    CommandPaletteEscapeAction::BackToSavedLayoutRenameSelect => {
-                        if self.command_palette.back_from_saved_layout_rename_input() {
-                            self.apply_command_palette_mode_setup(
-                                CommandPaletteMode::Layouts,
-                                false,
-                                CommandPaletteNotifyEvent::InteractionOnly,
-                                cx,
-                            );
-                        }
-                    }
-                    CommandPaletteEscapeAction::BackToTaskBrowse => {
-                        self.command_palette.set_task_intent(TaskIntent::Browse);
-                        self.apply_command_palette_mode_setup(
-                            CommandPaletteMode::Tasks,
-                            false,
-                            CommandPaletteNotifyEvent::InteractionOnly,
-                            cx,
-                        );
-                    }
-                    CommandPaletteEscapeAction::BackFromPluginInput => {
-                        if !self.back_from_plugin_input(cx) {
-                            self.set_command_palette_mode(CommandPaletteMode::Commands, false, cx);
-                        }
-                    }
-                }
+                );
+                self.apply_command_palette_escape_action(escape_action, cx);
             }
             CommandPaletteNavKey::Enter => {
                 self.execute_command_palette_selection(window, cx);
@@ -983,8 +922,114 @@ impl TerminalView {
                     );
                 }
             }
+            CommandPaletteNavKey::PageUp => {
+                self.move_command_palette_selection(
+                    |palette| palette.move_selection_page(CommandPaletteScrollDirection::Up),
+                    cx,
+                );
+            }
+            CommandPaletteNavKey::PageDown => {
+                self.move_command_palette_selection(
+                    |palette| palette.move_selection_page(CommandPaletteScrollDirection::Down),
+                    cx,
+                );
+            }
+            CommandPaletteNavKey::First => {
+                self.move_command_palette_selection(
+                    |palette| palette.move_selection_to_edge(CommandPaletteScrollDirection::Up),
+                    cx,
+                );
+            }
+            CommandPaletteNavKey::Last => {
+                self.move_command_palette_selection(
+                    |palette| palette.move_selection_to_edge(CommandPaletteScrollDirection::Down),
+                    cx,
+                );
+            }
         }
 
+        true
+    }
+
+    fn apply_command_palette_escape_action(
+        &mut self,
+        escape_action: CommandPaletteEscapeAction,
+        cx: &mut Context<Self>,
+    ) {
+        match escape_action {
+            CommandPaletteEscapeAction::ClosePalette => self.close_command_palette(cx),
+            CommandPaletteEscapeAction::BackToCommands => {
+                self.set_command_palette_mode(CommandPaletteMode::Commands, false, cx);
+            }
+            CommandPaletteEscapeAction::BackToTmuxRenameSelect => {
+                if self.command_palette.back_from_tmux_rename_input() {
+                    self.apply_command_palette_mode_setup(
+                        CommandPaletteMode::TmuxSessions,
+                        false,
+                        CommandPaletteNotifyEvent::InteractionOnly,
+                        cx,
+                    );
+                }
+            }
+            CommandPaletteEscapeAction::BackToSavedLayoutRenameSelect => {
+                if self.command_palette.back_from_saved_layout_rename_input() {
+                    self.apply_command_palette_mode_setup(
+                        CommandPaletteMode::Layouts,
+                        false,
+                        CommandPaletteNotifyEvent::InteractionOnly,
+                        cx,
+                    );
+                }
+            }
+            CommandPaletteEscapeAction::BackToTaskBrowse => {
+                self.command_palette.set_task_intent(TaskIntent::Browse);
+                self.apply_command_palette_mode_setup(
+                    CommandPaletteMode::Tasks,
+                    false,
+                    CommandPaletteNotifyEvent::InteractionOnly,
+                    cx,
+                );
+            }
+            CommandPaletteEscapeAction::BackFromPluginInput => {
+                if !self.back_from_plugin_input(cx) {
+                    self.set_command_palette_mode(CommandPaletteMode::Commands, false, cx);
+                }
+            }
+        }
+    }
+
+    fn move_command_palette_selection(
+        &mut self,
+        move_selection: impl FnOnce(&mut CommandPaletteState) -> bool,
+        cx: &mut Context<Self>,
+    ) {
+        let len = self.command_palette.filtered_len();
+        if move_selection(&mut self.command_palette) {
+            self.animate_command_palette_to_selected(len, cx);
+            self.notify_for_command_palette_event(CommandPaletteNotifyEvent::InteractionOnly, cx);
+        }
+    }
+
+    /// Backspace on an empty query steps back one palette level, the same way
+    /// Escape does — except in Commands, where it would close the palette out
+    /// from under someone clearing their query.
+    fn pop_command_palette_mode_from_empty_query(&mut self, cx: &mut Context<Self>) -> bool {
+        if !self.command_palette.input().text().is_empty() {
+            return false;
+        }
+
+        let escape_action = Self::command_palette_escape_action(
+            self.command_palette.mode(),
+            self.command_palette.tmux_session_intent(),
+            self.command_palette.command_intent(),
+            self.command_palette.saved_layout_intent(),
+            self.command_palette.task_intent(),
+        );
+        if escape_action == CommandPaletteEscapeAction::ClosePalette {
+            return false;
+        }
+
+        self.apply_command_palette_escape_action(escape_action, cx);
         true
     }
 
@@ -1053,6 +1098,10 @@ impl TerminalView {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if item.enabled {
+            self.command_palette.record_recent_item(&item);
+        }
+
         match item.kind {
             CommandPaletteItemKind::Command(action) => {
                 if !item.enabled {
@@ -1749,23 +1798,93 @@ mod tests {
 
     #[test]
     fn nav_key_parser_maps_expected_keys() {
+        let plain = Modifiers::default();
         assert_eq!(
-            CommandPaletteNavKey::parse("escape"),
+            CommandPaletteNavKey::parse("escape", plain),
             Some(CommandPaletteNavKey::Escape)
         );
         assert_eq!(
-            CommandPaletteNavKey::parse("enter"),
+            CommandPaletteNavKey::parse("enter", plain),
             Some(CommandPaletteNavKey::Enter)
         );
         assert_eq!(
-            CommandPaletteNavKey::parse("up"),
+            CommandPaletteNavKey::parse("up", plain),
             Some(CommandPaletteNavKey::Up)
         );
         assert_eq!(
-            CommandPaletteNavKey::parse("down"),
+            CommandPaletteNavKey::parse("down", plain),
             Some(CommandPaletteNavKey::Down)
         );
-        assert_eq!(CommandPaletteNavKey::parse("left"), None);
+        assert_eq!(
+            CommandPaletteNavKey::parse("pageup", plain),
+            Some(CommandPaletteNavKey::PageUp)
+        );
+        assert_eq!(
+            CommandPaletteNavKey::parse("pagedown", plain),
+            Some(CommandPaletteNavKey::PageDown)
+        );
+        assert_eq!(CommandPaletteNavKey::parse("left", plain), None);
+    }
+
+    #[test]
+    fn nav_key_parser_maps_control_pairs_and_edge_jumps() {
+        let control = Modifiers {
+            control: true,
+            ..Modifiers::default()
+        };
+        let platform = Modifiers {
+            platform: true,
+            ..Modifiers::default()
+        };
+
+        for key in ["n", "j"] {
+            assert_eq!(
+                CommandPaletteNavKey::parse(key, control),
+                Some(CommandPaletteNavKey::Down),
+                "ctrl-{key} should move down"
+            );
+        }
+        for key in ["p", "k"] {
+            assert_eq!(
+                CommandPaletteNavKey::parse(key, control),
+                Some(CommandPaletteNavKey::Up),
+                "ctrl-{key} should move up"
+            );
+        }
+
+        assert_eq!(
+            CommandPaletteNavKey::parse("home", control),
+            Some(CommandPaletteNavKey::First)
+        );
+        assert_eq!(
+            CommandPaletteNavKey::parse("end", control),
+            Some(CommandPaletteNavKey::Last)
+        );
+        assert_eq!(
+            CommandPaletteNavKey::parse("up", platform),
+            Some(CommandPaletteNavKey::First)
+        );
+        assert_eq!(
+            CommandPaletteNavKey::parse("down", platform),
+            Some(CommandPaletteNavKey::Last)
+        );
+    }
+
+    #[test]
+    fn nav_key_parser_leaves_plain_home_and_end_to_the_query_field() {
+        let plain = Modifiers::default();
+        assert_eq!(CommandPaletteNavKey::parse("home", plain), None);
+        assert_eq!(CommandPaletteNavKey::parse("end", plain), None);
+    }
+
+    #[test]
+    fn nav_key_parser_ignores_unrelated_modifier_combinations() {
+        let control_shift = Modifiers {
+            control: true,
+            shift: true,
+            ..Modifiers::default()
+        };
+        assert_eq!(CommandPaletteNavKey::parse("n", control_shift), None);
     }
 
     #[test]
@@ -1851,11 +1970,15 @@ mod tests {
     fn tmux_query_surfaces_only_tmux_sessions_entry() {
         let items =
             TerminalView::command_palette_core_command_items_for_state(test_caps(true, true));
-        let filtered_indices =
-            super::state::filter_command_palette_item_indices_by_query(&items, "tmux");
-        let filtered_actions = filtered_indices
+        let matches = super::state::rank_command_palette_items(
+            &items,
+            "tmux",
+            &super::recents::CommandPaletteRecents::default(),
+            super::state::CommandPaletteRanking::ByScore,
+        );
+        let filtered_actions = matches
             .into_iter()
-            .filter_map(|index| match items[index].kind {
+            .filter_map(|matched| match items[matched.item_index].kind {
                 CommandPaletteItemKind::Command(action) => Some(action),
                 _ => None,
             })

--- a/crates/desktop_app/src/terminal_view/command_palette/plugins.rs
+++ b/crates/desktop_app/src/terminal_view/command_palette/plugins.rs
@@ -2,9 +2,9 @@ use super::*;
 use serde_json::Value;
 use std::collections::{BTreeMap, VecDeque};
 use termy_plugin_runtime::{
-    PluginAction, PluginCommand, PluginContext, PluginEvent, PluginEventDispatch, PluginIcon,
-    PluginInput, PluginPaneContext, PluginPaneKind, PluginRuntimeKind, PluginTabContext,
-    PluginToastLevel,
+    PluginAction, PluginCommand, PluginCommandPlacement, PluginContext, PluginEvent,
+    PluginEventDispatch, PluginIcon, PluginInput, PluginPaneContext, PluginPaneKind,
+    PluginRuntimeKind, PluginTabContext, PluginToastLevel,
 };
 
 const PLUGIN_SELECTED_TEXT_MAX_BYTES: usize = 64 * 1024;
@@ -205,6 +205,21 @@ fn plugin_selected_text(mut text: Option<String>) -> (Option<String>, bool) {
 
 fn duration_millis(duration: Duration) -> u64 {
     u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
+
+fn placed_plugin_commands(
+    mut commands: Vec<PluginCommand>,
+    placement: PluginCommandPlacement,
+) -> Vec<PluginCommand> {
+    commands.retain(|command| command.placements.contains(&placement));
+    commands.sort_by(|left, right| {
+        left.plugin_name
+            .to_lowercase()
+            .cmp(&right.plugin_name.to_lowercase())
+            .then_with(|| left.title.to_lowercase().cmp(&right.title.to_lowercase()))
+            .then_with(|| left.qualified_id().cmp(&right.qualified_id()))
+    });
+    commands
 }
 
 impl TerminalView {
@@ -416,6 +431,11 @@ impl TerminalView {
                             cx,
                         );
                     }
+                    if refresh.changed
+                        && (view.terminal_context_menu.is_some() || view.tab_context_menu.is_some())
+                    {
+                        view.notify_overlay(cx);
+                    }
                 })
             });
         })
@@ -423,8 +443,7 @@ impl TerminalView {
     }
 
     pub(super) fn command_palette_plugin_items(&self) -> Vec<CommandPaletteItem> {
-        self.plugin_runtime
-            .commands()
+        self.plugin_commands_for_placement(PluginCommandPlacement::CommandPalette)
             .into_iter()
             .map(|command| {
                 let enabled = command.disabled_reason.is_none();
@@ -449,6 +468,13 @@ impl TerminalView {
                 }
             })
             .collect()
+    }
+
+    pub(in crate::terminal_view) fn plugin_commands_for_placement(
+        &self,
+        placement: PluginCommandPlacement,
+    ) -> Vec<PluginCommand> {
+        placed_plugin_commands(self.plugin_runtime.commands(), placement)
     }
 
     pub(super) fn plugin_input_uses_free_text(&self) -> bool {
@@ -610,7 +636,7 @@ impl TerminalView {
             .is_some_and(PluginInputSession::is_last_input)
     }
 
-    pub(super) fn start_plugin_command(
+    pub(in crate::terminal_view) fn start_plugin_command(
         &mut self,
         plugin_id: &str,
         command_id: &str,
@@ -884,10 +910,11 @@ impl TerminalView {
                 },
                 PluginAction::ViewOpen {
                     view,
+                    target,
                     plugin_id,
                     revision,
                 } => {
-                    self.open_plugin_ui(&plugin_id, &view, &revision, window, cx)?;
+                    self.open_plugin_ui(&plugin_id, &view, &revision, target, window, cx)?;
                 }
             }
         }
@@ -933,6 +960,7 @@ mod tests {
             plugin_name: "Test".to_string(),
             id: "run".to_string(),
             title: "Test: Run".to_string(),
+            placements: vec![PluginCommandPlacement::CommandPalette],
             keywords: Vec::new(),
             status: None,
             disabled_reason: None,
@@ -940,6 +968,63 @@ mod tests {
             inputs,
             timeout_ms: 10_000,
         }
+    }
+
+    #[test]
+    fn plugin_placements_filter_and_sort_context_menu_commands() {
+        let placed = |plugin_name: &str,
+                      id: &str,
+                      title: &str,
+                      placements: Vec<PluginCommandPlacement>,
+                      disabled_reason: Option<&str>| {
+            let mut command = command(Vec::new());
+            command.plugin_id = plugin_name.to_lowercase();
+            command.plugin_name = plugin_name.to_string();
+            command.id = id.to_string();
+            command.title = title.to_string();
+            command.placements = placements;
+            command.disabled_reason = disabled_reason.map(str::to_string);
+            command
+        };
+        let commands = vec![
+            placed(
+                "Zulu",
+                "palette",
+                "Palette only",
+                vec![PluginCommandPlacement::CommandPalette],
+                None,
+            ),
+            placed(
+                "Beta",
+                "later",
+                "Later",
+                vec![PluginCommandPlacement::TerminalContextMenu],
+                None,
+            ),
+            placed(
+                "alpha",
+                "disabled",
+                "Disabled but visible",
+                vec![PluginCommandPlacement::TerminalContextMenu],
+                Some("Unavailable"),
+            ),
+            placed("Hidden", "hidden", "Hidden", Vec::new(), None),
+        ];
+
+        let visible = placed_plugin_commands(commands, PluginCommandPlacement::TerminalContextMenu);
+
+        assert_eq!(
+            visible
+                .iter()
+                .map(|command| command.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["disabled", "later"]
+        );
+        assert_eq!(
+            visible[0].disabled_reason.as_deref(),
+            Some("Unavailable"),
+            "disabled commands remain visible so the menu can explain their state"
+        );
     }
 
     #[test]

--- a/crates/desktop_app/src/terminal_view/command_palette/presentation.rs
+++ b/crates/desktop_app/src/terminal_view/command_palette/presentation.rs
@@ -1,0 +1,347 @@
+//! Per-row presentation lookups: which icon a palette row paints and which
+//! category label it carries.
+//!
+//! Categories group the flat command catalog so a scan of the Commands list
+//! reads as sections ("Panes", "Tabs", "Search") instead of one long wall.
+//! They are only rendered where rows come from mixed sources; single-purpose
+//! modes (themes, sessions, layouts, tasks) would repeat one label per row.
+
+use super::plugins;
+use super::state::{CommandPaletteItem, CommandPaletteItemKind};
+use termy_command_core::CommandId;
+
+pub(super) fn command_icon_path(id: CommandId) -> &'static str {
+    use termy_command_core::CommandId::*;
+    match id {
+        NewTab => "icons/command_palette/new-tab.svg",
+        NewBrowserTab => "icons/command_palette/link.svg",
+        CloseTab | ClosePane | ClosePaneOrTab => "icons/command_palette/close-tab.svg",
+        MoveTabLeft | SwitchTabLeft => "icons/command_palette/tab-left.svg",
+        MoveTabRight | SwitchTabRight | CycleTabs => "icons/command_palette/tab-right.svg",
+        // Jumping to a numbered tab is not directional, so it does not borrow
+        // the move-right glyph.
+        SwitchToTab1 | SwitchToTab2 | SwitchToTab3 | SwitchToTab4 | SwitchToTab5 | SwitchToTab6
+        | SwitchToTab7 | SwitchToTab8 | SwitchToTab9 => "icons/settings/tabs.svg",
+        RenameTab => "icons/command_palette/rename.svg",
+        SplitPaneVertical => "icons/command_palette/split-right.svg",
+        SplitPaneHorizontal => "icons/command_palette/split-down.svg",
+        FocusPaneLeft | FocusPaneRight | FocusPaneUp | FocusPaneDown | FocusPaneNext
+        | FocusPanePrevious => "icons/command_palette/focus-pane.svg",
+        ResizePaneLeft | ResizePaneRight | ResizePaneUp | ResizePaneDown => {
+            "icons/command_palette/resize-pane.svg"
+        }
+        TogglePaneZoom => "icons/command_palette/zoom-pane.svg",
+        MinimizeWindow => "icons/command_palette/minimize.svg",
+        ManageTmuxSessions => "icons/settings/terminal.svg",
+        ManageSavedLayouts => "icons/command_palette/layout.svg",
+        RunTask => "icons/command_palette/play.svg",
+        AppInfo => "icons/command_palette/info.svg",
+        RestartApp => "icons/command_palette/restart.svg",
+        OpenConfig | PrettifyConfig | OpenSettings => "icons/settings/advanced.svg",
+        ImportColors => "icons/settings/colors.svg",
+        SwitchTheme => "icons/settings/themes.svg",
+        ZoomIn => "icons/command_palette/zoom-in.svg",
+        ZoomOut => "icons/command_palette/zoom-out.svg",
+        ZoomReset => "icons/command_palette/zoom-reset.svg",
+        OpenSearch
+        | CloseSearch
+        | SearchNext
+        | SearchPrevious
+        | ToggleSearchCaseSensitive
+        | ToggleSearchRegex => "icons/settings/search.svg",
+        CheckForUpdates => "icons/command_palette/check-update.svg",
+        Quit => "icons/command_palette/power.svg",
+        ToggleCommandPalette => "icons/command_palette/command.svg",
+        Copy | Paste | SelectAll => "icons/command_palette/clipboard.svg",
+        InstallCli => "icons/command_palette/cli.svg",
+        ToggleTabBarVisibility => "icons/settings/tabs.svg",
+        ToggleWorkspaceSidebar => "icons/command_palette/sidebar.svg",
+        ToggleInspector => "icons/settings/advanced.svg",
+    }
+}
+
+pub(super) fn palette_item_icon_path(item: &CommandPaletteItem) -> &'static str {
+    match &item.kind {
+        CommandPaletteItemKind::Command(action) => command_icon_path(action.to_command_id()),
+        CommandPaletteItemKind::PluginCommand { icon, .. }
+        | CommandPaletteItemKind::PluginInputSubmit { icon }
+        | CommandPaletteItemKind::PluginInputOption { icon, .. } => {
+            plugins::plugin_icon_path(*icon)
+        }
+        CommandPaletteItemKind::Theme(_) => "icons/settings/themes.svg",
+        CommandPaletteItemKind::TmuxSessionAttachOrSwitch { .. }
+        | CommandPaletteItemKind::TmuxSessionCreateAndAttach { .. }
+        | CommandPaletteItemKind::TmuxSessionDetachCurrent
+        | CommandPaletteItemKind::TmuxSessionOpenRenameMode
+        | CommandPaletteItemKind::TmuxSessionOpenKillMode
+        | CommandPaletteItemKind::TmuxSessionRenameSelect { .. }
+        | CommandPaletteItemKind::TmuxSessionRenameApply { .. }
+        | CommandPaletteItemKind::TmuxSessionKill { .. } => "icons/settings/terminal.svg",
+        CommandPaletteItemKind::SavedLayoutOpen { .. }
+        | CommandPaletteItemKind::SavedLayoutOpenTasksMode { .. }
+        | CommandPaletteItemKind::SavedLayoutOpenSaveMode
+        | CommandPaletteItemKind::SavedLayoutSaveAs { .. }
+        | CommandPaletteItemKind::SavedLayoutOpenRenameMode
+        | CommandPaletteItemKind::SavedLayoutRenameSelect { .. }
+        | CommandPaletteItemKind::SavedLayoutRenameApply { .. }
+        | CommandPaletteItemKind::SavedLayoutOpenDeleteMode
+        | CommandPaletteItemKind::SavedLayoutDelete { .. } => "icons/command_palette/layout.svg",
+        CommandPaletteItemKind::TaskOpenCreateGlobalMode
+        | CommandPaletteItemKind::TaskOpenCreateLayoutMode { .. }
+        | CommandPaletteItemKind::TaskOpenSaveCurrentCommandGlobalMode
+        | CommandPaletteItemKind::TaskOpenSaveCurrentCommandLayoutMode { .. }
+        | CommandPaletteItemKind::TaskCreate { .. }
+        | CommandPaletteItemKind::Task { .. } => "icons/command_palette/play.svg",
+        CommandPaletteItemKind::AppInfoEntry { .. } => "icons/command_palette/info.svg",
+        CommandPaletteItemKind::AppInfoCopyAll { .. } => "icons/command_palette/clipboard.svg",
+    }
+}
+
+/// Group label for a built-in command. Exhaustive on purpose: a new command
+/// fails to compile until it is filed under a category.
+pub(super) fn command_category(id: CommandId) -> &'static str {
+    use termy_command_core::CommandId::*;
+    match id {
+        NewTab
+        | NewBrowserTab
+        | CloseTab
+        | RenameTab
+        | MoveTabLeft
+        | MoveTabRight
+        | SwitchTabLeft
+        | SwitchTabRight
+        | CycleTabs
+        | SwitchToTab1
+        | SwitchToTab2
+        | SwitchToTab3
+        | SwitchToTab4
+        | SwitchToTab5
+        | SwitchToTab6
+        | SwitchToTab7
+        | SwitchToTab8
+        | SwitchToTab9
+        | ToggleTabBarVisibility => "Tabs",
+        SplitPaneVertical | SplitPaneHorizontal | ClosePane | ClosePaneOrTab | FocusPaneLeft
+        | FocusPaneRight | FocusPaneUp | FocusPaneDown | FocusPaneNext | FocusPanePrevious
+        | ResizePaneLeft | ResizePaneRight | ResizePaneUp | ResizePaneDown | TogglePaneZoom => {
+            "Panes"
+        }
+        MinimizeWindow | ToggleWorkspaceSidebar => "Window",
+        ManageTmuxSessions | ManageSavedLayouts | RunTask => "Sessions",
+        OpenSearch
+        | CloseSearch
+        | SearchNext
+        | SearchPrevious
+        | ToggleSearchCaseSensitive
+        | ToggleSearchRegex => "Search",
+        Copy | Paste | SelectAll => "Edit",
+        SwitchTheme | ImportColors | ZoomIn | ZoomOut | ZoomReset => "Appearance",
+        OpenConfig | PrettifyConfig | OpenSettings | InstallCli => "Settings",
+        AppInfo | RestartApp | CheckForUpdates | Quit | ToggleCommandPalette | ToggleInspector => {
+            "App"
+        }
+    }
+}
+
+/// Modifier glyphs GPUI writes with no separator (macOS, and the platform key
+/// on Linux/Windows).
+const MODIFIER_GLYPHS: &[char] = &['^', '⌃', '⌥', '⌘', '⇧', '❖', '⊞'];
+/// Modifier words GPUI writes with a trailing dash on non-macOS platforms.
+const MODIFIER_WORDS: &[(&str, &str)] = &[
+    ("ctrl-", "Ctrl"),
+    ("alt-", "Alt"),
+    ("shift-", "Shift"),
+    ("super-", "Super"),
+    ("cmd-", "Cmd"),
+    ("win-", "Win"),
+    ("fn-", "Fn"),
+];
+
+/// Splits a keybinding label into one group of keycaps per keystroke, so the
+/// renderer can draw `⇧⌘K` as three caps instead of one wide chip.
+///
+/// GPUI joins keystrokes with a space and writes modifiers either as bare
+/// glyphs (`⇧⌘K`) or as dash-suffixed words (`ctrl-shift-k`), depending on the
+/// platform; both forms are handled here.
+pub(super) fn shortcut_keycaps(label: &str) -> Vec<Vec<String>> {
+    label
+        .split_whitespace()
+        .map(keystroke_keycaps)
+        .filter(|caps| !caps.is_empty())
+        .collect()
+}
+
+fn keystroke_keycaps(keystroke: &str) -> Vec<String> {
+    let mut caps = Vec::new();
+    let mut rest = keystroke;
+
+    loop {
+        if let Some((prefix, label)) = MODIFIER_WORDS
+            .iter()
+            .find(|(prefix, _)| rest.len() > prefix.len() && rest.starts_with(*prefix))
+        {
+            caps.push((*label).to_string());
+            rest = &rest[prefix.len()..];
+            continue;
+        }
+
+        let Some(first) = rest.chars().next() else {
+            break;
+        };
+        // A lone modifier glyph is the whole keystroke (someone bound ⌘ by
+        // itself), so it stays as the key rather than being eaten as a prefix.
+        if MODIFIER_GLYPHS.contains(&first) && rest.chars().count() > 1 {
+            caps.push(first.to_string());
+            rest = &rest[first.len_utf8()..];
+            continue;
+        }
+
+        break;
+    }
+
+    if !rest.is_empty() {
+        caps.push(rest.to_string());
+    }
+    caps
+}
+
+/// Category label for a row, or `None` for rows whose mode already says what
+/// they are.
+pub(super) fn palette_item_category(item: &CommandPaletteItem) -> Option<String> {
+    match &item.kind {
+        CommandPaletteItemKind::Command(action) => {
+            Some(command_category(action.to_command_id()).to_string())
+        }
+        CommandPaletteItemKind::PluginCommand { plugin_id, .. } => Some(plugin_id.clone()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::terminal_view::CommandAction;
+
+    #[test]
+    fn every_command_has_an_embedded_icon_and_a_category() {
+        for id in CommandId::all() {
+            let icon = command_icon_path(id);
+            let embedded = gpui::AssetSource::load(&crate::asset_source::EmbeddedAssets, icon)
+                .ok()
+                .flatten()
+                .is_some();
+            assert!(
+                embedded,
+                "icon {icon} for {} is not embedded",
+                id.config_name()
+            );
+            assert!(
+                !command_category(id).is_empty(),
+                "missing category for {}",
+                id.config_name()
+            );
+        }
+    }
+
+    #[test]
+    fn categories_stay_a_small_scannable_set() {
+        let mut categories: Vec<&str> = CommandId::all().map(command_category).collect();
+        categories.sort_unstable();
+        categories.dedup();
+
+        assert_eq!(
+            categories,
+            vec![
+                "App",
+                "Appearance",
+                "Edit",
+                "Panes",
+                "Search",
+                "Sessions",
+                "Settings",
+                "Tabs",
+                "Window",
+            ]
+        );
+    }
+
+    #[test]
+    fn plugin_rows_use_their_plugin_id_as_category() {
+        let item = CommandPaletteItem {
+            title: "Do Thing".to_string(),
+            keywords: String::new(),
+            enabled: true,
+            status_hint: None,
+            tmux_status_hint: None,
+            kind: CommandPaletteItemKind::PluginCommand {
+                plugin_id: "acme".to_string(),
+                command_id: "do-thing".to_string(),
+                icon: termy_plugin_runtime::PluginIcon::Command,
+            },
+        };
+
+        assert_eq!(palette_item_category(&item).as_deref(), Some("acme"));
+    }
+
+    #[test]
+    fn non_command_rows_have_no_category() {
+        let theme = CommandPaletteItem::theme("nord".to_string(), false);
+        assert_eq!(palette_item_category(&theme), None);
+
+        let task = CommandPaletteItem::task("build", "cargo build", None, None);
+        assert_eq!(palette_item_category(&task), None);
+    }
+
+    #[test]
+    fn keycaps_split_macos_glyph_shortcuts() {
+        assert_eq!(shortcut_keycaps("⌘K"), vec![vec!["⌘", "K"]]);
+        assert_eq!(shortcut_keycaps("⇧⌘K"), vec![vec!["⇧", "⌘", "K"]]);
+        assert_eq!(
+            shortcut_keycaps("^⌥⌘⇧K"),
+            vec![vec!["^", "⌥", "⌘", "⇧", "K"]]
+        );
+    }
+
+    #[test]
+    fn keycaps_split_dash_separated_shortcuts() {
+        assert_eq!(shortcut_keycaps("ctrl-k"), vec![vec!["Ctrl", "k"]]);
+        assert_eq!(
+            shortcut_keycaps("ctrl-shift-k"),
+            vec![vec!["Ctrl", "Shift", "k"]]
+        );
+    }
+
+    #[test]
+    fn keycaps_group_multi_keystroke_bindings() {
+        assert_eq!(
+            shortcut_keycaps("⌘K ⌘T"),
+            vec![vec!["⌘", "K"], vec!["⌘", "T"]]
+        );
+    }
+
+    #[test]
+    fn keycaps_keep_a_lone_modifier_as_the_key() {
+        assert_eq!(shortcut_keycaps("⌘"), vec![vec!["⌘"]]);
+        assert_eq!(shortcut_keycaps(""), Vec::<Vec<String>>::new());
+    }
+
+    #[test]
+    fn keycaps_keep_symbol_keys_intact() {
+        assert_eq!(shortcut_keycaps("⌘-"), vec![vec!["⌘", "-"]]);
+        assert_eq!(shortcut_keycaps("⌘↑"), vec![vec!["⌘", "↑"]]);
+        assert_eq!(shortcut_keycaps("ctrl--"), vec![vec!["Ctrl", "-"]]);
+    }
+
+    #[test]
+    fn split_commands_are_filed_under_panes() {
+        let split = CommandPaletteItem::command_with_state(
+            "Split Pane Vertical",
+            "split",
+            CommandAction::SplitPaneVertical,
+            true,
+            None,
+        );
+
+        assert_eq!(palette_item_category(&split).as_deref(), Some("Panes"));
+    }
+}

--- a/crates/desktop_app/src/terminal_view/command_palette/recents.rs
+++ b/crates/desktop_app/src/terminal_view/command_palette/recents.rs
@@ -1,0 +1,224 @@
+//! Most-recently-used tracking for command palette rows.
+//!
+//! Executed commands are remembered (most recent first) so the palette can
+//! surface them without a query and boost them while filtering. Only rows with
+//! a stable identity are tracked: built-in commands keyed by their config name
+//! and plugin commands keyed by `plugin:<plugin_id>:<command_id>`.
+
+use super::state::{CommandPaletteItem, CommandPaletteItemKind};
+use std::path::{Path, PathBuf};
+
+pub(super) const RECENTS_FILE: &str = "command-palette-recents.json";
+const MAX_RECENTS: usize = 50;
+/// Score added to the most recent entry while filtering; later entries get
+/// progressively less so relevance still leads.
+const RECENT_BONUS_MAX: i32 = 24;
+const RECENT_BONUS_STEP: i32 = 2;
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(in super::super) struct CommandPaletteRecents {
+    /// Command keys, most recently executed first.
+    keys: Vec<String>,
+}
+
+impl CommandPaletteRecents {
+    pub(in super::super) fn load() -> Self {
+        let Some(path) = recents_path() else {
+            return Self::default();
+        };
+        Self::load_from_path(&path)
+    }
+
+    pub(super) fn load_from_path(path: &Path) -> Self {
+        let contents = match std::fs::read_to_string(path) {
+            Ok(contents) => contents,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Self::default(),
+            Err(error) => {
+                log::warn!("Failed to read command palette recents: {error}");
+                return Self::default();
+            }
+        };
+
+        match serde_json::from_str::<Vec<String>>(&contents) {
+            Ok(mut keys) => {
+                keys.truncate(MAX_RECENTS);
+                Self { keys }
+            }
+            Err(error) => {
+                log::warn!("Failed to parse command palette recents: {error}");
+                Self::default()
+            }
+        }
+    }
+
+    /// Moves `key` to the front and persists the list. Persistence failures are
+    /// logged and otherwise ignored: recents are a convenience, not state the
+    /// palette depends on.
+    pub(super) fn record(&mut self, key: String) {
+        self.push(key);
+        if let Some(path) = recents_path()
+            && let Err(error) = self.save_to_path(&path)
+        {
+            log::warn!("Failed to save command palette recents: {error}");
+        }
+    }
+
+    pub(super) fn push(&mut self, key: String) {
+        self.keys.retain(|existing| existing != &key);
+        self.keys.insert(0, key);
+        self.keys.truncate(MAX_RECENTS);
+    }
+
+    pub(super) fn save_to_path(&self, path: &Path) -> std::io::Result<()> {
+        let contents = serde_json::to_string(&self.keys)
+            .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+        std::fs::write(path, contents)
+    }
+
+    /// Position in the recents list, 0 being the most recent.
+    pub(super) fn rank(&self, key: &str) -> Option<usize> {
+        self.keys.iter().position(|existing| existing == key)
+    }
+
+    pub(super) fn rank_for_item(&self, item: &CommandPaletteItem) -> Option<usize> {
+        self.rank(&recent_key_for_item(item)?)
+    }
+
+    pub(super) fn bonus_for_item(&self, item: &CommandPaletteItem) -> i32 {
+        match self.rank_for_item(item) {
+            Some(rank) => {
+                (RECENT_BONUS_MAX - (rank as i32).saturating_mul(RECENT_BONUS_STEP)).max(0)
+            }
+            None => 0,
+        }
+    }
+}
+
+/// Stable identity for rows worth remembering, or `None` for rows whose
+/// meaning depends on transient state (themes, sessions, layouts, tasks).
+pub(super) fn recent_key_for_item(item: &CommandPaletteItem) -> Option<String> {
+    match &item.kind {
+        CommandPaletteItemKind::Command(action) => {
+            Some(action.to_command_id().config_name().to_string())
+        }
+        CommandPaletteItemKind::PluginCommand {
+            plugin_id,
+            command_id,
+            ..
+        } => Some(format!("plugin:{plugin_id}:{command_id}")),
+        _ => None,
+    }
+}
+
+fn recents_path() -> Option<PathBuf> {
+    let config_path = termy_config_core::config_path()?;
+    Some(config_path.parent()?.join(RECENTS_FILE))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::terminal_view::CommandAction;
+    use tempfile::tempdir;
+
+    fn command_item(action: CommandAction) -> CommandPaletteItem {
+        CommandPaletteItem::command_with_state("Title", "keywords", action, true, None)
+    }
+
+    #[test]
+    fn push_moves_existing_key_to_front_without_duplicating() {
+        let mut recents = CommandPaletteRecents::default();
+        recents.push("new_tab".to_string());
+        recents.push("close_tab".to_string());
+        recents.push("new_tab".to_string());
+
+        assert_eq!(recents.keys, vec!["new_tab", "close_tab"]);
+        assert_eq!(recents.rank("new_tab"), Some(0));
+        assert_eq!(recents.rank("close_tab"), Some(1));
+        assert_eq!(recents.rank("split_pane_vertical"), None);
+    }
+
+    #[test]
+    fn push_caps_stored_history() {
+        let mut recents = CommandPaletteRecents::default();
+        for index in 0..(MAX_RECENTS + 10) {
+            recents.push(format!("command_{index}"));
+        }
+
+        assert_eq!(recents.keys.len(), MAX_RECENTS);
+        assert_eq!(recents.keys[0], format!("command_{}", MAX_RECENTS + 9));
+    }
+
+    #[test]
+    fn bonus_decays_with_rank_and_never_goes_negative() {
+        let mut recents = CommandPaletteRecents::default();
+        for index in 0..30 {
+            recents.push(format!("command_{index}"));
+        }
+        recents.push("new_tab".to_string());
+
+        let mut item = command_item(CommandAction::NewTab);
+        assert_eq!(recents.bonus_for_item(&item), RECENT_BONUS_MAX);
+
+        recents.push("close_tab".to_string());
+        assert_eq!(
+            recents.bonus_for_item(&item),
+            RECENT_BONUS_MAX - RECENT_BONUS_STEP
+        );
+
+        item = command_item(CommandAction::ZoomReset);
+        assert_eq!(recents.bonus_for_item(&item), 0);
+    }
+
+    #[test]
+    fn round_trips_through_disk() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join(RECENTS_FILE);
+
+        let mut recents = CommandPaletteRecents::default();
+        recents.push("new_tab".to_string());
+        recents.push("close_tab".to_string());
+        recents.save_to_path(&path).expect("save");
+
+        let loaded = CommandPaletteRecents::load_from_path(&path);
+        assert_eq!(loaded, recents);
+    }
+
+    #[test]
+    fn missing_or_corrupt_file_loads_empty_history() {
+        let dir = tempdir().expect("tempdir");
+        let missing = dir.path().join(RECENTS_FILE);
+        assert_eq!(
+            CommandPaletteRecents::load_from_path(&missing),
+            CommandPaletteRecents::default()
+        );
+
+        let corrupt = dir.path().join("corrupt.json");
+        std::fs::write(&corrupt, "{ not json").expect("write");
+        assert_eq!(
+            CommandPaletteRecents::load_from_path(&corrupt),
+            CommandPaletteRecents::default()
+        );
+    }
+
+    #[test]
+    fn plugin_commands_get_namespaced_keys() {
+        let item = CommandPaletteItem {
+            title: "Do Thing".to_string(),
+            keywords: String::new(),
+            enabled: true,
+            status_hint: None,
+            tmux_status_hint: None,
+            kind: CommandPaletteItemKind::PluginCommand {
+                plugin_id: "acme".to_string(),
+                command_id: "do-thing".to_string(),
+                icon: termy_plugin_runtime::PluginIcon::Command,
+            },
+        };
+
+        assert_eq!(
+            recent_key_for_item(&item).as_deref(),
+            Some("plugin:acme:do-thing")
+        );
+    }
+}

--- a/crates/desktop_app/src/terminal_view/command_palette/render.rs
+++ b/crates/desktop_app/src/terminal_view/command_palette/render.rs
@@ -1,4 +1,6 @@
 use super::super::*;
+use super::presentation::{palette_item_category, palette_item_icon_path, shortcut_keycaps};
+use super::state::{command_palette_layout_for_viewport, command_palette_viewport_height};
 use super::style::{
     COMMAND_PALETTE_PANEL_RADIUS, COMMAND_PALETTE_ROW_RADIUS, COMMAND_PALETTE_SHORTCUT_RADIUS,
     CommandPaletteStyle,
@@ -8,6 +10,84 @@ use crate::ui::scrollbar::{self, ScrollbarPaintStyle, ScrollbarRange};
 use gpui::prelude::FluentBuilder;
 use gpui::uniform_list;
 use std::ops::Range;
+
+/// Renders a row title with the query's matched characters accented. Disabled
+/// rows and rows without a query keep flat text.
+fn highlighted_title(
+    title: String,
+    highlights: &[Range<usize>],
+    is_enabled: bool,
+    style: &CommandPaletteStyle,
+) -> AnyElement {
+    if highlights.is_empty() || !is_enabled {
+        return title.into_any_element();
+    }
+
+    let highlight = gpui::HighlightStyle {
+        color: Some(style.match_text.into()),
+        font_weight: Some(gpui::FontWeight::BOLD),
+        ..Default::default()
+    };
+    let runs: Vec<(Range<usize>, gpui::HighlightStyle)> = highlights
+        .iter()
+        .filter(|range| {
+            range.end <= title.len()
+                && title.is_char_boundary(range.start)
+                && title.is_char_boundary(range.end)
+        })
+        .map(|range| (range.clone(), highlight))
+        .collect();
+
+    if runs.is_empty() {
+        return title.into_any_element();
+    }
+
+    gpui::StyledText::new(title)
+        .with_highlights(runs)
+        .into_any_element()
+}
+
+/// Draws a keybinding as one chip per key: `⇧⌘K` reads as three caps, and a
+/// multi-keystroke binding puts extra space between its keystrokes.
+fn shortcut_keycap_row(
+    label: &str,
+    text_color: gpui::Rgba,
+    style: &CommandPaletteStyle,
+) -> AnyElement {
+    let keystrokes = shortcut_keycaps(label);
+    if keystrokes.is_empty() {
+        return div().into_any_element();
+    }
+
+    div()
+        .flex_none()
+        .flex()
+        .items_center()
+        .gap(px(COMMAND_PALETTE_KEYSTROKE_GAP))
+        .children(keystrokes.into_iter().map(|keycaps| {
+            div()
+                .flex_none()
+                .flex()
+                .items_center()
+                .gap(px(COMMAND_PALETTE_KEYCAP_GAP))
+                .children(keycaps.into_iter().map(|keycap| {
+                    div()
+                        .flex_none()
+                        .h(px(20.0))
+                        .min_w(px(20.0))
+                        .px(px(5.0))
+                        .flex()
+                        .items_center()
+                        .justify_center()
+                        .rounded(px(COMMAND_PALETTE_SHORTCUT_RADIUS))
+                        .bg(style.shortcut_bg)
+                        .text_size(px(10.0))
+                        .text_color(text_color)
+                        .child(keycap)
+                }))
+        }))
+        .into_any_element()
+}
 
 impl TerminalView {
     pub(super) fn command_palette_scrollbar_range(
@@ -133,6 +213,9 @@ impl TerminalView {
         let selected = self.command_palette.selected_filtered_index().unwrap_or(0);
         let style = CommandPaletteStyle::resolve(self);
         let transparent = self.overlay_style().transparent_background();
+        // Only the Commands list mixes sources; every other mode would repeat
+        // the same category on every row.
+        let show_categories = self.command_palette.mode() == CommandPaletteMode::Commands;
 
         let mut rows = Vec::with_capacity(range.len());
         for index in range {
@@ -181,7 +264,13 @@ impl TerminalView {
                 | CommandPaletteItemKind::AppInfoCopyAll { .. } => None,
             };
             let title = item.title.clone();
-            let status_hint = item.status_hint.clone();
+            let title_highlights = self.command_palette.filtered_title_highlights(index);
+            // An unavailable row always says why on the row itself, instead of
+            // only explaining after someone tries to run it.
+            let status_hint = item
+                .status_hint
+                .clone()
+                .or_else(|| (!is_enabled).then(|| COMMAND_PALETTE_UNAVAILABLE_HINT.to_string()));
             let text_color = if is_enabled {
                 style.primary_text
             } else {
@@ -193,11 +282,16 @@ impl TerminalView {
                 style.muted_text
             };
             let icon_path = palette_item_icon_path(&item);
-            let icon_tint = if is_selected {
-                style.primary_text
+            // Selection is carried by the row background and accent bar alone;
+            // a tint flip here would make every unselected row read as dimmed.
+            let icon_tint = if is_enabled {
+                style.icon_text
             } else {
                 style.muted_text
             };
+            let category = show_categories
+                .then(|| palette_item_category(&item))
+                .flatten();
 
             let selection_accent = is_selected.then(|| {
                 div()
@@ -227,11 +321,16 @@ impl TerminalView {
                     })
                     .children(selection_accent)
                     .when(is_enabled, |row| row.cursor_pointer())
-                    .on_mouse_move(cx.listener(move |this, _event, _window, cx| {
-                        if this.command_palette.set_selected_filtered_index(index) {
-                            this.notify_overlay(cx);
-                        }
-                    }))
+                    .on_mouse_move(
+                        cx.listener(move |this, event: &MouseMoveEvent, _window, cx| {
+                            if !this.command_palette.accept_hover_at(event.position) {
+                                return;
+                            }
+                            if this.command_palette.set_selected_filtered_index(index) {
+                                this.notify_overlay(cx);
+                            }
+                        }),
+                    )
                     .on_mouse_down(
                         MouseButton::Left,
                         cx.listener(move |this, _event, window, cx| {
@@ -261,13 +360,31 @@ impl TerminalView {
                                             .size(px(COMMAND_PALETTE_ROW_ICON_SIZE))
                                             .text_color(icon_tint),
                                     )
-                                    .child(div().flex_1().truncate().child(title)),
+                                    .child(div().flex_1().truncate().child(highlighted_title(
+                                        title,
+                                        &title_highlights,
+                                        is_enabled,
+                                        &style,
+                                    ))),
                             )
                             .child(
                                 div()
                                     .flex()
                                     .items_center()
                                     .gap(px(6.0))
+                                    .children(category.map(|label| {
+                                        div()
+                                            .flex_none()
+                                            .max_w(px(COMMAND_PALETTE_ROW_CATEGORY_MAX_WIDTH))
+                                            // Sits a touch further from the key
+                                            // chips than they sit from each other.
+                                            .mr(px(4.0))
+                                            .overflow_hidden()
+                                            .truncate()
+                                            .text_size(px(11.0))
+                                            .text_color(style.muted_text)
+                                            .child(label)
+                                    }))
                                     .children(status_hint.map(|label| {
                                         div()
                                             .flex_none()
@@ -283,18 +400,7 @@ impl TerminalView {
                                             .child(label)
                                     }))
                                     .children(shortcut.map(|label| {
-                                        div()
-                                            .flex_none()
-                                            .h(px(20.0))
-                                            .px(px(6.0))
-                                            .flex()
-                                            .items_center()
-                                            .justify_center()
-                                            .rounded(px(COMMAND_PALETTE_SHORTCUT_RADIUS))
-                                            .bg(style.shortcut_bg)
-                                            .text_size(px(10.0))
-                                            .text_color(shortcut_text)
-                                            .child(label)
+                                        shortcut_keycap_row(&label, shortcut_text, &style)
                                     })),
                             ),
                     )
@@ -306,108 +412,142 @@ impl TerminalView {
 
     pub(in super::super) fn render_command_palette_modal(
         &mut self,
+        window: &Window,
         cx: &mut Context<Self>,
     ) -> AnyElement {
+        let plugin_ui = self.command_palette_plugin_ui(cx);
+        let plugin_ui_title = plugin_ui
+            .as_ref()
+            .map(|view| view.read(cx).title().to_string());
         let item_count = self.command_palette.filtered_len();
-        let list_height = COMMAND_PALETTE_MAX_ITEMS as f32 * COMMAND_PALETTE_ROW_HEIGHT;
-        let mode_title = match self.command_palette.mode() {
-            CommandPaletteMode::Commands => "Commands".to_string(),
-            CommandPaletteMode::Themes => format!("Theme: {}", self.theme_id),
-            CommandPaletteMode::TmuxSessions => match self.command_palette.tmux_session_intent() {
-                TmuxSessionIntent::AttachOrSwitch => "tmux Sessions".to_string(),
-                TmuxSessionIntent::RenameSelect => "tmux Sessions: Rename".to_string(),
-                TmuxSessionIntent::RenameInput => "tmux Sessions: Rename".to_string(),
-                TmuxSessionIntent::Kill => "tmux Sessions: Kill".to_string(),
-            },
-            CommandPaletteMode::Layouts => match self.command_palette.saved_layout_intent() {
-                SavedLayoutIntent::Browse => "Saved Layouts".to_string(),
-                SavedLayoutIntent::SaveInput => "Saved Layouts: Save".to_string(),
-                SavedLayoutIntent::RenameSelect => "Saved Layouts: Rename".to_string(),
-                SavedLayoutIntent::RenameInput => "Saved Layouts: Rename".to_string(),
-                SavedLayoutIntent::Delete => "Saved Layouts: Delete".to_string(),
-            },
-            CommandPaletteMode::Tasks => match self.current_named_layout.as_deref() {
-                Some(layout_name) if self.command_palette.task_intent() == TaskIntent::Browse => {
-                    format!("Tasks: {layout_name}")
+        let viewport = window.viewport_size();
+        let layout = command_palette_layout_for_viewport(viewport.width.into(), {
+            // The palette lives inside the terminal-scoped overlay, so the
+            // chrome above it is not usable height.
+            let height: f32 = viewport.height.into();
+            (height - self.terminal_content_top_inset()).max(0.0)
+        });
+        self.command_palette.set_visible_rows(layout.visible_rows);
+        let list_height = command_palette_viewport_height(layout.visible_rows);
+        let mode_title = if let Some(title) = plugin_ui_title.as_ref() {
+            title.clone()
+        } else {
+            match self.command_palette.mode() {
+                CommandPaletteMode::Commands => "Commands".to_string(),
+                CommandPaletteMode::Themes => format!("Theme: {}", self.theme_id),
+                CommandPaletteMode::TmuxSessions => {
+                    match self.command_palette.tmux_session_intent() {
+                        TmuxSessionIntent::AttachOrSwitch => "tmux Sessions".to_string(),
+                        TmuxSessionIntent::RenameSelect => "tmux Sessions: Rename".to_string(),
+                        TmuxSessionIntent::RenameInput => "tmux Sessions: Rename".to_string(),
+                        TmuxSessionIntent::Kill => "tmux Sessions: Kill".to_string(),
+                    }
                 }
-                _ => match self.command_palette.task_intent() {
-                    TaskIntent::Browse => "Tasks".to_string(),
-                    TaskIntent::CreateGlobalInput => "Tasks: New".to_string(),
-                    TaskIntent::CreateLayoutInput => match self.current_named_layout.as_deref() {
-                        Some(layout_name) => format!("Tasks: New for {layout_name}"),
-                        None => "Tasks: New".to_string(),
+                CommandPaletteMode::Layouts => match self.command_palette.saved_layout_intent() {
+                    SavedLayoutIntent::Browse => "Saved Layouts".to_string(),
+                    SavedLayoutIntent::SaveInput => "Saved Layouts: Save".to_string(),
+                    SavedLayoutIntent::RenameSelect => "Saved Layouts: Rename".to_string(),
+                    SavedLayoutIntent::RenameInput => "Saved Layouts: Rename".to_string(),
+                    SavedLayoutIntent::Delete => "Saved Layouts: Delete".to_string(),
+                },
+                CommandPaletteMode::Tasks => match self.current_named_layout.as_deref() {
+                    Some(layout_name)
+                        if self.command_palette.task_intent() == TaskIntent::Browse =>
+                    {
+                        format!("Tasks: {layout_name}")
+                    }
+                    _ => match self.command_palette.task_intent() {
+                        TaskIntent::Browse => "Tasks".to_string(),
+                        TaskIntent::CreateGlobalInput => "Tasks: New".to_string(),
+                        TaskIntent::CreateLayoutInput => match self.current_named_layout.as_deref()
+                        {
+                            Some(layout_name) => format!("Tasks: New for {layout_name}"),
+                            None => "Tasks: New".to_string(),
+                        },
                     },
                 },
-            },
-            CommandPaletteMode::PluginInputs => {
-                let progress = self.plugin_input_progress_label();
-                if progress.is_empty() {
-                    self.plugin_input_mode_title()
-                } else {
-                    format!("{} · {progress}", self.plugin_input_mode_title())
+                CommandPaletteMode::PluginInputs => {
+                    let progress = self.plugin_input_progress_label();
+                    if progress.is_empty() {
+                        self.plugin_input_mode_title()
+                    } else {
+                        format!("{} · {progress}", self.plugin_input_mode_title())
+                    }
                 }
+                CommandPaletteMode::AppInfo => "App Info".to_string(),
             }
-            CommandPaletteMode::AppInfo => "App Info".to_string(),
         };
         // (keycap, action) pairs for the footer bar. An empty keycap renders the
         // action as a plain note instead of a key hint.
-        let footer_hints: &[(&str, &str)] = match self.command_palette.mode() {
-            CommandPaletteMode::Commands => &[("↵", "Run"), ("esc", "Close"), ("↑↓", "Navigate")],
-            CommandPaletteMode::Themes => {
-                &[("↵", "Apply Theme"), ("esc", "Back"), ("↑↓", "Navigate")]
+        let footer_hints: &[(&str, &str)] = if plugin_ui.is_some() {
+            &[("esc", "Back"), ("", "Type to search commands")]
+        } else {
+            match self.command_palette.mode() {
+                CommandPaletteMode::Commands => {
+                    &[("↵", "Run"), ("esc", "Close"), ("↑↓", "Navigate")]
+                }
+                CommandPaletteMode::Themes => {
+                    &[("↵", "Apply Theme"), ("esc", "Back"), ("↑↓", "Navigate")]
+                }
+                CommandPaletteMode::TmuxSessions => {
+                    match self.command_palette.tmux_session_intent() {
+                        TmuxSessionIntent::AttachOrSwitch => &[
+                            ("↵", "Open/Create/Manage Session"),
+                            ("esc", "Back"),
+                            ("↑↓", "Navigate"),
+                        ],
+                        TmuxSessionIntent::RenameSelect => {
+                            &[("↵", "Select Session"), ("esc", "Back"), ("↑↓", "Navigate")]
+                        }
+                        TmuxSessionIntent::RenameInput => {
+                            &[("↵", "Rename Session"), ("esc", "Back"), ("↑↓", "Navigate")]
+                        }
+                        TmuxSessionIntent::Kill => {
+                            &[("↵", "Kill Session"), ("esc", "Back"), ("↑↓", "Navigate")]
+                        }
+                    }
+                }
+                CommandPaletteMode::Layouts => match self.command_palette.saved_layout_intent() {
+                    SavedLayoutIntent::Browse => &[
+                        ("↵", "Load/Save/Manage Layout"),
+                        ("esc", "Back"),
+                        ("↑↓", "Navigate"),
+                    ],
+                    SavedLayoutIntent::SaveInput => {
+                        &[("↵", "Save Layout"), ("esc", "Back"), ("↑↓", "Navigate")]
+                    }
+                    SavedLayoutIntent::RenameSelect => {
+                        &[("↵", "Select Layout"), ("esc", "Back"), ("↑↓", "Navigate")]
+                    }
+                    SavedLayoutIntent::RenameInput => {
+                        &[("↵", "Rename Layout"), ("esc", "Back"), ("↑↓", "Navigate")]
+                    }
+                    SavedLayoutIntent::Delete => {
+                        &[("↵", "Delete Layout"), ("esc", "Back"), ("↑↓", "Navigate")]
+                    }
+                },
+                CommandPaletteMode::Tasks => match self.command_palette.task_intent() {
+                    TaskIntent::Browse => &[("↵", "Run Task"), ("esc", "Back"), ("↑↓", "Navigate")],
+                    TaskIntent::CreateGlobalInput | TaskIntent::CreateLayoutInput => &[
+                        ("", "Format: name: command"),
+                        ("↵", "Save Task"),
+                        ("esc", "Back"),
+                    ],
+                },
+                CommandPaletteMode::PluginInputs => {
+                    match (self.plugin_input_is_last(), self.plugin_input_can_go_back()) {
+                        (true, true) => &[("↵", "Run"), ("esc", "Previous"), ("↑↓", "Navigate")],
+                        (true, false) => &[("↵", "Run"), ("esc", "Back"), ("↑↓", "Navigate")],
+                        (false, true) => {
+                            &[("↵", "Continue"), ("esc", "Previous"), ("↑↓", "Navigate")]
+                        }
+                        (false, false) => &[("↵", "Continue"), ("esc", "Back"), ("↑↓", "Navigate")],
+                    }
+                }
+                CommandPaletteMode::AppInfo => {
+                    &[("↵", "Copy"), ("esc", "Back"), ("↑↓", "Navigate")]
+                }
             }
-            CommandPaletteMode::TmuxSessions => match self.command_palette.tmux_session_intent() {
-                TmuxSessionIntent::AttachOrSwitch => &[
-                    ("↵", "Open/Create/Manage Session"),
-                    ("esc", "Back"),
-                    ("↑↓", "Navigate"),
-                ],
-                TmuxSessionIntent::RenameSelect => {
-                    &[("↵", "Select Session"), ("esc", "Back"), ("↑↓", "Navigate")]
-                }
-                TmuxSessionIntent::RenameInput => {
-                    &[("↵", "Rename Session"), ("esc", "Back"), ("↑↓", "Navigate")]
-                }
-                TmuxSessionIntent::Kill => {
-                    &[("↵", "Kill Session"), ("esc", "Back"), ("↑↓", "Navigate")]
-                }
-            },
-            CommandPaletteMode::Layouts => match self.command_palette.saved_layout_intent() {
-                SavedLayoutIntent::Browse => &[
-                    ("↵", "Load/Save/Manage Layout"),
-                    ("esc", "Back"),
-                    ("↑↓", "Navigate"),
-                ],
-                SavedLayoutIntent::SaveInput => {
-                    &[("↵", "Save Layout"), ("esc", "Back"), ("↑↓", "Navigate")]
-                }
-                SavedLayoutIntent::RenameSelect => {
-                    &[("↵", "Select Layout"), ("esc", "Back"), ("↑↓", "Navigate")]
-                }
-                SavedLayoutIntent::RenameInput => {
-                    &[("↵", "Rename Layout"), ("esc", "Back"), ("↑↓", "Navigate")]
-                }
-                SavedLayoutIntent::Delete => {
-                    &[("↵", "Delete Layout"), ("esc", "Back"), ("↑↓", "Navigate")]
-                }
-            },
-            CommandPaletteMode::Tasks => match self.command_palette.task_intent() {
-                TaskIntent::Browse => &[("↵", "Run Task"), ("esc", "Back"), ("↑↓", "Navigate")],
-                TaskIntent::CreateGlobalInput | TaskIntent::CreateLayoutInput => &[
-                    ("", "Format: name: command"),
-                    ("↵", "Save Task"),
-                    ("esc", "Back"),
-                ],
-            },
-            CommandPaletteMode::PluginInputs => {
-                match (self.plugin_input_is_last(), self.plugin_input_can_go_back()) {
-                    (true, true) => &[("↵", "Run"), ("esc", "Previous"), ("↑↓", "Navigate")],
-                    (true, false) => &[("↵", "Run"), ("esc", "Back"), ("↑↓", "Navigate")],
-                    (false, true) => &[("↵", "Continue"), ("esc", "Previous"), ("↑↓", "Navigate")],
-                    (false, false) => &[("↵", "Continue"), ("esc", "Back"), ("↑↓", "Navigate")],
-                }
-            }
-            CommandPaletteMode::AppInfo => &[("↵", "Copy"), ("esc", "Back"), ("↑↓", "Navigate")],
         };
         let style = CommandPaletteStyle::resolve(self);
         let input_font = Font {
@@ -441,7 +581,16 @@ impl TerminalView {
             _ => "No matching items",
         };
 
-        let list = if item_count == 0 {
+        let list = if let Some(plugin_ui) = plugin_ui.clone() {
+            div()
+                .id("command-palette-plugin-ui")
+                .w_full()
+                .h(px(list_height))
+                .min_h(px(0.0))
+                .overflow_hidden()
+                .child(plugin_ui)
+                .into_any_element()
+        } else if item_count == 0 {
             div()
                 .w_full()
                 .py(px(28.0))
@@ -554,32 +703,40 @@ impl TerminalView {
         let mut divider = style.muted_text;
         divider.a = COMMAND_PALETTE_DIVIDER_ALPHA;
 
-        let mode_chip: Option<AnyElement> =
-            if matches!(self.command_palette.mode(), CommandPaletteMode::Commands) {
-                None
-            } else {
-                Some(
-                    div()
-                        .flex_none()
-                        .max_w(px(260.0))
-                        .h(px(22.0))
-                        .px(px(8.0))
-                        .rounded(px(COMMAND_PALETTE_SHORTCUT_RADIUS))
-                        .bg(style.shortcut_bg)
-                        .overflow_hidden()
-                        .text_size(px(10.0))
-                        .text_color(style.muted_text)
-                        .flex()
-                        .items_center()
-                        .child(div().min_w(px(0.0)).truncate().child(mode_title))
-                        .into_any_element(),
-                )
-            };
+        // Breadcrumb, not a trailing tag: which sub-mode you are in decides what
+        // Enter does, so it reads before the query instead of after it.
+        let mode_breadcrumb: Option<AnyElement> = if plugin_ui.is_none()
+            && matches!(self.command_palette.mode(), CommandPaletteMode::Commands)
+        {
+            None
+        } else {
+            Some(
+                div()
+                    .flex_none()
+                    .max_w(px(COMMAND_PALETTE_BREADCRUMB_MAX_WIDTH))
+                    .h(px(22.0))
+                    .px(px(8.0))
+                    .rounded(px(COMMAND_PALETTE_SHORTCUT_RADIUS))
+                    .bg(style.shortcut_bg)
+                    .overflow_hidden()
+                    .text_size(px(11.0))
+                    .text_color(style.primary_text)
+                    .flex()
+                    .items_center()
+                    .child(div().min_w(px(0.0)).truncate().child(mode_title))
+                    .into_any_element(),
+            )
+        };
 
-        let input_placeholder = (self.command_palette.mode() == CommandPaletteMode::PluginInputs
-            && self.command_palette.input().text().is_empty())
-        .then(|| self.plugin_input_placeholder())
-        .filter(|placeholder| !placeholder.is_empty());
+        let input_placeholder =
+            if plugin_ui.is_some() && self.command_palette.input().text().is_empty() {
+                Some("Search commands…".to_string())
+            } else {
+                (self.command_palette.mode() == CommandPaletteMode::PluginInputs
+                    && self.command_palette.input().text().is_empty())
+                .then(|| self.plugin_input_placeholder())
+                .filter(|placeholder| !placeholder.is_empty())
+            };
         let input_head = div()
             .id("command-palette-input")
             .w_full()
@@ -594,6 +751,7 @@ impl TerminalView {
                     .size(px(18.0))
                     .text_color(style.muted_text),
             )
+            .children(mode_breadcrumb)
             .child(
                 div()
                     .flex_1()
@@ -620,13 +778,16 @@ impl TerminalView {
                         InlineInputAlignment::Left,
                         cx,
                     )),
-            )
-            .children(mode_chip);
+            );
 
-        let result_counter = format!(
-            "{item_count} {}",
-            if item_count == 1 { "item" } else { "items" }
-        );
+        let result_counter = if plugin_ui.is_some() {
+            "Plugin UI".to_string()
+        } else {
+            format!(
+                "{item_count} {}",
+                if item_count == 1 { "item" } else { "items" }
+            )
+        };
         let footer = div()
             .w_full()
             .h(px(COMMAND_PALETTE_FOOTER_HEIGHT))
@@ -681,7 +842,7 @@ impl TerminalView {
 
         let panel = div()
             .id("command-palette-panel")
-            .w(px(COMMAND_PALETTE_WIDTH))
+            .w(px(layout.width))
             .rounded(px(COMMAND_PALETTE_PANEL_RADIUS))
             .bg(style.panel_bg)
             .border_1()
@@ -702,7 +863,8 @@ impl TerminalView {
             .child(div().h(px(1.0)).w_full().bg(divider))
             .child(footer);
 
-        let scrollbar_drag_active = self.command_palette_scrollbar_drag.is_some();
+        let scrollbar_drag_active =
+            plugin_ui.is_none() && self.command_palette_scrollbar_drag.is_some();
         div()
             .id("command-palette-modal")
             .size_full()
@@ -754,7 +916,7 @@ impl TerminalView {
                     .flex()
                     .flex_col()
                     .items_center()
-                    .pt(px(COMMAND_PALETTE_TOP_OFFSET))
+                    .pt(px(layout.top_offset))
                     .child(panel),
             )
             .into_any()

--- a/crates/desktop_app/src/terminal_view/command_palette/state.rs
+++ b/crates/desktop_app/src/terminal_view/command_palette/state.rs
@@ -1,10 +1,13 @@
 use super::super::*;
+use super::fuzzy::{self, FuzzyMatch, FuzzyQuery};
 use super::plugins::PluginInputSession;
+use super::recents::CommandPaletteRecents;
 use super::state_layouts::SavedLayoutIntent;
 use super::state_tmux::{TmuxSessionIntent, TmuxSessionRow, TmuxSessionStatusHint};
 use crate::config::SHELL_DECIDE_THEME_ID;
-use gpui::UniformListScrollHandle;
+use gpui::{Pixels, Point, UniformListScrollHandle};
 use std::collections::HashMap;
+use std::ops::Range;
 #[cfg(unix)]
 #[cfg(test)]
 use std::os::unix::fs::PermissionsExt;
@@ -20,6 +23,26 @@ pub(in super::super) enum CommandPaletteMode {
     Tasks,
     PluginInputs,
     AppInfo,
+}
+
+impl CommandPaletteMode {
+    /// Modes whose rows come from a flat catalog rank by match quality; modes
+    /// that build curated lists (sessions, layouts, tasks, plugin options) keep
+    /// the order their builder chose.
+    fn ranking(self) -> CommandPaletteRanking {
+        match self {
+            Self::Commands | Self::Themes | Self::AppInfo => CommandPaletteRanking::ByScore,
+            Self::TmuxSessions | Self::Layouts | Self::Tasks | Self::PluginInputs => {
+                CommandPaletteRanking::PreserveOrder
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum CommandPaletteScrollDirection {
+    Up,
+    Down,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -252,8 +275,16 @@ pub(in super::super) struct CommandPaletteState {
     pub(super) saved_layout_rename_source: Option<String>,
     input: InlineInputState,
     items: Vec<CommandPaletteItem>,
-    filtered_indices: Vec<usize>,
+    filtered: Vec<CommandPaletteMatch>,
+    recents: CommandPaletteRecents,
     selected_filtered_index: usize,
+    /// Rows the list can show at once, recomputed from the window size.
+    visible_rows: usize,
+    /// Last pointer position seen over the list. Hover only takes over the
+    /// selection once the pointer actually moves, so a list scrolling under a
+    /// resting cursor cannot yank the keyboard selection back.
+    pointer_position: Option<Point<Pixels>>,
+    hover_locked: bool,
     scroll_handle: UniformListScrollHandle,
     scroll_target_y: Option<f32>,
     scroll_max_y: f32,
@@ -283,8 +314,12 @@ impl CommandPaletteState {
             saved_layout_rename_source: None,
             input: InlineInputState::new(String::new()),
             items: Vec::new(),
-            filtered_indices: Vec::new(),
+            filtered: Vec::new(),
+            recents: CommandPaletteRecents::default(),
             selected_filtered_index: 0,
+            visible_rows: COMMAND_PALETTE_MAX_ITEMS,
+            pointer_position: None,
+            hover_locked: false,
             scroll_handle: UniformListScrollHandle::new(),
             scroll_target_y: None,
             scroll_max_y: 0.0,
@@ -347,9 +382,27 @@ impl CommandPaletteState {
     }
 
     pub(super) fn set_items_unfiltered(&mut self, items: Vec<CommandPaletteItem>) {
-        self.filtered_indices = (0..items.len()).collect();
+        self.filtered = (0..items.len())
+            .map(|item_index| CommandPaletteMatch {
+                item_index,
+                ..CommandPaletteMatch::default()
+            })
+            .collect();
         self.items = items;
         self.clamp_selection();
+    }
+
+    /// Re-reads the persisted most-recently-used commands so a palette opened
+    /// in one window reflects commands run in another.
+    pub(in super::super) fn reload_recents(&mut self) {
+        self.recents = CommandPaletteRecents::load();
+    }
+
+    pub(super) fn record_recent_item(&mut self, item: &CommandPaletteItem) {
+        let Some(key) = super::recents::recent_key_for_item(item) else {
+            return;
+        };
+        self.recents.record(key);
     }
 
     pub(super) fn reset_for_next_plugin_input(&mut self) {
@@ -391,19 +444,33 @@ impl CommandPaletteState {
     }
 
     pub(super) fn refilter_current_query(&mut self) {
-        let filtered_indices =
-            filter_command_palette_item_indices_by_query(&self.items, self.input.text());
-        self.filtered_indices = filtered_indices;
+        // Typing is keyboard intent: the row under a resting cursor must not
+        // steal the selection when the list re-orders beneath it.
+        self.lock_hover();
+        self.filtered = rank_command_palette_items(
+            &self.items,
+            self.input.text(),
+            &self.recents,
+            self.mode.ranking(),
+        );
         self.clamp_selection();
     }
 
     pub(super) fn filtered_len(&self) -> usize {
-        self.filtered_indices.len()
+        self.filtered.len()
     }
 
     pub(super) fn filtered_item(&self, filtered_index: usize) -> Option<&CommandPaletteItem> {
-        let item_index = *self.filtered_indices.get(filtered_index)?;
-        self.items.get(item_index)
+        let matched = self.filtered.get(filtered_index)?;
+        self.items.get(matched.item_index)
+    }
+
+    /// Title byte ranges that matched the current query, for highlighting.
+    pub(super) fn filtered_title_highlights(&self, filtered_index: usize) -> Vec<Range<usize>> {
+        self.filtered
+            .get(filtered_index)
+            .map(|matched| matched.title_highlights.clone())
+            .unwrap_or_default()
     }
 
     pub(super) fn selected_filtered_index(&self) -> Option<usize> {
@@ -432,6 +499,7 @@ impl CommandPaletteState {
         let Some(selected) = self.selected_filtered_index() else {
             return false;
         };
+        self.lock_hover();
         if selected == 0 {
             return false;
         }
@@ -442,11 +510,69 @@ impl CommandPaletteState {
         let Some(selected) = self.selected_filtered_index() else {
             return false;
         };
+        self.lock_hover();
         let len = self.filtered_len();
         if selected + 1 >= len {
             return false;
         }
         self.set_selected_filtered_index(selected + 1)
+    }
+
+    /// Moves by one screenful, stopping at the ends of the list.
+    pub(super) fn move_selection_page(&mut self, direction: CommandPaletteScrollDirection) -> bool {
+        let Some(selected) = self.selected_filtered_index() else {
+            return false;
+        };
+        self.lock_hover();
+        let page = self.visible_rows.max(1);
+        let target = match direction {
+            CommandPaletteScrollDirection::Up => selected.saturating_sub(page),
+            CommandPaletteScrollDirection::Down => selected
+                .saturating_add(page)
+                .min(self.filtered_len().saturating_sub(1)),
+        };
+        self.set_selected_filtered_index(target)
+    }
+
+    pub(super) fn move_selection_to_edge(
+        &mut self,
+        direction: CommandPaletteScrollDirection,
+    ) -> bool {
+        if self.selected_filtered_index().is_none() {
+            return false;
+        }
+        self.lock_hover();
+        let target = match direction {
+            CommandPaletteScrollDirection::Up => 0,
+            CommandPaletteScrollDirection::Down => self.filtered_len().saturating_sub(1),
+        };
+        self.set_selected_filtered_index(target)
+    }
+
+    pub(super) fn visible_rows(&self) -> usize {
+        self.visible_rows
+    }
+
+    pub(super) fn set_visible_rows(&mut self, visible_rows: usize) {
+        self.visible_rows = visible_rows.max(1);
+    }
+
+    /// Suspends hover-to-select until the pointer physically moves again.
+    fn lock_hover(&mut self) {
+        self.hover_locked = true;
+    }
+
+    /// Records a pointer sample over the list and reports whether hover should
+    /// drive the selection. Returns `false` for events that repeat the last
+    /// position, which is what the platform emits when the list scrolls beneath
+    /// a resting cursor.
+    pub(super) fn accept_hover_at(&mut self, position: Point<Pixels>) -> bool {
+        let moved = self.pointer_position != Some(position);
+        self.pointer_position = Some(position);
+        if moved {
+            self.hover_locked = false;
+        }
+        !self.hover_locked
     }
 
     pub(super) fn base_scroll_handle(&self) -> gpui::ScrollHandle {
@@ -474,7 +600,7 @@ impl CommandPaletteState {
     }
 
     pub(super) fn set_scroll_max_y_for_count(&mut self, item_count: usize) {
-        self.scroll_max_y = command_palette_max_scroll_for_count(item_count);
+        self.scroll_max_y = command_palette_max_scroll_for_count(item_count, self.visible_rows);
     }
 
     pub(super) fn is_scroll_animating(&self) -> bool {
@@ -517,7 +643,11 @@ impl CommandPaletteState {
     fn reset_for_mode(&mut self) {
         self.input.clear();
         self.items.clear();
-        self.filtered_indices.clear();
+        self.filtered.clear();
+        // A pointer sample from the previous mode must not decide whether the
+        // first hover in this one counts as movement.
+        self.pointer_position = None;
+        self.hover_locked = false;
         self.selected_filtered_index = 0;
         self.scroll_handle = UniformListScrollHandle::new();
         self.shortcut_cache.clear();
@@ -566,71 +696,175 @@ pub(super) fn ordered_theme_ids_for_palette(
     theme_ids
 }
 
-pub(super) fn filter_command_palette_item_indices_by_query(
+/// A row that survived filtering, together with the title ranges that matched
+/// the query so the renderer can highlight them.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(super) struct CommandPaletteMatch {
+    pub(super) item_index: usize,
+    /// Byte ranges into the item title, ascending and disjoint.
+    pub(super) title_highlights: Vec<Range<usize>>,
+    score: i32,
+}
+
+/// Whether a mode wants rows reordered by match quality, or presented in the
+/// order its item builder produced (session lists, plugin option lists, and
+/// other curated lists rely on their own ordering).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum CommandPaletteRanking {
+    ByScore,
+    PreserveOrder,
+}
+
+/// Filters `items` by `query` and, for score-ranked modes, orders them by
+/// relevance with recently executed commands boosted.
+pub(super) fn rank_command_palette_items(
     items: &[CommandPaletteItem],
     query: &str,
-) -> Vec<usize> {
-    let query = query.trim().to_ascii_lowercase();
-    let query_terms: Vec<String> = query
-        .split(|ch: char| !ch.is_ascii_alphanumeric())
-        .filter(|term| !term.is_empty())
-        .map(ToOwned::to_owned)
-        .collect();
+    recents: &CommandPaletteRecents,
+    ranking: CommandPaletteRanking,
+) -> Vec<CommandPaletteMatch> {
+    let Some(query) = FuzzyQuery::new(query) else {
+        return unfiltered_matches(items, recents, ranking);
+    };
 
-    if query_terms.is_empty() {
-        return (0..items.len()).collect();
-    }
-
-    let has_title_matches = items
+    let title_matches: Vec<Option<FuzzyMatch>> = items
         .iter()
-        .any(|item| command_palette_text_matches_terms(&item.title, &query_terms));
+        .map(|item| fuzzy::match_text(&item.title, &query))
+        .collect();
+    // Keyword hits are a fallback only: when any title matches, keyword-only
+    // rows stay hidden so a typed word does not drag in loosely related rows.
+    let has_title_matches = title_matches.iter().any(Option::is_some);
 
-    items
+    let mut matches: Vec<CommandPaletteMatch> = items
         .iter()
         .enumerate()
-        .filter_map(|(index, item)| {
-            let title_match = command_palette_text_matches_terms(&item.title, &query_terms);
-            let matches = if has_title_matches {
-                title_match
-            } else {
-                title_match || command_palette_text_matches_terms(&item.keywords, &query_terms)
+        .zip(title_matches)
+        .filter_map(|((item_index, item), title_match)| {
+            let (score, title_highlights) = match title_match {
+                Some(matched) => (matched.score, matched.ranges),
+                None if has_title_matches => return None,
+                None => (fuzzy::match_text(&item.keywords, &query)?.score, Vec::new()),
             };
-            matches.then_some(index)
-        })
-        .collect()
-}
 
-fn command_palette_text_matches_terms(text: &str, query_terms: &[String]) -> bool {
-    let searchable = text.to_ascii_lowercase();
-    let words: Vec<&str> = searchable
-        .split(|ch: char| !ch.is_ascii_alphanumeric())
-        .filter(|word| !word.is_empty())
+            Some(CommandPaletteMatch {
+                item_index,
+                title_highlights,
+                score: score + recents.bonus_for_item(item),
+            })
+        })
         .collect();
 
-    query_terms
-        .iter()
-        .all(|term| words.iter().any(|word| word.starts_with(term)))
+    if ranking == CommandPaletteRanking::ByScore {
+        // Unavailable rows sink below every runnable one, whatever they score:
+        // they stay reachable (with their reason on the row) without pushing
+        // runnable commands out of the first screenful. Stable sort keeps the
+        // builder's order for equally scored rows.
+        matches.sort_by_key(|matched| {
+            (
+                !items[matched.item_index].enabled,
+                std::cmp::Reverse(matched.score),
+            )
+        });
+    }
+
+    matches
 }
 
-pub(super) fn command_palette_viewport_height() -> f32 {
-    COMMAND_PALETTE_MAX_ITEMS as f32 * COMMAND_PALETTE_ROW_HEIGHT
+/// Empty-query ordering: recently executed rows first (most recent first),
+/// everything else in its original order.
+fn unfiltered_matches(
+    items: &[CommandPaletteItem],
+    recents: &CommandPaletteRecents,
+    ranking: CommandPaletteRanking,
+) -> Vec<CommandPaletteMatch> {
+    let mut matches: Vec<CommandPaletteMatch> = (0..items.len())
+        .map(|item_index| CommandPaletteMatch {
+            item_index,
+            title_highlights: Vec::new(),
+            score: 0,
+        })
+        .collect();
+
+    if ranking == CommandPaletteRanking::ByScore {
+        matches.sort_by_key(|matched| {
+            let item = &items[matched.item_index];
+            (
+                !item.enabled,
+                recents.rank_for_item(item).unwrap_or(usize::MAX),
+            )
+        });
+    }
+
+    matches
 }
 
-pub(super) fn command_palette_max_scroll_for_count(item_count: usize) -> f32 {
-    (item_count as f32 * COMMAND_PALETTE_ROW_HEIGHT - command_palette_viewport_height()).max(0.0)
+/// Panel geometry for the window the palette is drawn in.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(super) struct CommandPaletteLayout {
+    pub(super) width: f32,
+    pub(super) top_offset: f32,
+    pub(super) visible_rows: usize,
+}
+
+/// Fits the panel to the space it actually has. The preferred width, top
+/// offset, and row count are unchanged on a normal window; they only shrink
+/// when the panel would otherwise overflow.
+pub(super) fn command_palette_layout_for_viewport(
+    viewport_width: f32,
+    viewport_height: f32,
+) -> CommandPaletteLayout {
+    let width = (viewport_width - COMMAND_PALETTE_VIEWPORT_MARGIN_X * 2.0)
+        .clamp(COMMAND_PALETTE_MIN_WIDTH, COMMAND_PALETTE_WIDTH)
+        .min(viewport_width.max(1.0));
+
+    let top_offset = COMMAND_PALETTE_TOP_OFFSET
+        .min(viewport_height * COMMAND_PALETTE_TOP_OFFSET_RATIO)
+        .max(COMMAND_PALETTE_MIN_TOP_OFFSET);
+
+    // Everything above and below the list: the offset from the window top, the
+    // input head, both dividers, the list padding, the footer, and a margin so
+    // the panel never touches the bottom edge.
+    let chrome_height = top_offset
+        + COMMAND_PALETTE_INPUT_HEAD_HEIGHT
+        + COMMAND_PALETTE_FOOTER_HEIGHT
+        + COMMAND_PALETTE_LIST_PADDING_Y * 2.0
+        + 2.0
+        + COMMAND_PALETTE_VIEWPORT_MARGIN_Y;
+    let rows_that_fit = ((viewport_height - chrome_height) / COMMAND_PALETTE_ROW_HEIGHT).floor();
+    let visible_rows = if rows_that_fit.is_finite() && rows_that_fit > 0.0 {
+        (rows_that_fit as usize).clamp(COMMAND_PALETTE_MIN_ITEMS, COMMAND_PALETTE_MAX_ITEMS)
+    } else {
+        COMMAND_PALETTE_MIN_ITEMS
+    };
+
+    CommandPaletteLayout {
+        width,
+        top_offset,
+        visible_rows,
+    }
+}
+
+pub(super) fn command_palette_viewport_height(visible_rows: usize) -> f32 {
+    visible_rows as f32 * COMMAND_PALETTE_ROW_HEIGHT
+}
+
+pub(super) fn command_palette_max_scroll_for_count(item_count: usize, visible_rows: usize) -> f32 {
+    (item_count as f32 * COMMAND_PALETTE_ROW_HEIGHT - command_palette_viewport_height(visible_rows))
+        .max(0.0)
 }
 
 pub(super) fn command_palette_target_scroll_y(
     current_y: f32,
     selected_index: usize,
     item_count: usize,
+    visible_rows: usize,
 ) -> Option<f32> {
     if item_count == 0 {
         return None;
     }
 
-    let viewport_height = command_palette_viewport_height();
-    let max_scroll = command_palette_max_scroll_for_count(item_count);
+    let viewport_height = command_palette_viewport_height(visible_rows);
+    let max_scroll = command_palette_max_scroll_for_count(item_count, visible_rows);
     let row_top = selected_index as f32 * COMMAND_PALETTE_ROW_HEIGHT;
     let row_bottom = row_top + COMMAND_PALETTE_ROW_HEIGHT;
 
@@ -717,6 +951,24 @@ mod tests {
         CommandPaletteItem::command_with_state(title, keywords, action, true, None)
     }
 
+    fn ranked_actions(items: &[CommandPaletteItem], query: &str) -> Vec<CommandAction> {
+        ranked_actions_with_recents(items, query, &CommandPaletteRecents::default())
+    }
+
+    fn ranked_actions_with_recents(
+        items: &[CommandPaletteItem],
+        query: &str,
+        recents: &CommandPaletteRecents,
+    ) -> Vec<CommandAction> {
+        rank_command_palette_items(items, query, recents, CommandPaletteRanking::ByScore)
+            .into_iter()
+            .filter_map(|matched| match items[matched.item_index].kind {
+                CommandPaletteItemKind::Command(action) => Some(action),
+                _ => None,
+            })
+            .collect()
+    }
+
     #[test]
     fn command_exists_in_path_finds_executable_file() {
         let dir = tempdir().expect("tempdir");
@@ -750,7 +1002,7 @@ mod tests {
     }
 
     #[test]
-    fn query_re_prefers_title_matches_over_keywords() {
+    fn query_re_ranks_prefix_titles_first_and_hides_keyword_only_rows() {
         let items = vec![
             command_item("Close Tab", "remove tab", CommandAction::CloseTab),
             command_item("Rename Tab", "title name", CommandAction::RenameTab),
@@ -767,21 +1019,18 @@ mod tests {
             ),
         ];
 
-        let filtered_indices = filter_command_palette_item_indices_by_query(&items, "re");
-        let actions: Vec<CommandAction> = filtered_indices
-            .into_iter()
-            .filter_map(|index| match items[index].kind {
-                CommandPaletteItemKind::Command(action) => Some(action),
-                _ => None,
-            })
-            .collect();
+        let actions = ranked_actions(&items, "re");
 
+        // "Close Tab" only matches through its keywords, so it stays hidden
+        // while titles match. "Check for Updates" matches as a scattered
+        // subsequence and ranks below the three prefix matches.
         assert_eq!(
             actions,
             vec![
                 CommandAction::RenameTab,
                 CommandAction::RestartApp,
-                CommandAction::ZoomReset
+                CommandAction::ZoomReset,
+                CommandAction::CheckForUpdates,
             ]
         );
     }
@@ -789,28 +1038,14 @@ mod tests {
     #[test]
     fn query_uses_keywords_when_no_titles_match() {
         let items = vec![
-            command_item("Zoom In", "font increase", CommandAction::ZoomIn),
-            command_item("Zoom Out", "font decrease", CommandAction::ZoomOut),
-            command_item("Reset Zoom", "font default", CommandAction::ZoomReset),
+            command_item("Zoom In", "increase", CommandAction::ZoomIn),
+            command_item("Zoom Out", "decrease", CommandAction::ZoomOut),
+            command_item("Reset Zoom", "default", CommandAction::ZoomReset),
         ];
 
-        let filtered_indices = filter_command_palette_item_indices_by_query(&items, "font");
-        let actions: Vec<CommandAction> = filtered_indices
-            .into_iter()
-            .filter_map(|index| match items[index].kind {
-                CommandPaletteItemKind::Command(action) => Some(action),
-                _ => None,
-            })
-            .collect();
+        let actions = ranked_actions(&items, "decrease");
 
-        assert_eq!(
-            actions,
-            vec![
-                CommandAction::ZoomIn,
-                CommandAction::ZoomOut,
-                CommandAction::ZoomReset
-            ]
-        );
+        assert_eq!(actions, vec![CommandAction::ZoomOut]);
     }
 
     #[test]
@@ -821,13 +1056,154 @@ mod tests {
             command_item("Nord", "theme", CommandAction::SwitchTheme),
         ];
 
-        let filtered_indices = filter_command_palette_item_indices_by_query(&items, "tokyo-night");
-        let titles: Vec<&str> = filtered_indices
-            .into_iter()
-            .map(|index| items[index].title.as_str())
+        let matches = rank_command_palette_items(
+            &items,
+            "tokyo-night",
+            &CommandPaletteRecents::default(),
+            CommandPaletteRanking::ByScore,
+        );
+        let titles: Vec<&str> = matches
+            .iter()
+            .map(|matched| items[matched.item_index].title.as_str())
             .collect();
 
         assert_eq!(titles, vec!["Tokyo Night"]);
+    }
+
+    #[test]
+    fn fuzzy_initials_match_and_rank_above_scattered_hits() {
+        let items = vec![
+            command_item("Close Tab", "close", CommandAction::CloseTab),
+            command_item("New Tab", "new", CommandAction::NewTab),
+            command_item("Copy Text", "copy", CommandAction::Copy),
+        ];
+
+        let actions = ranked_actions(&items, "nt");
+
+        assert_eq!(actions.first(), Some(&CommandAction::NewTab));
+    }
+
+    #[test]
+    fn recent_commands_are_boosted_and_lead_the_unfiltered_list() {
+        let items = vec![
+            command_item("New Tab", "tab", CommandAction::NewTab),
+            command_item("Close Tab", "tab", CommandAction::CloseTab),
+            command_item("Rename Tab", "tab", CommandAction::RenameTab),
+        ];
+
+        let mut recents = CommandPaletteRecents::default();
+        recents.push(
+            CommandAction::RenameTab
+                .to_command_id()
+                .config_name()
+                .into(),
+        );
+
+        assert_eq!(
+            ranked_actions_with_recents(&items, "", &recents),
+            vec![
+                CommandAction::RenameTab,
+                CommandAction::NewTab,
+                CommandAction::CloseTab,
+            ]
+        );
+
+        // The boost is a tiebreaker: a stronger title match still wins.
+        assert_eq!(
+            ranked_actions_with_recents(&items, "tab", &recents).first(),
+            Some(&CommandAction::RenameTab)
+        );
+        assert_eq!(
+            ranked_actions_with_recents(&items, "close", &recents).first(),
+            Some(&CommandAction::CloseTab)
+        );
+    }
+
+    #[test]
+    fn unavailable_rows_sink_below_runnable_ones() {
+        let items = vec![
+            CommandPaletteItem::command_with_state(
+                "New Browser Tab",
+                "tab",
+                CommandAction::NewBrowserTab,
+                false,
+                Some("Disabled"),
+            ),
+            command_item("Rename Tab", "tab", CommandAction::RenameTab),
+            command_item("New Tab", "tab", CommandAction::NewTab),
+        ];
+
+        // "New Browser Tab" is the strongest match for "new" but is disabled,
+        // so it still lands last.
+        assert_eq!(
+            ranked_actions(&items, "new"),
+            vec![CommandAction::NewTab, CommandAction::NewBrowserTab]
+        );
+        assert_eq!(
+            ranked_actions(&items, "tab").last(),
+            Some(&CommandAction::NewBrowserTab)
+        );
+        assert_eq!(
+            ranked_actions(&items, "").last(),
+            Some(&CommandAction::NewBrowserTab)
+        );
+    }
+
+    #[test]
+    fn unavailable_rows_keep_builder_order_in_curated_modes() {
+        let items = vec![
+            CommandPaletteItem::command_with_state(
+                "Install CLI",
+                "cli",
+                CommandAction::InstallCli,
+                false,
+                Some("Installed"),
+            ),
+            command_item("New Tab", "tab", CommandAction::NewTab),
+        ];
+
+        let matches = rank_command_palette_items(
+            &items,
+            "",
+            &CommandPaletteRecents::default(),
+            CommandPaletteRanking::PreserveOrder,
+        );
+        let order: Vec<usize> = matches.iter().map(|matched| matched.item_index).collect();
+
+        assert_eq!(order, vec![0, 1]);
+    }
+
+    #[test]
+    fn title_highlights_cover_the_matched_characters() {
+        let items = vec![command_item("New Tab", "tab", CommandAction::NewTab)];
+
+        let matches = rank_command_palette_items(
+            &items,
+            "nt",
+            &CommandPaletteRecents::default(),
+            CommandPaletteRanking::ByScore,
+        );
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].title_highlights, vec![0..1, 4..5]);
+    }
+
+    #[test]
+    fn curated_modes_keep_builder_order() {
+        let items = vec![
+            command_item("Zoom Out", "zoom", CommandAction::ZoomOut),
+            command_item("Zoom", "zoom", CommandAction::ZoomIn),
+        ];
+
+        let matches = rank_command_palette_items(
+            &items,
+            "zoom",
+            &CommandPaletteRecents::default(),
+            CommandPaletteRanking::PreserveOrder,
+        );
+        let order: Vec<usize> = matches.iter().map(|matched| matched.item_index).collect();
+
+        assert_eq!(order, vec![0, 1]);
     }
 
     #[test]
@@ -870,13 +1246,140 @@ mod tests {
 
     #[test]
     fn target_scroll_y_only_moves_when_selection_leaves_viewport() {
-        assert_eq!(command_palette_target_scroll_y(0.0, 2, 12), Some(0.0));
+        let rows = COMMAND_PALETTE_MAX_ITEMS;
+        assert_eq!(command_palette_target_scroll_y(0.0, 2, 12, rows), Some(0.0));
         assert_eq!(
-            command_palette_target_scroll_y(0.0, 9, 12),
-            Some((10.0 * COMMAND_PALETTE_ROW_HEIGHT) - command_palette_viewport_height())
+            command_palette_target_scroll_y(0.0, 9, 12, rows),
+            Some((10.0 * COMMAND_PALETTE_ROW_HEIGHT) - command_palette_viewport_height(rows))
         );
-        assert_eq!(command_palette_target_scroll_y(90.0, 0, 12), Some(0.0));
-        assert_eq!(command_palette_target_scroll_y(0.0, 0, 0), None);
+        assert_eq!(
+            command_palette_target_scroll_y(90.0, 0, 12, rows),
+            Some(0.0)
+        );
+        assert_eq!(command_palette_target_scroll_y(0.0, 0, 0, rows), None);
+    }
+
+    #[test]
+    fn target_scroll_y_follows_a_shrunken_viewport() {
+        // With only three rows visible, selecting row 5 has to scroll further
+        // than it would in the full-height list.
+        let short = command_palette_target_scroll_y(0.0, 5, 12, 3).expect("target");
+        let tall = command_palette_target_scroll_y(0.0, 5, 12, 8).expect("target");
+        assert!(short > tall, "short {short} should scroll past tall {tall}");
+        assert_eq!(
+            short,
+            6.0 * COMMAND_PALETTE_ROW_HEIGHT - 3.0 * COMMAND_PALETTE_ROW_HEIGHT
+        );
+    }
+
+    #[test]
+    fn hover_is_ignored_until_the_pointer_actually_moves() {
+        let mut state = CommandPaletteState::new(true);
+        state.set_items(vec![
+            command_item("New Tab", "tab", CommandAction::NewTab),
+            command_item("Close Tab", "tab", CommandAction::CloseTab),
+            command_item("Rename Tab", "tab", CommandAction::RenameTab),
+        ]);
+
+        let resting = point(px(10.0), px(20.0));
+        assert!(
+            state.accept_hover_at(resting),
+            "first sample is a real move"
+        );
+
+        // Keyboard navigation locks hover; the platform then re-sends the same
+        // pointer position as the list scrolls beneath the cursor.
+        assert!(state.move_selection_down());
+        assert_eq!(state.selected_filtered_index(), Some(1));
+        assert!(!state.accept_hover_at(resting));
+        assert_eq!(state.selected_filtered_index(), Some(1));
+
+        // A genuine move re-enables hover.
+        assert!(state.accept_hover_at(point(px(10.0), px(48.0))));
+    }
+
+    #[test]
+    fn typing_locks_hover_so_results_do_not_jump_to_the_cursor() {
+        let mut state = CommandPaletteState::new(true);
+        state.set_items(vec![
+            command_item("New Tab", "tab", CommandAction::NewTab),
+            command_item("Close Tab", "tab", CommandAction::CloseTab),
+        ]);
+
+        let resting = point(px(10.0), px(20.0));
+        assert!(state.accept_hover_at(resting));
+
+        state.input_mut().set_text("tab".to_string());
+        state.refilter_current_query();
+
+        assert!(!state.accept_hover_at(resting));
+    }
+
+    #[test]
+    fn page_and_edge_moves_respect_the_visible_row_count() {
+        let mut state = CommandPaletteState::new(true);
+        state.set_visible_rows(3);
+        state.set_items(
+            (0..10)
+                .map(|index| {
+                    command_item(&format!("Command {index}"), "cmd", CommandAction::NewTab)
+                })
+                .collect(),
+        );
+
+        assert!(state.move_selection_page(CommandPaletteScrollDirection::Down));
+        assert_eq!(state.selected_filtered_index(), Some(3));
+        assert!(state.move_selection_page(CommandPaletteScrollDirection::Down));
+        assert_eq!(state.selected_filtered_index(), Some(6));
+        assert!(state.move_selection_page(CommandPaletteScrollDirection::Up));
+        assert_eq!(state.selected_filtered_index(), Some(3));
+
+        assert!(state.move_selection_to_edge(CommandPaletteScrollDirection::Down));
+        assert_eq!(state.selected_filtered_index(), Some(9));
+        assert!(state.move_selection_to_edge(CommandPaletteScrollDirection::Up));
+        assert_eq!(state.selected_filtered_index(), Some(0));
+
+        // Already at the edge: no change reported, no panic.
+        assert!(!state.move_selection_page(CommandPaletteScrollDirection::Up));
+        assert!(!state.move_selection_to_edge(CommandPaletteScrollDirection::Up));
+    }
+
+    #[test]
+    fn page_moves_on_an_empty_list_do_nothing() {
+        let mut state = CommandPaletteState::new(true);
+        assert!(!state.move_selection_page(CommandPaletteScrollDirection::Down));
+        assert!(!state.move_selection_to_edge(CommandPaletteScrollDirection::Down));
+    }
+
+    #[test]
+    fn layout_keeps_preferred_geometry_on_a_roomy_window() {
+        let layout = command_palette_layout_for_viewport(1440.0, 900.0);
+
+        assert_eq!(layout.width, COMMAND_PALETTE_WIDTH);
+        assert_eq!(layout.top_offset, COMMAND_PALETTE_TOP_OFFSET);
+        assert_eq!(layout.visible_rows, COMMAND_PALETTE_MAX_ITEMS);
+    }
+
+    #[test]
+    fn layout_shrinks_to_fit_a_small_window() {
+        let layout = command_palette_layout_for_viewport(420.0, 320.0);
+
+        assert_eq!(
+            layout.width,
+            420.0 - COMMAND_PALETTE_VIEWPORT_MARGIN_X * 2.0
+        );
+        assert!(layout.top_offset < COMMAND_PALETTE_TOP_OFFSET);
+        assert!(layout.visible_rows < COMMAND_PALETTE_MAX_ITEMS);
+        assert!(layout.visible_rows >= COMMAND_PALETTE_MIN_ITEMS);
+    }
+
+    #[test]
+    fn layout_never_exceeds_a_tiny_viewport() {
+        let layout = command_palette_layout_for_viewport(200.0, 120.0);
+
+        assert!(layout.width <= 200.0);
+        assert_eq!(layout.visible_rows, COMMAND_PALETTE_MIN_ITEMS);
+        assert!(layout.top_offset >= COMMAND_PALETTE_MIN_TOP_OFFSET);
     }
 
     #[test]

--- a/crates/desktop_app/src/terminal_view/command_palette/style.rs
+++ b/crates/desktop_app/src/terminal_view/command_palette/style.rs
@@ -1,5 +1,6 @@
 use super::super::{
-    COMMAND_PALETTE_INPUT_SELECTION_ALPHA, COMMAND_PALETTE_PANEL_BG_ALPHA,
+    COMMAND_PALETTE_ICON_TEXT_ALPHA, COMMAND_PALETTE_INPUT_SELECTION_ALPHA,
+    COMMAND_PALETTE_MATCH_TEXT_ALPHA, COMMAND_PALETTE_PANEL_BG_ALPHA,
     COMMAND_PALETTE_PANEL_SOLID_ALPHA, COMMAND_PALETTE_ROW_SELECTED_BG_ALPHA,
     COMMAND_PALETTE_SCROLLBAR_THUMB_ALPHA, COMMAND_PALETTE_SCROLLBAR_TRACK_ALPHA,
     COMMAND_PALETTE_SELECTED_ACCENT_ALPHA, COMMAND_PALETTE_SHORTCUT_BG_ALPHA,
@@ -22,6 +23,10 @@ pub(in super::super) struct CommandPaletteStyle {
     // Accent bar marking the selected row; mirrors the active-tab indicator so
     // the chrome speaks one visual language.
     pub(super) selected_accent: gpui::Rgba,
+    // Accent applied to the characters a query matched in a row title.
+    pub(super) match_text: gpui::Rgba,
+    // Row icon tone, held constant across selection.
+    pub(super) icon_text: gpui::Rgba,
     pub(super) shortcut_bg: gpui::Rgba,
     pub(super) shortcut_text: gpui::Rgba,
     pub(super) scrollbar_track: gpui::Rgba,
@@ -59,6 +64,8 @@ impl CommandPaletteStyle {
         let muted_text = overlay_style.panel_foreground(OVERLAY_MUTED_TEXT_ALPHA);
         let input_selection =
             overlay_style.chrome_panel_cursor(COMMAND_PALETTE_INPUT_SELECTION_ALPHA);
+        let match_text = overlay_style.chrome_panel_cursor(COMMAND_PALETTE_MATCH_TEXT_ALPHA);
+        let icon_text = overlay_style.panel_foreground(COMMAND_PALETTE_ICON_TEXT_ALPHA);
         let shortcut_bg = overlay_style.chrome_panel_cursor(COMMAND_PALETTE_SHORTCUT_BG_ALPHA);
         let shortcut_text = overlay_style.panel_foreground(COMMAND_PALETTE_SHORTCUT_TEXT_ALPHA);
         let scrollbar_track =
@@ -74,6 +81,8 @@ impl CommandPaletteStyle {
             input_selection,
             selected_bg,
             selected_accent,
+            match_text,
+            icon_text,
             shortcut_bg,
             shortcut_text,
             scrollbar_track,

--- a/crates/desktop_app/src/terminal_view/constants.rs
+++ b/crates/desktop_app/src/terminal_view/constants.rs
@@ -16,7 +16,17 @@ const CHILD_WORKING_DIR_CACHE_TTL_MS: u64 = 1500;
 pub(super) const SELECTION_BG_ALPHA: f32 = 0.35;
 pub(super) const DIM_TEXT_FACTOR: f32 = 0.66;
 pub(super) const COMMAND_PALETTE_WIDTH: f32 = 560.0;
+pub(super) const COMMAND_PALETTE_MIN_WIDTH: f32 = 320.0;
 pub(super) const COMMAND_PALETTE_MAX_ITEMS: usize = 8;
+/// Floor for the row count in short windows; below this the list stops being
+/// worth scrolling.
+pub(super) const COMMAND_PALETTE_MIN_ITEMS: usize = 3;
+/// Breathing room kept between the panel and the window edges.
+pub(super) const COMMAND_PALETTE_VIEWPORT_MARGIN_X: f32 = 24.0;
+pub(super) const COMMAND_PALETTE_VIEWPORT_MARGIN_Y: f32 = 24.0;
+pub(super) const COMMAND_PALETTE_MIN_TOP_OFFSET: f32 = 12.0;
+pub(super) const COMMAND_PALETTE_TOP_OFFSET_RATIO: f32 = 0.08;
+pub(super) const COMMAND_PALETTE_LIST_PADDING_Y: f32 = 6.0;
 pub(super) const COMMAND_PALETTE_ROW_HEIGHT: f32 = 34.0;
 pub(super) const COMMAND_PALETTE_SCROLLBAR_WIDTH: f32 = 8.0;
 pub(super) const COMMAND_PALETTE_SCROLLBAR_MIN_THUMB_HEIGHT: f32 = 18.0;
@@ -24,6 +34,14 @@ pub(super) const COMMAND_PALETTE_INPUT_HEAD_HEIGHT: f32 = 44.0;
 pub(super) const COMMAND_PALETTE_INPUT_TEXT_SIZE: f32 = 14.0;
 pub(super) const COMMAND_PALETTE_ROW_ICON_SIZE: f32 = 14.0;
 pub(super) const COMMAND_PALETTE_ROW_PADDING_X: f32 = 12.0;
+pub(super) const COMMAND_PALETTE_ROW_CATEGORY_MAX_WIDTH: f32 = 96.0;
+pub(super) const COMMAND_PALETTE_BREADCRUMB_MAX_WIDTH: f32 = 220.0;
+/// Gap between the keycaps of one keystroke, and between keystrokes of a
+/// multi-stroke binding.
+pub(super) const COMMAND_PALETTE_KEYCAP_GAP: f32 = 2.0;
+pub(super) const COMMAND_PALETTE_KEYSTROKE_GAP: f32 = 6.0;
+/// Shown on rows that are unavailable but carry no more specific reason.
+pub(super) const COMMAND_PALETTE_UNAVAILABLE_HINT: &str = "unavailable";
 pub(super) const COMMAND_PALETTE_FOOTER_HEIGHT: f32 = 32.0;
 pub(super) const COMMAND_PALETTE_SELECTED_ACCENT_WIDTH: f32 = 2.0;
 pub(super) const COMMAND_PALETTE_SELECTED_ACCENT_INSET_Y: f32 = 8.0;
@@ -69,6 +87,10 @@ pub(super) const OVERLAY_MUTED_TEXT_ALPHA: f32 = 0.62;
 pub(super) const COMMAND_PALETTE_PANEL_SOLID_ALPHA: f32 = 0.90;
 pub(super) const COMMAND_PALETTE_ROW_SELECTED_BG_ALPHA: f32 = 0.20;
 pub(super) const COMMAND_PALETTE_SELECTED_ACCENT_ALPHA: f32 = 0.95;
+pub(super) const COMMAND_PALETTE_MATCH_TEXT_ALPHA: f32 = 1.0;
+/// Row icons hold one tone regardless of selection, so selection reads from the
+/// row background and accent bar alone.
+pub(super) const COMMAND_PALETTE_ICON_TEXT_ALPHA: f32 = 0.72;
 pub(super) const COMMAND_PALETTE_SHORTCUT_BG_ALPHA: f32 = 0.10;
 pub(super) const COMMAND_PALETTE_SHORTCUT_TEXT_ALPHA: f32 = 0.80;
 pub(super) const COMMAND_PALETTE_PANEL_BG_ALPHA: f32 = 0.98;

--- a/crates/desktop_app/src/terminal_view/inline_input.rs
+++ b/crates/desktop_app/src/terminal_view/inline_input.rs
@@ -1094,6 +1094,7 @@ impl TerminalView {
     }
 
     pub(super) fn command_palette_query_changed(&mut self, cx: &mut Context<Self>) {
+        self.dismiss_command_palette_plugin_ui(cx);
         self.refresh_command_palette_matches(true, cx);
         self.notify_for_inline_input_target(InlineInputTarget::CommandPalette, cx);
     }

--- a/crates/desktop_app/src/terminal_view/interaction/context_menu.rs
+++ b/crates/desktop_app/src/terminal_view/interaction/context_menu.rs
@@ -318,6 +318,8 @@ impl TerminalView {
         native_anchor: Option<termy_native_sdk::NativeContextMenuAnchor>,
         cx: &mut Context<Self>,
     ) {
+        #[cfg(not(target_os = "macos"))]
+        self.schedule_plugin_refresh(cx);
         let _ = self.close_tab_context_menu(cx);
         let (selected_text, can_paste) = self.terminal_context_menu_capabilities(cx);
         let can_copy = selected_text.is_some();
@@ -385,6 +387,8 @@ impl TerminalView {
         native_anchor: Option<termy_native_sdk::NativeContextMenuAnchor>,
         cx: &mut Context<Self>,
     ) {
+        #[cfg(not(target_os = "macos"))]
+        self.schedule_plugin_refresh(cx);
         let Some((tab_id, pinned)) = self.tabs.get(tab_index).map(|tab| (tab.id, tab.pinned))
         else {
             return;

--- a/crates/desktop_app/src/terminal_view/interaction/input.rs
+++ b/crates/desktop_app/src/terminal_view/interaction/input.rs
@@ -778,7 +778,8 @@ impl TerminalView {
 
         if self.overlay_owns_terminal_input() {
             if self.is_command_palette_open() {
-                if self.handle_command_palette_key_down(key, window, cx) {
+                if self.handle_command_palette_key_down(key, event.keystroke.modifiers, window, cx)
+                {
                     self.remember_consumed_key_release(key);
                 }
                 return;

--- a/crates/desktop_app/src/terminal_view/plugin_ui.rs
+++ b/crates/desktop_app/src/terminal_view/plugin_ui.rs
@@ -1,4 +1,7 @@
-use super::{TerminalView, command_palette::style::CommandPaletteStyle};
+use super::{
+    TerminalView,
+    command_palette::{CommandPaletteMode, style::CommandPaletteStyle},
+};
 use crate::commands;
 use crate::text_input::{TextInputAlignment, TextInputElement, TextInputProvider, TextInputState};
 use gpui::prelude::FluentBuilder;
@@ -12,7 +15,7 @@ use std::{borrow::Cow, collections::BTreeMap};
 use termy_plugin_runtime::{
     PluginContext, PluginRuntime, PluginUiAlignment, PluginUiButtonVariant, PluginUiGap,
     PluginUiNode, PluginUiTextVariant, PluginUiTone, PluginViewAction, PluginViewDescriptor,
-    PluginViewRender, PluginViewValue,
+    PluginViewRender, PluginViewTarget, PluginViewValue,
 };
 
 const PANEL_WIDTH: f32 = 620.0;
@@ -52,6 +55,7 @@ pub(super) struct PluginUiView {
     runtime: PluginRuntime,
     descriptor: PluginViewDescriptor,
     revision: String,
+    target: PluginViewTarget,
     nodes: Vec<PluginUiNode>,
     values: BTreeMap<String, PluginViewValue>,
     active_input: Option<ActiveInput>,
@@ -69,6 +73,7 @@ impl PluginUiView {
         runtime: PluginRuntime,
         descriptor: PluginViewDescriptor,
         revision: String,
+        target: PluginViewTarget,
         cx: &mut Context<Self>,
     ) -> Self {
         Self {
@@ -77,6 +82,7 @@ impl PluginUiView {
             runtime,
             descriptor,
             revision,
+            target,
             nodes: Vec::new(),
             values: BTreeMap::new(),
             active_input: None,
@@ -90,6 +96,14 @@ impl PluginUiView {
 
     fn focus(&self, window: &mut Window, cx: &mut Context<Self>) {
         self.focus_handle.focus(window, cx);
+    }
+
+    pub(in crate::terminal_view) fn target(&self) -> PluginViewTarget {
+        self.target
+    }
+
+    pub(in crate::terminal_view) fn title(&self) -> &str {
+        &self.descriptor.title
     }
 
     fn current_context(
@@ -1229,8 +1243,9 @@ impl Render for PluginUiView {
         let viewport = window.viewport_size();
         let viewport_width: f32 = viewport.width.into();
         let viewport_height: f32 = viewport.height.into();
+        let available_height = (viewport_height - chrome_height).max(1.0);
         let (panel_width, panel_max_height) =
-            Self::panel_dimensions(viewport_width, (viewport_height - chrome_height).max(1.0));
+            Self::panel_dimensions(viewport_width, available_height);
         let rendered_nodes = self
             .nodes
             .iter()
@@ -1264,6 +1279,51 @@ impl Render for PluginUiView {
                 .children(rendered_nodes)
                 .into_any_element()
         };
+        if self.target == PluginViewTarget::CommandPalette {
+            return div()
+                .id("plugin-ui-command-palette-content")
+                .size_full()
+                .min_h(px(0.0))
+                .overflow_hidden()
+                .track_focus(&self.focus_handle)
+                .key_context("PluginUI")
+                .on_action(cx.listener(Self::handle_copy_action))
+                .on_action(cx.listener(Self::handle_paste_action))
+                .on_action(cx.listener(Self::handle_select_all_action))
+                .on_key_down(cx.listener(Self::handle_key_down))
+                .child(
+                    div()
+                        .id("plugin-ui-content")
+                        .size_full()
+                        .min_h(px(0.0))
+                        .overflow_y_scroll()
+                        .track_scroll(&self.scroll_handle)
+                        .px(px(14.0))
+                        .py(px(12.0))
+                        .flex()
+                        .flex_col()
+                        .gap(px(12.0))
+                        .children(self.error.as_ref().map(|error| {
+                            div()
+                                .w_full()
+                                .px(px(10.0))
+                                .py(px(8.0))
+                                .rounded(px(CONTROL_RADIUS))
+                                .bg(style.control_bg)
+                                .text_size(px(12.0))
+                                .text_color(style.danger)
+                                .child(error.clone())
+                        }))
+                        .child(content)
+                        .children(self.busy.then(|| {
+                            div()
+                                .text_size(px(11.0))
+                                .text_color(style.muted_text)
+                                .child("Working…")
+                        })),
+                )
+                .into_any_element();
+        }
         let title = self.descriptor.title.clone();
         let close_button = div()
             .id("plugin-ui-close")
@@ -1407,6 +1467,7 @@ impl TerminalView {
         plugin_id: &str,
         view_id: &str,
         revision: &str,
+        target: PluginViewTarget,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Result<(), String> {
@@ -1418,7 +1479,13 @@ impl TerminalView {
             return Err("Plugin changed before its view could open; try again".to_string());
         }
         let context = self.plugin_context(cx);
-        self.close_command_palette(cx);
+        match target {
+            PluginViewTarget::Modal => self.close_command_palette(cx),
+            PluginViewTarget::CommandPalette => {
+                self.open_command_palette_in_mode(CommandPaletteMode::Commands, cx);
+                self.command_palette_input_mut().clear();
+            }
+        }
         self.close_search(cx);
         self.cancel_rename_tab(cx);
         self.cancel_rename_workspace(cx);
@@ -1430,16 +1497,63 @@ impl TerminalView {
         let window_handle = window.window_handle();
         let runtime = self.plugin_runtime.clone();
         let revision = revision.to_string();
-        let plugin_ui = cx
-            .new(|cx| PluginUiView::new(parent, window_handle, runtime, descriptor, revision, cx));
+        let plugin_ui = cx.new(|cx| {
+            PluginUiView::new(
+                parent,
+                window_handle,
+                runtime,
+                descriptor,
+                revision,
+                target,
+                cx,
+            )
+        });
         self.plugin_ui = Some(plugin_ui.clone());
         plugin_ui.update(cx, |view, cx| {
-            view.focus(window, cx);
+            if target == PluginViewTarget::Modal {
+                view.focus(window, cx);
+            }
             view.load(context, cx);
         });
+        if target == PluginViewTarget::CommandPalette {
+            self.focus_handle.focus(window, cx);
+        }
         cx.notify();
         self.notify_overlay(cx);
         Ok(())
+    }
+
+    pub(in crate::terminal_view) fn command_palette_plugin_ui(
+        &self,
+        cx: &App,
+    ) -> Option<gpui::Entity<PluginUiView>> {
+        self.plugin_ui
+            .as_ref()
+            .filter(|view| view.read(cx).target() == PluginViewTarget::CommandPalette)
+            .cloned()
+    }
+
+    pub(in crate::terminal_view) fn modal_plugin_ui(
+        &self,
+        cx: &App,
+    ) -> Option<gpui::Entity<PluginUiView>> {
+        self.plugin_ui
+            .as_ref()
+            .filter(|view| view.read(cx).target() == PluginViewTarget::Modal)
+            .cloned()
+    }
+
+    pub(in crate::terminal_view) fn dismiss_command_palette_plugin_ui(
+        &mut self,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        if self.command_palette_plugin_ui(cx).is_none() {
+            return false;
+        }
+        self.plugin_ui = None;
+        cx.notify();
+        self.notify_overlay(cx);
+        true
     }
 
     fn close_plugin_ui(&mut self, window: &mut Window, cx: &mut Context<Self>) {

--- a/crates/desktop_app/src/terminal_view/render.rs
+++ b/crates/desktop_app/src/terminal_view/render.rs
@@ -650,6 +650,17 @@ fn terminal_scrollbar_track_width(frame_width: f32) -> f32 {
     TERMINAL_SCROLLBAR_TRACK_WIDTH.min(frame_width.max(0.0))
 }
 
+#[cfg(any(not(target_os = "macos"), test))]
+fn context_menu_visible_height(
+    content_height: f32,
+    viewport_height: Option<f32>,
+    row_height: f32,
+) -> f32 {
+    viewport_height
+        .map(|height| content_height.min((height - 16.0).max(row_height + 8.0)))
+        .unwrap_or(content_height)
+}
+
 impl Focusable for TerminalView {
     fn focus_handle(&self, _cx: &App) -> FocusHandle {
         self.focus_handle.clone()
@@ -1994,16 +2005,30 @@ impl TerminalView {
         #[cfg(not(target_os = "macos"))]
         {
             let state = self.terminal_context_menu.clone()?;
+            let plugin_commands = self.plugin_commands_for_placement(
+                termy_plugin_runtime::PluginCommandPlacement::TerminalContextMenu,
+            );
             let overlay_style = self.overlay_style();
-            let menu_width = 220.0;
+            let menu_width = if plugin_commands.is_empty() {
+                220.0
+            } else {
+                260.0
+            };
             let row_height = 30.0;
             let row_count =
                 3.0 + if state.buffer_position.is_some() {
                     1.0
                 } else {
                     0.0
-                } + if state.image.is_some() { 1.0 } else { 0.0 };
-            let menu_height = row_height * row_count + 8.0;
+                } + if state.image.is_some() { 1.0 } else { 0.0 }
+                    + plugin_commands.len() as f32;
+            let content_height =
+                row_height * row_count + 8.0 + if plugin_commands.is_empty() { 0.0 } else { 7.0 };
+            let menu_height = context_menu_visible_height(
+                content_height,
+                self.last_viewport_size_px.map(|(_, height)| height as f32),
+                row_height,
+            );
             let (menu_x, menu_y) =
                 self.clamped_context_menu_origin(state.anchor_position, menu_width, menu_height);
             let panel_bg = overlay_style.chrome_panel_background(0.98);
@@ -2056,6 +2081,9 @@ impl TerminalView {
                     .px(px(10.0))
                     .flex()
                     .items_center()
+                    .overflow_hidden()
+                    .whitespace_nowrap()
+                    .text_ellipsis()
                     .text_size(px(13.0))
                     .text_color(text_active)
                     .cursor_pointer()
@@ -2078,6 +2106,9 @@ impl TerminalView {
                     .px(px(10.0))
                     .flex()
                     .items_center()
+                    .overflow_hidden()
+                    .whitespace_nowrap()
+                    .text_ellipsis()
                     .text_size(px(13.0))
                     .text_color(text_active)
                     .cursor_pointer()
@@ -2090,6 +2121,39 @@ impl TerminalView {
                         }),
                     )
                     .child("Copy Image")
+                    .into_any_element()
+            };
+            let plugin_command_item = |command: termy_plugin_runtime::PluginCommand| {
+                let enabled = command.disabled_reason.is_none();
+                let text_color = if enabled { text_active } else { text_disabled };
+                let plugin_id = command.plugin_id.clone();
+                let command_id = command.id.clone();
+                div()
+                    .id(SharedString::from(format!(
+                        "terminal-context-menu-plugin-{plugin_id}-{command_id}"
+                    )))
+                    .h(px(row_height))
+                    .px(px(10.0))
+                    .flex()
+                    .items_center()
+                    .overflow_hidden()
+                    .whitespace_nowrap()
+                    .text_ellipsis()
+                    .text_size(px(13.0))
+                    .text_color(text_color)
+                    .when(enabled, |style| style.cursor_pointer())
+                    .when(enabled, |style| style.hover(|style| style.bg(hover_bg)))
+                    .when(enabled, |style| {
+                        style.on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(move |view, _event: &MouseDownEvent, window, cx| {
+                                let _ = view.close_terminal_context_menu(cx);
+                                view.start_plugin_command(&plugin_id, &command_id, window, cx);
+                                cx.stop_propagation();
+                            }),
+                        )
+                    })
+                    .child(command.title)
                     .into_any_element()
             };
 
@@ -2129,6 +2193,8 @@ impl TerminalView {
                             .left(px(menu_x))
                             .top(px(menu_y))
                             .w(px(menu_width))
+                            .max_h(px(menu_height))
+                            .overflow_y_scroll()
                             .py(px(4.0))
                             .bg(panel_bg)
                             .border_1()
@@ -2171,7 +2237,13 @@ impl TerminalView {
                                 state.can_paste,
                                 CommandAction::Paste,
                             ))
-                            .child(open_search_item()),
+                            .child(open_search_item())
+                            .when(!plugin_commands.is_empty(), |panel| {
+                                panel.child(
+                                    div().h(px(1.0)).my(px(3.0)).mx(px(8.0)).bg(panel_border),
+                                )
+                            })
+                            .children(plugin_commands.into_iter().map(plugin_command_item)),
                     )
                     .into_any_element(),
             )
@@ -2362,15 +2434,30 @@ impl TerminalView {
         #[cfg(not(target_os = "macos"))]
         {
             let state = self.tab_context_menu.clone()?;
+            let plugin_commands = self.plugin_commands_for_placement(
+                termy_plugin_runtime::PluginCommandPlacement::TabContextMenu,
+            );
             let overlay_style = self.overlay_style();
-            let menu_width = 180.0;
+            let menu_width = if plugin_commands.is_empty() {
+                180.0
+            } else {
+                260.0
+            };
             let row_height = 30.0;
-            let menu_height = (row_height * 3.0) + 8.0; // 3 items + padding
+            let content_height = (row_height * (3 + plugin_commands.len()) as f32)
+                + 8.0
+                + if plugin_commands.is_empty() { 0.0 } else { 7.0 };
+            let menu_height = context_menu_visible_height(
+                content_height,
+                self.last_viewport_size_px.map(|(_, height)| height as f32),
+                row_height,
+            );
             let (menu_x, menu_y) =
                 self.clamped_context_menu_origin(state.anchor_position, menu_width, menu_height);
             let panel_bg = overlay_style.chrome_panel_background(0.98);
             let panel_border = overlay_style.chrome_panel_neutral(0.22);
             let text_active = overlay_style.panel_foreground(0.95);
+            let text_disabled = overlay_style.panel_foreground(0.42);
             let text_danger = gpui::Rgba {
                 r: 0.95,
                 g: 0.4,
@@ -2379,6 +2466,43 @@ impl TerminalView {
             };
             let hover_bg = overlay_style.chrome_panel_cursor(0.22);
             let pin_label = if state.pinned { "Unpin Tab" } else { "Pin Tab" };
+            let plugin_command_item = |command: termy_plugin_runtime::PluginCommand| {
+                let enabled = command.disabled_reason.is_none();
+                let text_color = if enabled { text_active } else { text_disabled };
+                let plugin_id = command.plugin_id.clone();
+                let command_id = command.id.clone();
+                let tab_id = state.tab_id;
+                div()
+                    .id(SharedString::from(format!(
+                        "tab-context-menu-plugin-{plugin_id}-{command_id}"
+                    )))
+                    .h(px(row_height))
+                    .px(px(10.0))
+                    .flex()
+                    .items_center()
+                    .overflow_hidden()
+                    .whitespace_nowrap()
+                    .text_ellipsis()
+                    .text_size(px(13.0))
+                    .text_color(text_color)
+                    .when(enabled, |style| style.cursor_pointer())
+                    .when(enabled, |style| style.hover(|style| style.bg(hover_bg)))
+                    .when(enabled, |style| {
+                        style.on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(move |view, _event: &MouseDownEvent, window, cx| {
+                                if let Some(index) = view.tab_index_by_id(tab_id) {
+                                    view.switch_tab(index, cx);
+                                }
+                                let _ = view.close_tab_context_menu(cx);
+                                view.start_plugin_command(&plugin_id, &command_id, window, cx);
+                                cx.stop_propagation();
+                            }),
+                        )
+                    })
+                    .child(command.title)
+                    .into_any_element()
+            };
 
             Some(
                 div()
@@ -2416,6 +2540,8 @@ impl TerminalView {
                             .left(px(menu_x))
                             .top(px(menu_y))
                             .w(px(menu_width))
+                            .max_h(px(menu_height))
+                            .overflow_y_scroll()
                             .py(px(4.0))
                             .bg(panel_bg)
                             .border_1()
@@ -2440,6 +2566,12 @@ impl TerminalView {
                                     cx.stop_propagation();
                                 }),
                             )
+                            .children(plugin_commands.iter().cloned().map(plugin_command_item))
+                            .when(!plugin_commands.is_empty(), |panel| {
+                                panel.child(
+                                    div().h(px(1.0)).my(px(3.0)).mx(px(8.0)).bg(panel_border),
+                                )
+                            })
                             // Rename Tab
                             .child({
                                 let tab_id = state.tab_id;
@@ -2530,7 +2662,7 @@ impl TerminalView {
 
     pub(super) fn render_overlay_layer(
         &mut self,
-        _window: &mut Window,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) -> AnyElement {
         let now = Instant::now();
@@ -2581,11 +2713,11 @@ impl TerminalView {
         }
         let colors = self.colors.clone();
         let command_palette_overlay = if self.is_command_palette_open() {
-            Some(self.render_command_palette_modal(cx))
+            Some(self.render_command_palette_modal(window, cx))
         } else {
             None
         };
-        let plugin_ui_overlay = self.plugin_ui.clone();
+        let plugin_ui_overlay = self.modal_plugin_ui(cx);
         let search_overlay = if self.search_open {
             Some(self.render_search_bar(cx))
         } else {
@@ -3840,6 +3972,18 @@ mod tests {
     #[test]
     fn terminal_progress_loader_fill_hides_clear_state() {
         assert_eq!(terminal_progress_loader_fill(ProgressState::Clear, 0), None);
+    }
+
+    #[test]
+    fn context_menu_height_scrolls_long_plugin_lists_inside_the_viewport() {
+        assert_eq!(context_menu_visible_height(900.0, Some(600.0), 30.0), 584.0);
+        assert_eq!(context_menu_visible_height(300.0, Some(600.0), 30.0), 300.0);
+        assert_eq!(context_menu_visible_height(900.0, None, 30.0), 900.0);
+    }
+
+    #[test]
+    fn context_menu_height_keeps_one_row_visible_in_tiny_viewports() {
+        assert_eq!(context_menu_visible_height(900.0, Some(20.0), 30.0), 38.0);
     }
 
     fn assert_close(left: f32, right: f32) {

--- a/crates/plugin_runtime/src/lib.rs
+++ b/crates/plugin_runtime/src/lib.rs
@@ -73,6 +73,7 @@ struct PluginRuntimeInner {
     plugins_dir: Option<PathBuf>,
     refresh: Mutex<()>,
     settings: Mutex<()>,
+    lifecycle_generations: Mutex<BTreeMap<String, u64>>,
     catalog: RwLock<PluginCatalog>,
     host: Mutex<PluginHostState>,
 }
@@ -246,6 +247,8 @@ pub struct PluginCommand {
     pub plugin_name: String,
     pub id: String,
     pub title: String,
+    #[serde(default = "default_command_placements")]
+    pub placements: Vec<PluginCommandPlacement>,
     #[serde(default)]
     pub keywords: Vec<String>,
     #[serde(default)]
@@ -264,6 +267,18 @@ impl PluginCommand {
     pub fn qualified_id(&self) -> String {
         format!("{}.{}", self.plugin_id, self.id)
     }
+}
+
+fn default_command_placements() -> Vec<PluginCommandPlacement> {
+    vec![PluginCommandPlacement::CommandPalette]
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum PluginCommandPlacement {
+    CommandPalette,
+    TerminalContextMenu,
+    TabContextMenu,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Deserialize)]
@@ -373,11 +388,21 @@ pub enum PluginAction {
     #[serde(rename = "view.open")]
     ViewOpen {
         view: String,
+        #[serde(default)]
+        target: PluginViewTarget,
         #[serde(skip)]
         plugin_id: String,
         #[serde(skip)]
         revision: String,
     },
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum PluginViewTarget {
+    #[default]
+    Modal,
+    CommandPalette,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize)]
@@ -696,6 +721,7 @@ impl PluginRuntime {
                 plugins_dir,
                 refresh: Mutex::new(()),
                 settings: Mutex::new(()),
+                lifecycle_generations: Mutex::new(BTreeMap::new()),
                 catalog: RwLock::new(PluginCatalog::default()),
                 host: Mutex::new(PluginHostState::default()),
             }),
@@ -789,7 +815,7 @@ impl PluginRuntime {
             let _ = fs::remove_dir_all(&temporary);
             return Err(error);
         }
-        self.invalidate_after_management();
+        self.invalidate_after_management(&manifest.id);
         Ok(installed_plugin_from_manifest(
             manifest,
             destination,
@@ -897,7 +923,7 @@ impl PluginRuntime {
         }
         let _ = fs::remove_dir_all(&backup);
         self.clear_plugin_bundle_cache(id);
-        self.invalidate_after_management();
+        self.invalidate_after_management(id);
         Ok(installed_plugin_from_manifest(
             manifest,
             destination,
@@ -938,7 +964,7 @@ impl PluginRuntime {
                 Err(error) => return Err(format!("Failed to disable plugin `{id}`: {error}")),
             }
         }
-        self.invalidate_after_management();
+        self.invalidate_after_management(id);
         Ok(())
     }
 
@@ -959,7 +985,7 @@ impl PluginRuntime {
             .map_err(|error| format!("Failed to uninstall plugin `{id}`: {error}"))?;
         self.clear_plugin_bundle_cache(id);
         self.clear_plugin_storage(id);
-        self.invalidate_after_management();
+        self.invalidate_after_management(id);
         Ok(())
     }
 
@@ -997,7 +1023,8 @@ impl PluginRuntime {
         Ok(root)
     }
 
-    fn invalidate_after_management(&self) {
+    fn invalidate_after_management(&self, plugin_id: &str) {
+        self.bump_plugin_lifecycle(plugin_id);
         self.inner
             .host
             .lock()
@@ -1009,6 +1036,65 @@ impl PluginRuntime {
             .write()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .fingerprint = None;
+    }
+
+    fn plugin_lifecycle_generation(&self, plugin_id: &str) -> u64 {
+        self.inner
+            .lifecycle_generations
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .get(plugin_id)
+            .copied()
+            .unwrap_or_default()
+    }
+
+    fn bump_plugin_lifecycle(&self, plugin_id: &str) {
+        let mut generations = self
+            .inner
+            .lifecycle_generations
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let generation = generations.entry(plugin_id.to_string()).or_default();
+        *generation = generation.wrapping_add(1);
+    }
+
+    fn revoke_changed_plugin_lifecycles(
+        &self,
+        previous: &BTreeMap<String, String>,
+        current: &BTreeMap<String, String>,
+    ) {
+        let changed = previous
+            .keys()
+            .chain(current.keys())
+            .filter(|plugin_id| previous.get(*plugin_id) != current.get(*plugin_id))
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        if changed.is_empty() {
+            return;
+        }
+        let mut generations = self
+            .inner
+            .lifecycle_generations
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        for plugin_id in changed {
+            let generation = generations.entry(plugin_id).or_default();
+            *generation = generation.wrapping_add(1);
+        }
+    }
+
+    fn ensure_plugin_lifecycle(
+        &self,
+        plugin_id: &str,
+        expected_generation: u64,
+    ) -> Result<(), String> {
+        if self.plugin_lifecycle_generation(plugin_id) == expected_generation {
+            Ok(())
+        } else {
+            Err(format!(
+                "Plugin `{plugin_id}` changed, was disabled, or was removed while its request was running; try again"
+            ))
+        }
     }
 
     pub fn commands(&self) -> Vec<PluginCommand> {
@@ -1340,13 +1426,17 @@ impl PluginRuntime {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         let discovered = discover_plugins(plugins_dir)?;
-        let (previous_fingerprint, had_commands) = {
+        let (previous_fingerprint, had_commands, previous_revisions) = {
             let catalog = self
                 .inner
                 .catalog
                 .read()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
-            (catalog.fingerprint, !catalog.commands.is_empty())
+            (
+                catalog.fingerprint,
+                !catalog.commands.is_empty(),
+                catalog.revisions.clone(),
+            )
         };
         let host_needs_restart = if discovered.sources.is_empty() {
             false
@@ -1367,6 +1457,14 @@ impl PluginRuntime {
         };
         if previous_fingerprint == Some(discovered.fingerprint) && !host_needs_restart {
             return Ok(PluginRefresh::default());
+        }
+        if previous_fingerprint != Some(discovered.fingerprint) {
+            let discovered_revisions = discovered
+                .sources
+                .iter()
+                .map(|source| (source.id.clone(), source.cache_key.clone()))
+                .collect::<BTreeMap<_, _>>();
+            self.revoke_changed_plugin_lifecycles(&previous_revisions, &discovered_revisions);
         }
 
         ensure_managed_files(plugins_dir)?;
@@ -1615,6 +1713,7 @@ impl PluginRuntime {
         validate_inputs(&command, &inputs)?;
         context.settings = self.resolved_plugin_settings(plugin_id)?;
         let timeout_ms = command.timeout_ms.clamp(100, MAX_INVOKE_TIMEOUT_MS);
+        let lifecycle_generation = self.plugin_lifecycle_generation(plugin_id);
         let (request_id, connection) = self.next_host_request()?;
         let request = HostRequest::Invoke {
             id: request_id,
@@ -1630,6 +1729,7 @@ impl PluginRuntime {
             timeout_ms,
             plugin_id,
             expected_revision,
+            lifecycle_generation,
         )
     }
 
@@ -1648,6 +1748,7 @@ impl PluginRuntime {
         }
         context.settings = self.resolved_plugin_settings(plugin_id)?;
         let timeout_ms = view.timeout_ms.clamp(100, MAX_INVOKE_TIMEOUT_MS);
+        let lifecycle_generation = self.plugin_lifecycle_generation(plugin_id);
         let (request_id, connection) = self.next_host_request()?;
         let request = HostRequest::ViewRender {
             id: request_id,
@@ -1658,6 +1759,7 @@ impl PluginRuntime {
         };
         let result =
             self.request_host::<HostViewRenderResult>(&connection, &request, timeout_ms)?;
+        self.ensure_plugin_lifecycle(plugin_id, lifecycle_generation)?;
         self.ensure_view_revision(plugin_id, view_id, expected_revision)?;
         self.prepare_view_render(result, plugin_id, expected_revision)
     }
@@ -1680,6 +1782,7 @@ impl PluginRuntime {
         validate_view_action(&action, &values)?;
         context.settings = self.resolved_plugin_settings(plugin_id)?;
         let timeout_ms = view.timeout_ms.clamp(100, MAX_INVOKE_TIMEOUT_MS);
+        let lifecycle_generation = self.plugin_lifecycle_generation(plugin_id);
         let (request_id, connection) = self.next_host_request()?;
         let request = HostRequest::ViewAction {
             id: request_id,
@@ -1692,6 +1795,7 @@ impl PluginRuntime {
         };
         let result =
             self.request_host::<HostViewRenderResult>(&connection, &request, timeout_ms)?;
+        self.ensure_plugin_lifecycle(plugin_id, lifecycle_generation)?;
         self.ensure_view_revision(plugin_id, view_id, expected_revision)?;
         self.prepare_view_render(result, plugin_id, expected_revision)
     }
@@ -1762,6 +1866,7 @@ impl PluginRuntime {
         mut context: PluginContext,
     ) -> Result<Vec<PluginAction>, String> {
         context.settings = self.resolved_plugin_settings(&subscription.plugin_id)?;
+        let lifecycle_generation = self.plugin_lifecycle_generation(&subscription.plugin_id);
         let (request_id, connection) = self.next_host_request()?;
         let request = HostRequest::Event {
             id: request_id,
@@ -1776,6 +1881,7 @@ impl PluginRuntime {
             subscription.timeout_ms,
             &subscription.plugin_id,
             &subscription.revision,
+            lifecycle_generation,
         )
     }
 
@@ -1799,9 +1905,11 @@ impl PluginRuntime {
         timeout_ms: u64,
         plugin_id: &str,
         revision: &str,
+        lifecycle_generation: u64,
     ) -> Result<Vec<PluginAction>, String> {
         let invoke_result =
             self.request_host::<HostInvokeResult>(connection, request, timeout_ms)?;
+        self.ensure_plugin_lifecycle(plugin_id, lifecycle_generation)?;
         self.prepare_actions(invoke_result.actions, plugin_id, revision)
     }
 
@@ -1891,6 +1999,7 @@ impl PluginRuntime {
                 view,
                 plugin_id: origin_plugin_id,
                 revision: origin_revision,
+                ..
             } = action
             else {
                 continue;
@@ -3071,6 +3180,17 @@ fn validate_commands(commands: &[PluginCommand]) -> Result<(), String> {
         }
         validate_text(&command.plugin_name, 200, "plugin name")?;
         validate_text(&command.title, 300, "command title")?;
+        let mut placements = HashSet::new();
+        if command
+            .placements
+            .iter()
+            .any(|placement| !placements.insert(*placement))
+        {
+            return Err(format!(
+                "Plugin command `{}` has duplicate placements",
+                command.qualified_id()
+            ));
+        }
         if command.inputs.len() > MAX_INPUTS_PER_COMMAND {
             return Err(format!(
                 "Plugin command `{}` has too many inputs",
@@ -3304,17 +3424,63 @@ fn validate_setting_value(setting: &PluginSetting, value: &Value) -> Result<(), 
     }
 }
 
+fn plugin_secret_account(plugin_id: &str, key: &str) -> String {
+    format!("v2:{}:{plugin_id}{key}", plugin_id.len())
+}
+
+fn legacy_plugin_secret_account(plugin_id: &str, key: &str) -> String {
+    format!("{plugin_id}.{key}")
+}
+
+fn can_migrate_legacy_plugin_secret(plugin_id: &str, key: &str) -> bool {
+    !plugin_id.contains('.') && !key.contains('.')
+}
+
 #[cfg(not(test))]
 fn plugin_secret_entry(plugin_id: &str, key: &str) -> Result<keyring::Entry, String> {
-    keyring::Entry::new(KEYRING_SERVICE, &format!("{plugin_id}.{key}"))
+    keyring::Entry::new(KEYRING_SERVICE, &plugin_secret_account(plugin_id, key))
         .map_err(|error| format!("Failed to access the credential store: {error}"))
+}
+
+#[cfg(not(test))]
+fn legacy_plugin_secret_entry(plugin_id: &str, key: &str) -> Result<keyring::Entry, String> {
+    keyring::Entry::new(
+        KEYRING_SERVICE,
+        &legacy_plugin_secret_account(plugin_id, key),
+    )
+    .map_err(|error| format!("Failed to access the credential store: {error}"))
 }
 
 #[cfg(not(test))]
 fn read_plugin_secret(plugin_id: &str, key: &str) -> Result<Option<String>, String> {
     match plugin_secret_entry(plugin_id, key)?.get_password() {
         Ok(secret) => Ok(Some(secret)),
-        Err(keyring::Error::NoEntry) => Ok(None),
+        Err(keyring::Error::NoEntry) if !can_migrate_legacy_plugin_secret(plugin_id, key) => {
+            Ok(None)
+        }
+        Err(keyring::Error::NoEntry) => {
+            let legacy = legacy_plugin_secret_entry(plugin_id, key)?;
+            let secret = match legacy.get_password() {
+                Ok(secret) => secret,
+                Err(keyring::Error::NoEntry) => return Ok(None),
+                Err(error) => {
+                    return Err(format!(
+                        "Failed to read legacy secret setting `{plugin_id}.{key}`: {error}"
+                    ));
+                }
+            };
+            plugin_secret_entry(plugin_id, key)?
+                .set_password(&secret)
+                .map_err(|error| {
+                    format!("Failed to migrate secret setting `{plugin_id}.{key}`: {error}")
+                })?;
+            match legacy.delete_credential() {
+                Ok(()) | Err(keyring::Error::NoEntry) => Ok(Some(secret)),
+                Err(error) => Err(format!(
+                    "Failed to clear legacy secret setting `{plugin_id}.{key}` after migration: {error}"
+                )),
+            }
+        }
         Err(error) => Err(format!(
             "Failed to read secret setting `{plugin_id}.{key}`: {error}"
         )),
@@ -3325,17 +3491,41 @@ fn read_plugin_secret(plugin_id: &str, key: &str) -> Result<Option<String>, Stri
 fn write_plugin_secret(plugin_id: &str, key: &str, secret: &str) -> Result<(), String> {
     plugin_secret_entry(plugin_id, key)?
         .set_password(secret)
-        .map_err(|error| format!("Failed to save secret setting `{plugin_id}.{key}`: {error}"))
+        .map_err(|error| format!("Failed to save secret setting `{plugin_id}.{key}`: {error}"))?;
+    if can_migrate_legacy_plugin_secret(plugin_id, key) {
+        match legacy_plugin_secret_entry(plugin_id, key)?.delete_credential() {
+            Ok(()) | Err(keyring::Error::NoEntry) => {}
+            Err(error) => {
+                return Err(format!(
+                    "Failed to clear legacy secret setting `{plugin_id}.{key}`: {error}"
+                ));
+            }
+        }
+    }
+    Ok(())
 }
 
 #[cfg(not(test))]
 fn delete_plugin_secret(plugin_id: &str, key: &str) -> Result<(), String> {
     match plugin_secret_entry(plugin_id, key)?.delete_credential() {
-        Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
-        Err(error) => Err(format!(
-            "Failed to clear secret setting `{plugin_id}.{key}`: {error}"
-        )),
+        Ok(()) | Err(keyring::Error::NoEntry) => {}
+        Err(error) => {
+            return Err(format!(
+                "Failed to clear secret setting `{plugin_id}.{key}`: {error}"
+            ));
+        }
     }
+    if can_migrate_legacy_plugin_secret(plugin_id, key) {
+        match legacy_plugin_secret_entry(plugin_id, key)?.delete_credential() {
+            Ok(()) | Err(keyring::Error::NoEntry) => {}
+            Err(error) => {
+                return Err(format!(
+                    "Failed to clear legacy secret setting `{plugin_id}.{key}`: {error}"
+                ));
+            }
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -3345,30 +3535,46 @@ static TEST_PLUGIN_SECRETS: std::sync::LazyLock<Mutex<BTreeMap<String, String>>>
 #[cfg(test)]
 #[allow(clippy::unnecessary_wraps)]
 fn read_plugin_secret(plugin_id: &str, key: &str) -> Result<Option<String>, String> {
-    Ok(TEST_PLUGIN_SECRETS
+    let mut secrets = TEST_PLUGIN_SECRETS
         .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .get(&format!("{plugin_id}.{key}"))
-        .cloned())
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let account = plugin_secret_account(plugin_id, key);
+    if let Some(secret) = secrets.get(&account) {
+        return Ok(Some(secret.clone()));
+    }
+    if !can_migrate_legacy_plugin_secret(plugin_id, key) {
+        return Ok(None);
+    }
+    let Some(secret) = secrets.remove(&legacy_plugin_secret_account(plugin_id, key)) else {
+        return Ok(None);
+    };
+    secrets.insert(account, secret.clone());
+    Ok(Some(secret))
 }
 
 #[cfg(test)]
 #[allow(clippy::unnecessary_wraps)]
 fn write_plugin_secret(plugin_id: &str, key: &str, secret: &str) -> Result<(), String> {
-    TEST_PLUGIN_SECRETS
+    let mut secrets = TEST_PLUGIN_SECRETS
         .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .insert(format!("{plugin_id}.{key}"), secret.to_string());
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    secrets.insert(plugin_secret_account(plugin_id, key), secret.to_string());
+    if can_migrate_legacy_plugin_secret(plugin_id, key) {
+        secrets.remove(&legacy_plugin_secret_account(plugin_id, key));
+    }
     Ok(())
 }
 
 #[cfg(test)]
 #[allow(clippy::unnecessary_wraps)]
 fn delete_plugin_secret(plugin_id: &str, key: &str) -> Result<(), String> {
-    TEST_PLUGIN_SECRETS
+    let mut secrets = TEST_PLUGIN_SECRETS
         .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .remove(&format!("{plugin_id}.{key}"));
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    secrets.remove(&plugin_secret_account(plugin_id, key));
+    if can_migrate_legacy_plugin_secret(plugin_id, key) {
+        secrets.remove(&legacy_plugin_secret_account(plugin_id, key));
+    }
     Ok(())
 }
 

--- a/crates/plugin_runtime/src/termy.d.ts
+++ b/crates/plugin_runtime/src/termy.d.ts
@@ -257,7 +257,11 @@ type TermyPluginAction =
   | { type: "clipboard.write"; text: string }
   | { type: "url.open"; url: string }
   /** Requires `"native-ui"` in plugin.json capabilities. */
-  | { type: "view.open"; view: string }
+  | {
+      type: "view.open";
+      view: string;
+      target?: "modal" | "commandPalette";
+    }
   | {
       type: "toast";
       level: "info" | "success" | "warning" | "error";
@@ -299,6 +303,15 @@ type TermyPluginCommand<
 > = {
   id: string;
   title: string;
+  /**
+   * Surfaces that list this command. Defaults to `["commandPalette"]`.
+   * Context menus are currently available on Linux and Windows.
+   */
+  placements?: (
+    | "commandPalette"
+    | "terminalContextMenu"
+    | "tabContextMenu"
+  )[];
   keywords?: string[];
   status?: string;
   enabled?: boolean;

--- a/crates/plugin_runtime/src/tests.rs
+++ b/crates/plugin_runtime/src/tests.rs
@@ -150,13 +150,22 @@ fn tsx_views_render_and_round_trip_actions() {
 type Todo = { id: string; title: string; done: boolean };
 
 export default definePlugin({
-  commands: [{
-    id: "open",
-    title: "Todos: Open",
-    run() {
-      return { type: "view.open", view: "todos" };
+  commands: [
+    {
+      id: "open",
+      title: "Todos: Open",
+      run() {
+        return { type: "view.open", view: "todos", target: "commandPalette" };
+      },
     },
-  }],
+    {
+      id: "open-modal",
+      title: "Todos: Open Modal",
+      run() {
+        return { type: "view.open", view: "todos" };
+      },
+    },
+  ],
   views: {
     todos: {
       title: "Todos",
@@ -253,10 +262,31 @@ export default definePlugin({
         actions,
         vec![PluginAction::ViewOpen {
             view: "todos".to_string(),
+            target: PluginViewTarget::CommandPalette,
             plugin_id: "todos".to_string(),
             revision: revision.clone(),
         }]
     );
+    let modal_revision = runtime
+        .command_with_revision("todos", "open-modal")
+        .expect("modal command revision")
+        .1;
+    let modal_actions = runtime
+        .invoke(
+            "todos",
+            "open-modal",
+            &modal_revision,
+            BTreeMap::new(),
+            test_plugin_context(),
+        )
+        .expect("open modal view action");
+    assert!(matches!(
+        modal_actions.as_slice(),
+        [PluginAction::ViewOpen {
+            target: PluginViewTarget::Modal,
+            ..
+        }]
+    ));
 
     let first = runtime
         .render_view("todos", "todos", &revision, test_plugin_context())
@@ -820,6 +850,111 @@ fn github_plugin_management_tracks_source_and_updates_atomically() {
             .expect("managed source tree")
             .iter()
             .all(|(path, _)| path != SOURCE_METADATA_FILE)
+    );
+}
+
+#[test]
+fn plugin_secret_accounts_are_injective_and_legacy_migration_is_unambiguous() {
+    assert_ne!(
+        plugin_secret_account("a.b", "c"),
+        plugin_secret_account("a", "b.c"),
+        "plugin and setting boundaries must be preserved in credential identities"
+    );
+    assert!(can_migrate_legacy_plugin_secret("github", "token"));
+    assert!(!can_migrate_legacy_plugin_secret("github.tools", "token"));
+    assert!(!can_migrate_legacy_plugin_secret("github", "auth.token"));
+
+    let mut secrets = TEST_PLUGIN_SECRETS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    secrets.insert(
+        legacy_plugin_secret_account("migration-proof", "token"),
+        "legacy-secret".to_string(),
+    );
+    secrets.insert(
+        legacy_plugin_secret_account("ambiguous.plugin", "token"),
+        "must-not-leak".to_string(),
+    );
+    drop(secrets);
+
+    assert_eq!(
+        read_plugin_secret("migration-proof", "token").expect("migrate legacy secret"),
+        Some("legacy-secret".to_string())
+    );
+    assert_eq!(
+        read_plugin_secret("ambiguous.plugin", "token").expect("skip ambiguous legacy secret"),
+        None
+    );
+    let secrets = TEST_PLUGIN_SECRETS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    assert!(!secrets.contains_key(&legacy_plugin_secret_account("migration-proof", "token")));
+    assert_eq!(
+        secrets.get(&plugin_secret_account("migration-proof", "token")),
+        Some(&"legacy-secret".to_string())
+    );
+}
+
+#[test]
+fn plugin_command_placements_default_and_validate() {
+    if !bun_is_available() {
+        return;
+    }
+    let temp = TempDir::new().expect("temp dir");
+    let config_path = temp.path().join("config.txt");
+    fs::write(&config_path, "").expect("write config");
+    let plugins = temp.path().join("plugins");
+    write_plugin(
+        &plugins,
+        "placements",
+        "Placements",
+        r#"
+export default definePlugin({
+  commands: [
+    { id: "default", title: "Default", run() {} },
+    {
+      id: "everywhere",
+      title: "Everywhere",
+      placements: ["commandPalette", "terminalContextMenu", "tabContextMenu"],
+      run() {},
+    },
+    { id: "shortcut-only", title: "Shortcut only", placements: [], run() {} },
+  ],
+});
+"#,
+    );
+
+    let runtime = PluginRuntime::new(Some(&config_path));
+    let refresh = runtime.refresh_if_changed();
+    assert!(refresh.errors.is_empty(), "errors: {:?}", refresh.errors);
+    let commands = runtime.commands();
+    assert_eq!(
+        commands
+            .iter()
+            .find(|command| command.id == "default")
+            .expect("default command")
+            .placements,
+        vec![PluginCommandPlacement::CommandPalette]
+    );
+    assert_eq!(
+        commands
+            .iter()
+            .find(|command| command.id == "everywhere")
+            .expect("everywhere command")
+            .placements,
+        vec![
+            PluginCommandPlacement::CommandPalette,
+            PluginCommandPlacement::TerminalContextMenu,
+            PluginCommandPlacement::TabContextMenu,
+        ]
+    );
+    assert!(
+        commands
+            .iter()
+            .find(|command| command.id == "shortcut-only")
+            .expect("shortcut-only command")
+            .placements
+            .is_empty()
     );
 }
 
@@ -1774,6 +1909,75 @@ export default definePlugin({
     slow.join()
         .expect("join slow invocation")
         .expect("slow invocation succeeds");
+}
+
+#[test]
+fn disabling_plugin_revokes_in_flight_actions() {
+    if !bun_is_available() {
+        return;
+    }
+    let temp = TempDir::new().expect("temp dir");
+    let config_path = temp.path().join("config.txt");
+    fs::write(&config_path, "").expect("write config");
+    let plugins = temp.path().join("plugins");
+    let marker = temp.path().join("revocation-started");
+    let marker_json =
+        serde_json::to_string(marker.to_string_lossy().as_ref()).expect("encode marker path");
+    let source = r#"
+const markerPath = __MARKER__;
+export default definePlugin({
+  commands: [{
+    id: "run",
+    title: "Revocation: Run",
+    timeoutMs: 2000,
+    async run() {
+      await Bun.write(markerPath, "started");
+      await Bun.sleep(300);
+      return { type: "toast", level: "info", message: "must be revoked" };
+    },
+  }],
+});
+"#
+    .replace("__MARKER__", &marker_json);
+    write_plugin(&plugins, "revocation", "Revocation", &source);
+
+    let runtime = PluginRuntime::new(Some(&config_path));
+    let refresh = runtime.refresh_if_changed();
+    assert!(refresh.errors.is_empty(), "errors: {:?}", refresh.errors);
+    let revision = runtime
+        .command_with_revision("revocation", "run")
+        .expect("revocation command")
+        .1;
+    let invoke_runtime = runtime.clone();
+    let invocation = thread::spawn(move || {
+        invoke_runtime.invoke(
+            "revocation",
+            "run",
+            &revision,
+            BTreeMap::new(),
+            test_plugin_context(),
+        )
+    });
+    let marker_deadline = Instant::now() + Duration::from_secs(2);
+    while !marker.exists() {
+        assert!(
+            Instant::now() < marker_deadline,
+            "revocation plugin did not start in time"
+        );
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    runtime
+        .set_plugin_enabled("revocation", false)
+        .expect("disable plugin while invocation is running");
+    let error = invocation
+        .join()
+        .expect("join revocation invocation")
+        .expect_err("disabled plugin actions must be revoked");
+    assert!(
+        error.contains("disabled") || error.contains("changed") || error.contains("removed"),
+        "unexpected revocation error: {error}"
+    );
 }
 
 #[test]

--- a/crates/plugin_runtime/src/worker.ts
+++ b/crates/plugin_runtime/src/worker.ts
@@ -74,6 +74,7 @@ type PluginContext = Record<string, unknown> &
 type PluginCommand = {
   id: string;
   title: string;
+  placements?: string[];
   keywords?: string[];
   status?: string;
   enabled?: boolean;
@@ -965,6 +966,23 @@ function normalizePlugin(
     if (command.icon !== undefined && !icons.includes(command.icon)) {
       throw new Error(`Command ${command.id} has an unsupported icon`);
     }
+    const supportedPlacements = [
+      "commandPalette",
+      "terminalContextMenu",
+      "tabContextMenu",
+    ];
+    const placements = command.placements ?? ["commandPalette"];
+    if (
+      !Array.isArray(placements) ||
+      placements.length > supportedPlacements.length ||
+      placements.some(
+        (placement) =>
+          typeof placement !== "string" || !supportedPlacements.includes(placement),
+      ) ||
+      new Set(placements).size !== placements.length
+    ) {
+      throw new Error(`Command ${command.id} has invalid or duplicate placements`);
+    }
     const disabledReason =
       command.enabled === false
         ? optionalText(
@@ -978,6 +996,7 @@ function normalizePlugin(
       pluginName: source.name,
       id: command.id,
       title: command.title,
+      placements,
       keywords: normalizeKeywords(command.keywords, `Keywords for ${command.id}`),
       status: optionalText(command.status, `Status for ${command.id}`, 200),
       disabledReason,

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -146,6 +146,7 @@ Each command accepts these fields:
 | --- | --- | --- |
 | `id` | yes | Stable command ID, unique within the plugin. |
 | `title` | yes | Label shown in the command palette. |
+| `placements` | no | Surfaces that list the command: `commandPalette`, `terminalContextMenu`, and `tabContextMenu`. Defaults to `["commandPalette"]`. |
 | `keywords` | no | Extra strings matched by palette search. |
 | `status` | no | Compact status text shown on the palette row. |
 | `enabled` | no | Set to `false` to keep the command visible but unavailable. |
@@ -155,6 +156,11 @@ Each command accepts these fields:
 | `run` | yes | Async or synchronous command handler. |
 
 Termy namespaces runtime commands as `<plugin-id>.<command-id>`, so command IDs only need to be unique inside their plugin.
+
+Context-menu placements are currently rendered on Linux and Windows. Commands
+with inputs open the same palette input flow from any surface. A command with an
+empty `placements` array stays available to keybindings without appearing in a
+menu.
 
 ## Imports and build cache
 
@@ -438,6 +444,14 @@ export default definePlugin({
 } satisfies TermyPlugin);
 ```
 
+`view.open` uses a centered modal by default. To render the same bounded native
+view inside the command palette's results area, while keeping its search and
+footer, set `target: "commandPalette"`:
+
+```ts
+return { type: "view.open", view: "todos", target: "commandPalette" };
+```
+
 The v1 component set is `TermyUI.Column`, `Row`, `Text`, `TextInput`, `Button`, `Checkbox`, `Divider`, `Spacer`, and fragments. Layout uses fixed gap and alignment enums; text uses fixed variant and tone enums; buttons use `secondary`, `primary`, or `danger`. Every input and interactive control needs a unique lowercase stable `id`. Controls send a named `action`, optional string `payload`, their current value, and the current text/checkbox `values` map to `onAction`. No JavaScript callback crosses into the native renderer.
 
 Views are limited to 32 per plugin, 256 nodes, 16 levels of nesting, 64 children per node, 64 value-bearing controls, and 4,096 characters per text value. Termy serializes interactions per plugin, disables controls while one is running, rejects stale plugin revisions, and rerenders after successful actions. Escape, the close button, or clicking outside the panel closes a view.
@@ -508,6 +522,9 @@ keybind = secondary-g=plugin:git-tools/status
 Commands without inputs run immediately. Commands with inputs open their input form. Termy refreshes the plugin catalog before invoking the shortcut, so saved plugin changes are picked up. Normal keybinding ordering applies: later lines win, `unbind` removes the shortcut, and a task keybinding takes priority on conflicts.
 
 Disabling a plugin in Settings keeps its files and storage installed but removes its commands the next time the command palette refreshes. Enabling it makes the commands available again. Uninstalling removes Termy's managed copy, storage, and cache, but not the source folder you originally selected.
+
+Termy rejects actions and native-view updates returned by a request that was
+already running when its plugin changed, was disabled, or was removed.
 
 Plugin loading and command execution have timeouts. A thrown error or timeout is contained to that plugin Worker and reported in Termy, while other plugins and the terminal keep running. A subprocess started by plugin code can outlive its Worker, so plugins that spawn processes must stop them themselves when cancellation matters. Plugins share the persistent host transport; if that transport exits, Termy discards it and rebuilds the host and Workers on the next plugin refresh instead of taking down the app. Fix a failed plugin and reopen the palette to load it again.
 

--- a/examples/plugins/git-tools/plugin.ts
+++ b/examples/plugins/git-tools/plugin.ts
@@ -9,6 +9,11 @@ export default definePlugin({
     {
       id: "inspect",
       title: "Git: Inspect repository",
+      placements: [
+        "commandPalette",
+        "terminalContextMenu",
+        "tabContextMenu",
+      ],
       keywords: ["git", "status", "branches", "commits"],
       status: "Plugin",
       icon: "terminal",

--- a/examples/plugins/todos/plugin.tsx
+++ b/examples/plugins/todos/plugin.tsx
@@ -27,6 +27,19 @@ export default definePlugin({
         return { type: "view.open", view: "todos" };
       },
     },
+    {
+      id: "open-palette",
+      title: "Todos: Open in Command Palette",
+      keywords: ["tasks", "checklist", "palette"],
+      icon: "command",
+      run() {
+        return {
+          type: "view.open",
+          view: "todos",
+          target: "commandPalette",
+        };
+      },
+    },
   ],
 
   views: {

--- a/website/content/docs/using-termy/plugins/commands-context.mdx
+++ b/website/content/docs/using-termy/plugins/commands-context.mdx
@@ -24,6 +24,7 @@ export default definePlugin({
     {
       id: "greet",
       title: "Hello: Greet me",
+      placements: ["commandPalette", "terminalContextMenu"],
       keywords: ["hello", "example"],
       icon: "info",
       inputs: [
@@ -63,6 +64,12 @@ export default definePlugin({
 Commands require `id`, `title`, and `run`. They may also declare search `keywords`,
 `status`, `enabled`, `disabledReason`, `timeoutMs`, and one of Termy's built-in
 `icon` names.
+
+`placements` controls where a command is listed. It accepts `commandPalette`,
+`terminalContextMenu`, and `tabContextMenu`, and defaults to
+`["commandPalette"]`. Context-menu placements are currently available on Linux
+and Windows. Commands with inputs use the same palette input flow from every
+surface. Use `placements: []` for a keybinding-only command.
 
 Inputs appear sequentially before the handler runs:
 
@@ -118,7 +125,7 @@ an action array, `{ actions: [...] }`, or nothing. Handlers may be async.
 | `termy.command` | Invoke a built-in Termy command. |
 | `clipboard.write` | Copy text to the system clipboard. |
 | `url.open` | Open an `http` or `https` URL. |
-| `view.open` | Open a native view declared by the same plugin. Requires `native-ui` in `plugin.json`. |
+| `view.open` | Open a native view declared by the same plugin. Add `target: "commandPalette"` to use the palette surface; the default is a modal. Requires `native-ui` in `plugin.json`. |
 | `toast` | Show an info, success, warning, or error notification. |
 
 Never interpolate free-form text directly into `terminal.run`. Map select values to

--- a/website/content/docs/using-termy/plugins/index.mdx
+++ b/website/content/docs/using-termy/plugins/index.mdx
@@ -24,7 +24,7 @@ tools rendered by Termy.
 
 | Feature | Use it for |
 | --- | --- |
-| Commands | Add searchable actions to the command palette and keybindings. |
+| Commands | Add actions to the command palette, context menus, and keybindings. |
 | Context | Read the active terminal, selection, working directory, shell, tab, and pane. |
 | Native UI | Return allowlisted JSX that Termy validates and renders with GPUI. |
 | Lifecycle events | Respond when the terminal is ready, a tab changes, the directory changes, or a command finishes. |

--- a/website/content/docs/using-termy/plugins/native-ui.mdx
+++ b/website/content/docs/using-termy/plugins/native-ui.mdx
@@ -82,6 +82,14 @@ export default definePlugin({
 The view key (`todos`) must match the `view` in the `view.open` action. The managed
 `termy.d.ts` file supplies `TermyUI`, JSX, view, and action types globally.
 
+Views use a centered modal by default. Add `target: "commandPalette"` to render
+the same bounded native document inside the palette results area while keeping
+the palette search and footer:
+
+```ts
+return { type: "view.open", view: "todos", target: "commandPalette" };
+```
+
 ## Handle interactions
 
 Interactive controls use named actions instead of JavaScript callbacks. Any view

--- a/website/content/docs/using-termy/plugins/security-limits.mdx
+++ b/website/content/docs/using-termy/plugins/security-limits.mdx
@@ -79,6 +79,8 @@ Saving a manifest or source file replaces the changed Worker and refreshes its
 commands without restarting Termy. Disabling a plugin keeps its managed files and
 storage but removes its commands on the next refresh. Uninstalling removes the
 managed copy, storage, and cache while leaving the original source folder untouched.
+Actions and native-view updates from requests already running when a plugin
+changes, is disabled, or is removed are rejected.
 
 Termy resolves Bun from `TERMY_BUN_PATH`, beside the Termy executable, `PATH`,
 Bun's default user install, Homebrew, and `/usr/local/bin`. Set `TERMY_BUN_PATH` to


### PR DESCRIPTION
## What changed

- Refactors the command palette into focused fuzzy matching, presentation, and recents modules with improved ranking, categories, icons, keycaps, scrolling, and responsive layout.
- Lets plugin native views render inside the command palette results surface while keeping search, breadcrumbs, and footer controls available.
- Adds typed plugin command placements for `commandPalette`, `terminalContextMenu`, and `tabContextMenu`. Existing commands still default to the command palette.
- Adds Linux/Windows terminal and tab context-menu integration, including input-bearing commands and bounded scrolling for long plugin command lists.
- Fixes ambiguous plugin secret identities with a versioned injective keyring account format and collision-aware legacy migration.
- Revokes command, event, and native-view results that finish after their plugin changes, is disabled, or is removed.
- Updates ambient TypeScript declarations, examples, and plugin documentation.

## Why

Plugins needed a way to provide custom native UI without replacing the command palette shell, plus explicit command placement outside the palette. The runtime also had two authority-boundary gaps: dotted plugin/setting IDs could collide in the credential store, and in-flight plugin work could return Termy-native actions after revocation.

## Impact

The plugin command API remains backward compatible: omitting `placements` keeps the command in the palette. Commands with inputs reuse the palette input flow from context menus. macOS context-menu contributions are intentionally out of scope for this PR.

## Validation

- `cargo test -p termy_plugin_runtime` — 36 passed
- `cargo test -p termy` — 741 passed, plus the Kitty graphics integration test
- `cargo check -p termy`
- `cargo test --target x86_64-pc-windows-gnu -p termy --no-run`
- `cd website && bun run types:check`
- `cd website && bun run lint`
- `git diff --check`

## Remaining QA

The Windows test binaries compile, including the non-macOS GPUI context-menu code, but an actual Windows/Linux GUI click-through has not been run from this macOS development machine. Linux cross-compilation is also blocked locally by the missing Linux C sysroot.