### PR TITLE
chore: add Cloud Agent development environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,5 @@
+{
+  "name": "Termy",
+  "user": "ubuntu",
+  "install": "bash .cursor/install.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Idempotent Cloud Agent bootstrap for the Termy workspace.
+# Safe to run repeatedly: every step is a no-op when already satisfied.
+set -euo pipefail
+
+echo "==> Installing Linux desktop build dependencies (GPUI + native)"
+export DEBIAN_FRONTEND=noninteractive
+sudo apt-get update
+sudo apt-get install -y --no-install-recommends \
+  build-essential \
+  cmake \
+  clang \
+  pkg-config \
+  libfontconfig-dev \
+  libwayland-dev \
+  libx11-xcb-dev \
+  libxkbcommon-x11-dev \
+  libssl-dev \
+  libzstd-dev \
+  libasound2-dev \
+  libvulkan1
+
+echo "==> Ensuring a Rust stable toolchain that supports edition 2024 (>= 1.85)"
+# CI pins to rolling `stable`; the workspace requires edition 2024, so an older
+# preinstalled stable (e.g. 1.83) must be updated.
+rustup update stable
+rustup default stable
+rustup component add clippy rustfmt
+
+echo "==> Ensuring Bun is available (plugin runtime + website tooling)"
+# crates/plugin_runtime shells out to Bun and looks it up in ~/.bun/bin.
+BUN_VERSION="bun-v1.3.14"
+if [ ! -x "$HOME/.bun/bin/bun" ]; then
+  curl -fsSL https://bun.sh/install | BUN_INSTALL="$HOME/.bun" bash -s "$BUN_VERSION"
+fi
+export PATH="$HOME/.bun/bin:$PATH"
+if ! grep -qs 'BUN_INSTALL' "$HOME/.bashrc"; then
+  {
+    echo 'export BUN_INSTALL="$HOME/.bun"'
+    echo 'export PATH="$BUN_INSTALL/bin:$PATH"'
+  } >> "$HOME/.bashrc"
+fi
+
+echo "==> Warming the Cargo build cache"
+cargo fetch
+cargo build --workspace
+
+echo "==> Termy environment ready"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Pull Request

Adds a reproducible Cursor Cloud Agent development environment for the Termy workspace so agents (and contributors) boot into a machine that can build and test the whole repo out of the box.

## Description

- Add `.cursor/environment.json` using the default Ubuntu base image with `user: ubuntu` and an `install` hook.
- Add idempotent `.cursor/install.sh` that:
  - installs the Linux desktop/native build dependencies (matches `.github/workflows/architecture-checks.yml`): `build-essential`, `cmake`, `clang`, `pkg-config`, `libfontconfig-dev`, `libwayland-dev`, `libx11-xcb-dev`, `libxkbcommon-x11-dev`, `libssl-dev`, `libzstd-dev`, `libasound2-dev`, `libvulkan1`;
  - updates Rust to the latest `stable` (the workspace requires **edition 2024**, i.e. Rust ≥ 1.85; the base image shipped 1.83) and adds `clippy` + `rustfmt`;
  - installs **Bun 1.3.14** into `~/.bun` (used by `crates/plugin_runtime` and the website), matching CI;
  - warms the Cargo cache with `cargo fetch` + `cargo build --workspace`.

Everything is idempotent: a second `install` run is a ~4s no-op.

## Screenshots/Videos

The flagship GPUI desktop app running headlessly (Xvfb + llvmpipe/Vulkan) in the configured environment, executing a real shell command and confirming the toolchain:

[Termy GPUI desktop app running a shell command](https://cursor.com/agents/bc-63bcd155-7dc2-4000-8b70-b5c0f0ac82ae/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftermy_desktop_app_running.png)

## Validation

- `cargo build --workspace` — succeeds (Rust 1.97.1).
- `cargo test -p termy_core --lib` — 232 passed / 0 failed.
- `cargo test -p termy_plugin_runtime` — 38 passed / 0 failed (Bun end-to-end).
- `cargo test -p termy_command_core / _search / _theme_core / _themes` — all passed.
- `termy-cli -version` → `Termy 0.2.37`; GPUI desktop app renders and runs a shell (screenshot above).
- Install idempotence — second run ~4s no-op.
- Validated end-to-end via a draft environment build (fresh git checkout + install) that succeeded.

Pre-existing `main` issues surfaced but **not** addressed here (out of scope; no code changed): `cargo fmt --all --check` drift, `scripts/check-boundaries.sh` file-size limits, and two Linux-specific test failures (`termy_config_core parser_tests::enum_keys_parse_table_driven` — `WorkingDirFallback::default()` is `Process` on Linux vs `Home` elsewhere; `termy_core resize_clear`).

## Related Issues

Closes #

## Checklist

- [x] I confirmed there is no existing open PR for the same or overlapping changes.
- [x] I ran the smallest validation pass for this change.
- [ ] `just check-boundaries` (if deps, config keys, commands, or generated docs changed).
- [ ] `just test-workspace` or targeted `cargo test -p <crate>` (if Rust behavior changed).
- [ ] `just fmt-check` (if Rust formatting may have drifted).
- [ ] `just test-tmux-integration` (if tmux behavior changed).
- [ ] Regenerated `docs/configuration.md` / `docs/keybindings.md` when schema or defaults changed.

> Note: this PR only adds environment configuration; no Rust code, config keys, commands, or generated docs changed.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63bcd155-7dc2-4000-8b70-b5c0f0ac82ae?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63bcd155-7dc2-4000-8b70-b5c0f0ac82ae&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

