### PR TITLE
feat(tmux): add tmux_exclusive to stay in control mode

### DIFF
--- a/crates/config_core/src/constants.rs
+++ b/crates/config_core/src/constants.rs
@@ -17,6 +17,7 @@ pub(crate) const DEFAULT_COLORTERM: &str = "truecolor";
 pub(crate) const DEFAULT_TMUX_ENABLED: bool = false;
 pub(crate) const DEFAULT_TMUX_BINARY: &str = "tmux";
 pub(crate) const DEFAULT_TMUX_PERSISTENCE: bool = true;
+pub(crate) const DEFAULT_TMUX_EXCLUSIVE: bool = false;
 pub(crate) const DEFAULT_TMUX_SHOW_ACTIVE_PANE_BORDER: bool = false;
 pub(crate) const DEFAULT_MOUSE_SCROLL_MULTIPLIER: f32 = 3.0;
 /// Unitless multiplier applied to the font's natural cell height to produce the

--- a/crates/config_core/src/default_config.txt
+++ b/crates/config_core/src/default_config.txt
@@ -17,6 +17,8 @@ auto_update = true
 tmux_enabled = false
 # Reuse tmux tabs and panes across app restarts
 tmux_persistence = true
+# Stay in tmux control mode; restart it instead of falling back to a classic terminal when control mode exits
+tmux_exclusive = false
 # Restore native tabs and pane splits across app restarts
 native_tab_persistence = false
 # Auto-save changes back into the currently loaded named layout

--- a/crates/config_core/src/parser.rs
+++ b/crates/config_core/src/parser.rs
@@ -286,6 +286,13 @@ impl AppConfig {
                         config.tmux_persistence = parsed;
                     }
                 }
+                RootSettingId::TmuxExclusive => {
+                    if let Some(parsed) =
+                        parse_bool_field(&mut diagnostics, line_number, key, value)
+                    {
+                        config.tmux_exclusive = parsed;
+                    }
+                }
                 RootSettingId::NativeTabPersistence => {
                     if let Some(parsed) =
                         parse_bool_field(&mut diagnostics, line_number, key, value)

--- a/crates/config_core/src/parser_tests.rs
+++ b/crates/config_core/src/parser_tests.rs
@@ -368,6 +368,7 @@ fn bool_root_setting_value(config: &AppConfig, setting: RootSettingId) -> Option
         RootSettingId::AutoUpdate => Some(config.auto_update),
         RootSettingId::TmuxEnabled => Some(config.tmux_enabled),
         RootSettingId::TmuxPersistence => Some(config.tmux_persistence),
+        RootSettingId::TmuxExclusive => Some(config.tmux_exclusive),
         RootSettingId::NativeTabPersistence => Some(config.native_tab_persistence),
         RootSettingId::NativeLayoutAutosave => Some(config.native_layout_autosave),
         RootSettingId::NativeBufferPersistence => Some(config.native_buffer_persistence),
@@ -606,6 +607,7 @@ fn tmux_runtime_options_parse() {
     let config = parse(
         "tmux_enabled = true\n\
          tmux_persistence = true\n\
+         tmux_exclusive = true\n\
          tmux_show_active_pane_border = true\n\
          tmux_binary = /opt/homebrew/bin/tmux\n\
          working_dir_fallback = process\n",
@@ -613,6 +615,7 @@ fn tmux_runtime_options_parse() {
 
     assert!(config.tmux_enabled);
     assert!(config.tmux_persistence);
+    assert!(config.tmux_exclusive);
     assert!(config.tmux_show_active_pane_border);
     assert_eq!(config.tmux_binary, "/opt/homebrew/bin/tmux");
     assert_eq!(config.working_dir_fallback, WorkingDirFallback::Process);

--- a/crates/config_core/src/schema.rs
+++ b/crates/config_core/src/schema.rs
@@ -373,6 +373,7 @@ define_root_settings! {
     (AutoUpdate, "auto_update", [], Advanced, "UPDATES", "Auto Update", "Enable automatic update checks", ["update", "check", "upgrade", "version"], RootSettingValueKind::Boolean, false),
     (TmuxEnabled, "tmux_enabled", [], Terminal, "TMUX", "Tmux Enabled", "Enable tmux runtime integration", ["tmux", "runtime", "integration", "enabled"], RootSettingValueKind::Boolean, false),
     (TmuxPersistence, "tmux_persistence", [], Terminal, "TMUX", "Tmux Persistence", "Reuse tmux tabs and panes across app restarts", ["tmux", "session", "persistence", "restart"], RootSettingValueKind::Boolean, false),
+    (TmuxExclusive, "tmux_exclusive", [], Terminal, "TMUX", "Tmux Exclusive", "Stay in tmux control mode; restart it instead of falling back to a classic terminal when control mode exits", ["tmux", "exclusive", "control", "mode", "restart", "fallback"], RootSettingValueKind::Boolean, false),
     (NativeTabPersistence, "native_tab_persistence", [], Advanced, "STARTUP", "Native Tab Persistence", "Restore native tabs and pane splits across app restarts", ["native", "tabs", "panes", "split", "restore", "startup"], RootSettingValueKind::Boolean, false),
     (NativeLayoutAutosave, "native_layout_autosave", [], Advanced, "STARTUP", "Native Layout Autosave", "Auto-save changes back into the currently loaded named layout", ["native", "layout", "autosave", "saved", "snapshot"], RootSettingValueKind::Boolean, false),
     (NativeBufferPersistence, "native_buffer_persistence", [], Advanced, "STARTUP", "Native Buffer Persistence", "Replay saved buffer text when restoring native layouts", ["native", "buffer", "scrollback", "history", "restore"], RootSettingValueKind::Boolean, false),
@@ -507,6 +508,7 @@ pub fn root_setting_default_value(config: &AppConfig, id: RootSettingId) -> Opti
         RootSettingId::AutoUpdate => Some(config.auto_update.to_string()),
         RootSettingId::TmuxEnabled => Some(config.tmux_enabled.to_string()),
         RootSettingId::TmuxPersistence => Some(config.tmux_persistence.to_string()),
+        RootSettingId::TmuxExclusive => Some(config.tmux_exclusive.to_string()),
         RootSettingId::NativeTabPersistence => Some(config.native_tab_persistence.to_string()),
         RootSettingId::NativeLayoutAutosave => Some(config.native_layout_autosave.to_string()),
         RootSettingId::NativeBufferPersistence => {

--- a/crates/config_core/src/types.rs
+++ b/crates/config_core/src/types.rs
@@ -3,8 +3,8 @@ use crate::constants::{
     DEFAULT_MOUSE_SCROLL_MULTIPLIER, DEFAULT_PANE_FOCUS_STRENGTH, DEFAULT_SCROLLBACK_HISTORY,
     DEFAULT_SIDEBAR_WIDTH, DEFAULT_TAB_SWITCH_MODIFIER_HINTS, DEFAULT_TAB_TITLE_COMMAND_FORMAT,
     DEFAULT_TAB_TITLE_EXPLICIT_PREFIX, DEFAULT_TAB_TITLE_FALLBACK, DEFAULT_TAB_TITLE_PROMPT_FORMAT,
-    DEFAULT_TERM, DEFAULT_TMUX_BINARY, DEFAULT_TMUX_ENABLED, DEFAULT_TMUX_PERSISTENCE,
-    DEFAULT_TMUX_SHOW_ACTIVE_PANE_BORDER, DEFAULT_WARN_ON_QUIT,
+    DEFAULT_TERM, DEFAULT_TMUX_BINARY, DEFAULT_TMUX_ENABLED, DEFAULT_TMUX_EXCLUSIVE,
+    DEFAULT_TMUX_PERSISTENCE, DEFAULT_TMUX_SHOW_ACTIVE_PANE_BORDER, DEFAULT_WARN_ON_QUIT,
     DEFAULT_WARN_ON_QUIT_WITH_RUNNING_PROCESS,
 };
 
@@ -353,6 +353,7 @@ pub struct AppConfig {
     pub auto_update: bool,
     pub tmux_enabled: bool,
     pub tmux_persistence: bool,
+    pub tmux_exclusive: bool,
     pub native_tab_persistence: bool,
     pub native_layout_autosave: bool,
     pub native_buffer_persistence: bool,
@@ -453,6 +454,7 @@ impl Default for AppConfig {
             auto_update: true,
             tmux_enabled: DEFAULT_TMUX_ENABLED,
             tmux_persistence: DEFAULT_TMUX_PERSISTENCE,
+            tmux_exclusive: DEFAULT_TMUX_EXCLUSIVE,
             native_tab_persistence: false,
             native_layout_autosave: false,
             native_buffer_persistence: false,

--- a/crates/desktop_app/src/settings_view/sections.rs
+++ b/crates/desktop_app/src/settings_view/sections.rs
@@ -388,6 +388,7 @@ impl SettingsWindow {
         let command_prefix_meta = Self::setting_metadata_or_fallback("tmux_command_prefix");
         let tmux_enabled = self.config.tmux_enabled;
         let tmux_persistence = self.config.tmux_persistence;
+        let tmux_exclusive = self.config.tmux_exclusive;
         let tmux_show_active_pane_border = self.config.tmux_show_active_pane_border;
         let binary = self.config.tmux_binary.clone();
         let command_prefix = self.config.tmux_command_prefix.clone().unwrap_or_default();
@@ -407,6 +408,14 @@ impl SettingsWindow {
                 "tmux_persistence-toggle",
                 RootSettingId::TmuxPersistence,
                 tmux_persistence,
+                "Saved",
+                cx,
+            ));
+            rows.push(self.render_root_bool_setting_row(
+                "tmux_exclusive",
+                "tmux_exclusive-toggle",
+                RootSettingId::TmuxExclusive,
+                tmux_exclusive,
                 "Saved",
                 cx,
             ));

--- a/crates/desktop_app/src/terminal_view/command_palette/mod.rs
+++ b/crates/desktop_app/src/terminal_view/command_palette/mod.rs
@@ -261,6 +261,7 @@ impl TerminalView {
                 self.command_palette.input().text(),
                 self.tmux_active_session_name_for_session_palette()
                     .as_deref(),
+                !self.tmux_exclusive,
             ),
             CommandPaletteMode::Layouts => {
                 let mut items = self
@@ -718,6 +719,7 @@ impl TerminalView {
                 self.command_palette.input().text(),
                 self.tmux_active_session_name_for_session_palette()
                     .as_deref(),
+                !self.tmux_exclusive,
             );
             self.command_palette.set_items(items);
         } else if self.command_palette.mode() == CommandPaletteMode::Layouts {

--- a/crates/desktop_app/src/terminal_view/command_palette/state_tmux.rs
+++ b/crates/desktop_app/src/terminal_view/command_palette/state_tmux.rs
@@ -285,6 +285,7 @@ impl CommandPaletteState {
         &self,
         query: &str,
         active_session_name: Option<&str>,
+        allow_detach: bool,
     ) -> Vec<CommandPaletteItem> {
         match self.tmux_session_intent {
             TmuxSessionIntent::AttachOrSwitch => {
@@ -297,7 +298,7 @@ impl CommandPaletteState {
                 let query = query.trim();
                 if query.is_empty() {
                     let mut utility_items = Vec::new();
-                    if active_session_name.is_some() {
+                    if allow_detach && active_session_name.is_some() {
                         utility_items.push(CommandPaletteItem::tmux_session_detach_current());
                     }
                     if !self.tmux_session_rows.is_empty() {
@@ -381,14 +382,14 @@ mod tests {
             TmuxSocketTarget::Default,
         );
 
-        let with_exact = state.tmux_session_items_for_query("work", None);
+        let with_exact = state.tmux_session_items_for_query("work", None, true);
         assert_eq!(with_exact.len(), 1);
         assert!(matches!(
             with_exact[0].kind,
             CommandPaletteItemKind::TmuxSessionAttachOrSwitch { .. }
         ));
 
-        let with_new = state.tmux_session_items_for_query("new-session", None);
+        let with_new = state.tmux_session_items_for_query("new-session", None, true);
         assert_eq!(with_new.len(), 2);
         assert!(matches!(
             with_new[0].kind,
@@ -408,7 +409,7 @@ mod tests {
             TmuxSocketTarget::DedicatedTermy,
         );
 
-        let items = state.tmux_session_items_for_query("work", None);
+        let items = state.tmux_session_items_for_query("work", None, true);
         assert_eq!(items.len(), 2);
         assert!(matches!(
             items[0].kind,
@@ -431,7 +432,7 @@ mod tests {
             TmuxSocketTarget::DedicatedTermy,
         );
 
-        let items = state.tmux_session_items_for_query("work", None);
+        let items = state.tmux_session_items_for_query("work", None, true);
         assert_eq!(items.len(), 2);
         assert!(items.iter().all(|item| matches!(
             item.kind,
@@ -467,7 +468,7 @@ mod tests {
             TmuxSocketTarget::Default,
         );
 
-        let items = state.tmux_session_items_for_query("", Some("work"));
+        let items = state.tmux_session_items_for_query("", Some("work"), true);
         let active = items
             .iter()
             .find(|item| item.title.starts_with("work"))
@@ -500,17 +501,17 @@ mod tests {
         );
         state.begin_tmux_session_rename("work", TmuxSocketTarget::Default);
 
-        let empty = state.tmux_session_items_for_query("   ", Some("work"));
+        let empty = state.tmux_session_items_for_query("   ", Some("work"), true);
         assert_eq!(empty.len(), 1);
         assert!(!empty[0].enabled);
         assert_eq!(empty[0].status_hint.as_deref(), Some("name required"));
 
-        let same = state.tmux_session_items_for_query("work", Some("work"));
+        let same = state.tmux_session_items_for_query("work", Some("work"), true);
         assert_eq!(same.len(), 1);
         assert!(!same[0].enabled);
         assert_eq!(same[0].status_hint.as_deref(), Some("unchanged"));
 
-        let valid = state.tmux_session_items_for_query("next", Some("work"));
+        let valid = state.tmux_session_items_for_query("next", Some("work"), true);
         assert_eq!(valid.len(), 1);
         assert!(valid[0].enabled);
         assert_eq!(valid[0].status_hint, None);
@@ -533,7 +534,7 @@ mod tests {
             TmuxSocketTarget::DedicatedTermy,
         );
 
-        let items = state.tmux_session_items_for_query("", None);
+        let items = state.tmux_session_items_for_query("", None, true);
         let attach_rows = items
             .iter()
             .filter(|item| {
@@ -558,7 +559,7 @@ mod tests {
             TmuxSocketTarget::Default,
         );
 
-        let items = state.tmux_session_items_for_query("", None);
+        let items = state.tmux_session_items_for_query("", None, true);
         let attach_rows = items
             .iter()
             .filter(|item| {
@@ -575,7 +576,7 @@ mod tests {
     fn tmux_session_create_row_uses_configured_create_socket_target() {
         let mut state = CommandPaletteState::new(false);
         state.set_tmux_session_rows(Vec::new(), TmuxSocketTarget::DedicatedTermy);
-        let items = state.tmux_session_items_for_query("new-session", None);
+        let items = state.tmux_session_items_for_query("new-session", None, true);
         assert_eq!(items.len(), 1);
         let create_socket_target = match &items[0].kind {
             CommandPaletteItemKind::TmuxSessionCreateAndAttach { socket_target, .. } => {
@@ -607,7 +608,7 @@ mod tests {
             TmuxSocketTarget::Default,
         );
 
-        let items = state.tmux_session_items_for_query("", Some("work"));
+        let items = state.tmux_session_items_for_query("", Some("work"), true);
         assert!(matches!(
             items.first().map(|item| &item.kind),
             Some(CommandPaletteItemKind::TmuxSessionDetachCurrent)
@@ -623,6 +624,26 @@ mod tests {
     }
 
     #[test]
+    fn tmux_attach_intent_hides_detach_utility_when_exclusive() {
+        let mut state = CommandPaletteState::new(false);
+        state.set_tmux_session_rows(
+            vec![tmux_row("work", TmuxSocketTarget::Default)],
+            TmuxSocketTarget::Default,
+        );
+
+        let items = state.tmux_session_items_for_query("", Some("work"), false);
+        assert!(
+            !items
+                .iter()
+                .any(|item| matches!(item.kind, CommandPaletteItemKind::TmuxSessionDetachCurrent))
+        );
+        assert!(matches!(
+            items.first().map(|item| &item.kind),
+            Some(CommandPaletteItemKind::TmuxSessionOpenRenameMode)
+        ));
+    }
+
+    #[test]
     fn tmux_attach_intent_hides_detach_utility_when_runtime_is_native() {
         let mut state = CommandPaletteState::new(false);
         state.set_tmux_session_rows(
@@ -630,7 +651,7 @@ mod tests {
             TmuxSocketTarget::Default,
         );
 
-        let items = state.tmux_session_items_for_query("", None);
+        let items = state.tmux_session_items_for_query("", None, true);
         assert!(
             !items
                 .iter()
@@ -656,7 +677,7 @@ mod tests {
             TmuxSocketTarget::Default,
         );
 
-        let items = state.tmux_session_items_for_query("wo", Some("work"));
+        let items = state.tmux_session_items_for_query("wo", Some("work"), true);
         assert!(!items.iter().any(|item| matches!(
             item.kind,
             CommandPaletteItemKind::TmuxSessionDetachCurrent

--- a/crates/desktop_app/src/terminal_view/mod.rs
+++ b/crates/desktop_app/src/terminal_view/mod.rs
@@ -1618,6 +1618,7 @@ pub struct TerminalView {
     /// (logged), so persistence degrades to a no-op instead of retry spam.
     workspace_store: std::cell::OnceCell<Option<Arc<crate::workspace_store::WorkspaceStore>>>,
     tmux_show_active_pane_border: bool,
+    tmux_exclusive: bool,
     config_path: Option<PathBuf>,
     config_fingerprint: Option<u64>,
     last_config_error_message: Option<String>,
@@ -4131,6 +4132,7 @@ impl TerminalView {
             native_persist_write_gate: Arc::new(Mutex::new(())),
             workspace_store: std::cell::OnceCell::new(),
             tmux_show_active_pane_border: config.tmux_show_active_pane_border,
+            tmux_exclusive: config.tmux_exclusive,
             config_path,
             config_fingerprint,
             last_config_error_message,
@@ -4572,6 +4574,7 @@ impl TerminalView {
         self.native_layout_autosave = config.native_layout_autosave;
         self.native_buffer_persistence = config.native_buffer_persistence;
         self.tmux_show_active_pane_border = config.tmux_show_active_pane_border;
+        self.tmux_exclusive = config.tmux_exclusive;
         self.configured_working_dir = config.working_dir.clone();
         self.terminal_runtime = Self::runtime_config_from_app_config(&config, &self.colors);
         if workspace_sidebar_enabled_changed

--- a/crates/desktop_app/src/terminal_view/runtime/tmux/mod.rs
+++ b/crates/desktop_app/src/terminal_view/runtime/tmux/mod.rs
@@ -55,6 +55,20 @@ fn tmux_detach_transition_decision(
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TmuxExitRecoveryDecision {
+    TransitionToNative,
+    RestartControlMode,
+}
+
+fn tmux_exit_recovery_decision(exclusive: bool) -> TmuxExitRecoveryDecision {
+    if exclusive {
+        TmuxExitRecoveryDecision::RestartControlMode
+    } else {
+        TmuxExitRecoveryDecision::TransitionToNative
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum TmuxPostActionRefresh {
     ImmediateSnapshot,
     EventDriven,
@@ -174,6 +188,18 @@ mod tests {
         assert_eq!(
             tmux_detach_transition_decision(true, true),
             TmuxDetachTransitionDecision::CommitNativeTransition
+        );
+    }
+
+    #[test]
+    fn tmux_exit_recovery_decision_respects_exclusive_mode() {
+        assert_eq!(
+            tmux_exit_recovery_decision(false),
+            TmuxExitRecoveryDecision::TransitionToNative
+        );
+        assert_eq!(
+            tmux_exit_recovery_decision(true),
+            TmuxExitRecoveryDecision::RestartControlMode
         );
     }
 

--- a/crates/desktop_app/src/terminal_view/runtime/tmux/transition.rs
+++ b/crates/desktop_app/src/terminal_view/runtime/tmux/transition.rs
@@ -280,9 +280,7 @@ impl TerminalView {
                         "{reason}; restarting tmux control mode (tmux_exclusive)"
                     ));
                 } else {
-                    termy_toast::warning(
-                        "tmux control mode exited; restarting (tmux_exclusive)",
-                    );
+                    termy_toast::warning("tmux control mode exited; restarting (tmux_exclusive)");
                 }
                 self.restart_tmux_runtime_after_exit(cx)
             }

--- a/crates/desktop_app/src/terminal_view/runtime/tmux/transition.rs
+++ b/crates/desktop_app/src/terminal_view/runtime/tmux/transition.rs
@@ -224,6 +224,12 @@ impl TerminalView {
         if !self.runtime_uses_tmux() {
             return false;
         }
+        if self.tmux_exclusive {
+            termy_toast::info(
+                "tmux_exclusive keeps Termy in control mode; disable it to detach to a classic terminal",
+            );
+            return false;
+        }
 
         // Detach should remain recoverable even if tmux just invalidated panes.
         let size = self
@@ -267,15 +273,106 @@ impl TerminalView {
             return false;
         }
 
-        // Exit recovery uses a deterministic fallback when no active pane remains.
-        let size = self
-            .active_terminal()
-            .map(|terminal| terminal.size())
-            .unwrap_or_default();
-        if let Some(reason) = reason {
-            termy_toast::error(reason);
+        match tmux_exit_recovery_decision(self.tmux_exclusive) {
+            TmuxExitRecoveryDecision::RestartControlMode => {
+                if let Some(reason) = reason {
+                    termy_toast::warning(format!(
+                        "{reason}; restarting tmux control mode (tmux_exclusive)"
+                    ));
+                } else {
+                    termy_toast::warning(
+                        "tmux control mode exited; restarting (tmux_exclusive)",
+                    );
+                }
+                self.restart_tmux_runtime_after_exit(cx)
+            }
+            TmuxExitRecoveryDecision::TransitionToNative => {
+                // Exit recovery uses a deterministic fallback when no active pane remains.
+                let size = self
+                    .active_terminal()
+                    .map(|terminal| terminal.size())
+                    .unwrap_or_default();
+                if let Some(reason) = reason {
+                    termy_toast::error(reason);
+                }
+                self.transition_tmux_runtime_to_native(size, cx)
+            }
         }
-        self.transition_tmux_runtime_to_native(size, cx)
+    }
+
+    /// Force-restart control mode after the previous client already exited.
+    /// Best-effort cleanup of the dead client must not block spawning a replacement.
+    fn restart_tmux_runtime_after_exit(&mut self, cx: &mut Context<Self>) -> bool {
+        if !self.runtime_uses_tmux() {
+            return false;
+        }
+
+        let runtime_config = self.tmux_runtime().config.clone();
+        let cols = self.tmux_runtime().client_cols.max(1);
+        let rows = self.tmux_runtime().client_rows.max(1);
+        let initial_working_dir = self.tmux_runtime().preferred_cwd.clone().or_else(|| {
+            termy_terminal_ui::resolve_launch_working_directory(
+                self.configured_working_dir.as_deref(),
+                self.terminal_runtime.working_dir_fallback,
+            )
+            .map(|path| path.to_string_lossy().into_owned())
+        });
+
+        if let Err(error) = TmuxClient::verify_tmux_version(
+            &runtime_config.command_prefix,
+            runtime_config.binary.as_str(),
+            3,
+            3,
+        ) {
+            termy_toast::error(format!("tmux exclusive restart failed: {error}"));
+            return false;
+        }
+
+        let next_client = match TmuxClient::new(
+            runtime_config.clone(),
+            cols,
+            rows,
+            initial_working_dir.as_deref(),
+            Some(self.event_wakeup_tx.clone()),
+        ) {
+            Ok(client) => client,
+            Err(error) => {
+                termy_toast::error(format!(
+                    "tmux exclusive restart failed to start control mode: {error}"
+                ));
+                return false;
+            }
+        };
+
+        let snapshot = match next_client.refresh_snapshot() {
+            Ok(snapshot) => snapshot,
+            Err(error) => {
+                let _ = next_client.shutdown_default();
+                termy_toast::error(format!(
+                    "tmux exclusive restart failed to fetch snapshot: {error}"
+                ));
+                return false;
+            }
+        };
+
+        // Previous control client already exited; ignore cleanup failures.
+        let _ = self.tmux_runtime().client.shutdown_default();
+
+        self.runtime = RuntimeState::Tmux(TmuxRuntime::new(
+            runtime_config,
+            next_client,
+            initial_working_dir,
+            cols,
+            rows,
+        ));
+        self.native_pane_layout_trees.clear();
+        self.native_pane_zoom_snapshots.clear();
+        self.apply_tmux_snapshot_rehydrate(snapshot);
+        self.reset_tab_interaction_state();
+        self.clear_selection();
+        self.refresh_runtime_capability_surfaces(cx);
+        cx.notify();
+        true
     }
 
     pub(in crate::terminal_view) fn tmux_client_cols(&self) -> u16 {

--- a/crates/ffi/include/termy.h
+++ b/crates/ffi/include/termy.h
@@ -276,6 +276,7 @@ typedef struct {
   bool auto_update;
   bool tmux_enabled;
   bool tmux_persistence;
+  bool tmux_exclusive;
   bool tmux_show_active_pane_border;
   bool simple_mode;
   bool native_tab_persistence;

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -288,6 +288,7 @@ pub struct TermyFfiNativeConfig {
     pub auto_update: bool,
     pub tmux_enabled: bool,
     pub tmux_persistence: bool,
+    pub tmux_exclusive: bool,
     pub tmux_show_active_pane_border: bool,
     pub simple_mode: bool,
     pub native_tab_persistence: bool,
@@ -1162,6 +1163,7 @@ pub unsafe extern "C" fn termy_config_native(
                 auto_update: app_config.auto_update,
                 tmux_enabled: app_config.tmux_enabled,
                 tmux_persistence: app_config.tmux_persistence,
+                tmux_exclusive: app_config.tmux_exclusive,
                 tmux_show_active_pane_border: app_config.tmux_show_active_pane_border,
                 simple_mode: app_config.simple_mode,
                 native_tab_persistence: app_config.native_tab_persistence,
@@ -3644,7 +3646,7 @@ mod tests {
 
     #[test]
     fn config_from_contents_exposes_safety_config() {
-        let contents = b"warn_on_quit = true\nwarn_on_quit_with_running_process = false\nauto_update = false\ntmux_enabled = true\ntmux_persistence = false\ntmux_binary = /opt/homebrew/bin/tmux\ntmux_show_active_pane_border = false\nsimple_mode = true\nnative_tab_persistence = true\nnative_layout_autosave = true\nnative_buffer_persistence = true\nshow_debug_overlay = true\nonboarding_complete = false\ntab_close_visibility = always\ntab_width_mode = active_grow_sticky\ntab_bar_position = right\nnative_tab_placement = sidebar\ntab_switch_modifier_hints = false\nui_font_family = Avenir Next\nchrome_contrast = true\ncommand_palette_show_keybinds = false\napp_icon = old\nshell_integration_enabled = false\nprogress_indicator_enabled = false\nauto_hide_tabbar = false\nshow_termy_in_titlebar = false\n";
+        let contents = b"warn_on_quit = true\nwarn_on_quit_with_running_process = false\nauto_update = false\ntmux_enabled = true\ntmux_persistence = false\ntmux_exclusive = true\ntmux_binary = /opt/homebrew/bin/tmux\ntmux_show_active_pane_border = false\nsimple_mode = true\nnative_tab_persistence = true\nnative_layout_autosave = true\nnative_buffer_persistence = true\nshow_debug_overlay = true\nonboarding_complete = false\ntab_close_visibility = always\ntab_width_mode = active_grow_sticky\ntab_bar_position = right\nnative_tab_placement = sidebar\ntab_switch_modifier_hints = false\nui_font_family = Avenir Next\nchrome_contrast = true\ncommand_palette_show_keybinds = false\napp_icon = old\nshell_integration_enabled = false\nprogress_indicator_enabled = false\nauto_hide_tabbar = false\nshow_termy_in_titlebar = false\n";
         let mut config = ptr::null_mut();
         assert_eq!(
             unsafe { termy_config_from_contents(contents.as_ptr(), contents.len(), &mut config) },
@@ -3667,6 +3669,7 @@ mod tests {
         assert!(!native.auto_update);
         assert!(native.tmux_enabled);
         assert!(!native.tmux_persistence);
+        assert!(native.tmux_exclusive);
         assert!(!native.tmux_show_active_pane_border);
         assert!(native.simple_mode);
         assert!(native.native_tab_persistence);

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -97,6 +97,11 @@ Platform note: the Agent Sidebar/Workspace is currently unavailable on Windows b
 - Reuse tmux tabs and panes across app restarts
 - Group: `TMUX`
 
+`tmux_exclusive`
+- Default: `false`
+- Stay in tmux control mode; restart it instead of falling back to a classic terminal when control mode exits
+- Group: `TMUX`
+
 `tmux_binary`
 - Default: `tmux`
 - tmux executable path or binary name

--- a/macos/Sources/TermySwift/Services/TermyAppConfiguration.swift
+++ b/macos/Sources/TermySwift/Services/TermyAppConfiguration.swift
@@ -274,12 +274,14 @@ struct TermyAppConfiguration {
 struct TermyTmuxConfiguration {
     var enabled: Bool
     var persistence: Bool
+    var exclusive: Bool
     var binary: String
     var showActivePaneBorder: Bool
 
     static let `default` = TermyTmuxConfiguration(
         enabled: false,
         persistence: true,
+        exclusive: false,
         binary: "tmux",
         showActivePaneBorder: true
     )
@@ -287,11 +289,13 @@ struct TermyTmuxConfiguration {
     init(
         enabled: Bool,
         persistence: Bool,
+        exclusive: Bool,
         binary: String,
         showActivePaneBorder: Bool
     ) {
         self.enabled = enabled
         self.persistence = persistence
+        self.exclusive = exclusive
         self.binary = binary
         self.showActivePaneBorder = showActivePaneBorder
     }
@@ -299,6 +303,7 @@ struct TermyTmuxConfiguration {
     init(_ ffiConfig: TermyFfiNativeConfig, binary: String) {
         enabled = ffiConfig.tmux_enabled
         persistence = ffiConfig.tmux_persistence
+        exclusive = ffiConfig.tmux_exclusive
         self.binary = binary
         showActivePaneBorder = ffiConfig.tmux_show_active_pane_border
     }

--- a/macos/Sources/TermySwift/Views/TerminalWorkspaceView.swift
+++ b/macos/Sources/TermySwift/Views/TerminalWorkspaceView.swift
@@ -112,7 +112,7 @@ struct TerminalWorkspaceView: View {
         ZStack {
             if let tmuxControlModel {
                 TmuxControlWorkspaceView(model: tmuxControlModel) { errorMessage in
-                    fallBackFromTmux(errorMessage)
+                    handleTmuxControlFailure(errorMessage)
                 }
             } else if let zoomedPane = store.zoomedPane {
                 TerminalPaneLeafView(pane: zoomedPane, store: store)
@@ -384,6 +384,34 @@ struct TerminalWorkspaceView: View {
                 "Workspace reset failed: \(String(reflecting: type(of: error)), privacy: .public)"
             )
             workspacePersistenceError = "Could not reset workspace: \(error)"
+        }
+    }
+
+    private func handleTmuxControlFailure(_ errorMessage: String) {
+        if configurationStore.configuration.tmux.exclusive {
+            restartExclusiveTmux(reason: errorMessage)
+        } else {
+            fallBackFromTmux(errorMessage)
+        }
+    }
+
+    private func restartExclusiveTmux(reason: String) {
+        TermyNativeLog.lifecycle.notice(
+            "tmux_exclusive restart after control-mode exit: \(reason, privacy: .public)"
+        )
+        tmuxControlModel?.stop()
+        tmuxControlModel = nil
+        do {
+            let model = try TmuxControlWorkspaceModel()
+            tmuxControlModel = model
+            tmuxFallbackMessage =
+                "tmux control mode exited; restarted because tmux_exclusive is enabled."
+        } catch {
+            TermyNativeLog.lifecycle.error(
+                "tmux_exclusive restart failed: \(String(describing: error), privacy: .public)"
+            )
+            tmuxFallbackMessage =
+                "tmux_exclusive is enabled, but control mode could not restart (\(error))."
         }
     }
 
@@ -788,6 +816,15 @@ private struct TmuxControlWorkspaceView: View {
             if !model.start() {
                 onUnavailable(model.errorMessage ?? "tmux control mode failed to start")
             }
+        }
+        .onChange(of: model.errorMessage) { _, message in
+            guard let message, message == "tmux control session exited" else {
+                return
+            }
+            guard configurationStore.configuration.tmux.exclusive else {
+                return
+            }
+            onUnavailable(message)
         }
         .onDisappear {
             model.stop()

--- a/macos/Tests/TermySwiftTests/SettingsSchemaParityTests.swift
+++ b/macos/Tests/TermySwiftTests/SettingsSchemaParityTests.swift
@@ -13,6 +13,7 @@ final class SettingsSchemaParityTests: XCTestCase {
             "auto_update",
             "tmux_enabled",
             "tmux_persistence",
+            "tmux_exclusive",
             "tmux_binary",
             "tmux_command_prefix",
             "tmux_show_active_pane_border",

--- a/macos/Tests/TermySwiftTests/TermyConfigurationParityTests.swift
+++ b/macos/Tests/TermySwiftTests/TermyConfigurationParityTests.swift
@@ -28,6 +28,7 @@ final class TermyConfigurationParityTests: XCTestCase {
         auto_update = false
         tmux_enabled = true
         tmux_persistence = false
+        tmux_exclusive = true
         tmux_binary = /opt/homebrew/bin/tmux
         tmux_show_active_pane_border = false
         simple_mode = true
@@ -67,6 +68,7 @@ final class TermyConfigurationParityTests: XCTestCase {
         XCTAssertEqual(configuration.safety.warnOnQuitWithRunningProcess, false)
         XCTAssertEqual(configuration.tmux.enabled, true)
         XCTAssertEqual(configuration.tmux.persistence, false)
+        XCTAssertEqual(configuration.tmux.exclusive, true)
         XCTAssertEqual(configuration.tmux.binary, "/opt/homebrew/bin/tmux")
         XCTAssertEqual(configuration.tmux.showActivePaneBorder, false)
 

--- a/website/content/docs/customize/terminal-behavior.mdx
+++ b/website/content/docs/customize/terminal-behavior.mdx
@@ -56,5 +56,6 @@ description: Shell, cursor, scrolling, clipboard, and terminal UI behavior.
 | --- | ------- | ----------- |
 | `tmux_enabled` | `false` | Enable tmux runtime integration. |
 | `tmux_persistence` | `true` | Reuse tmux tabs and panes across restarts. |
+| `tmux_exclusive` | `false` | Stay in tmux control mode; restart it instead of falling back to a classic terminal when control mode exits. |
 | `tmux_binary` | `tmux` | tmux executable path or binary name. |
 | `tmux_show_active_pane_border` | `false` | Show active tmux pane border highlight. |

--- a/website/content/docs/using-termy/tmux-sessions.mdx
+++ b/website/content/docs/using-termy/tmux-sessions.mdx
@@ -8,6 +8,7 @@ Requires `tmux` ≥ 3.3 on `PATH` (macOS / Linux), or reachable through a comman
 ```txt
 tmux_enabled                 = true
 tmux_persistence             = true
+tmux_exclusive               = false
 tmux_binary                  = tmux
 tmux_command_prefix          = none
 tmux_show_active_pane_border = false
@@ -17,6 +18,7 @@ tmux_show_active_pane_border = false
 | --- | ------ |
 | `tmux_enabled` | New tabs use tmux instead of a raw PTY |
 | `tmux_persistence` | Sessions survive app restarts |
+| `tmux_exclusive` | Stay in tmux control mode; restart it instead of falling back to a classic terminal when control mode exits (for example after Ctrl+D closes the last pane) |
 | `tmux_binary` | Path or name of the tmux binary |
 | `tmux_command_prefix` | Command that tmux runs through, e.g. `wsl.exe -e` or `ssh myhost` |
 
@@ -52,6 +54,7 @@ remote shell — the host working directory is not forwarded.
 | Blank tabs | Set `tmux_binary` to an absolute path |
 | `protocol version mismatch` | Point `tmux_binary` at the tmux version you intend to use |
 | Sessions lost on quit | Set `tmux_persistence = true` |
+| Control mode exits to a classic terminal | Set `tmux_exclusive = true` to restart control mode instead |
 | Double active-pane border | Set `tmux_show_active_pane_border = false` |
 | tmux mode ignored on Windows | Set `tmux_command_prefix` (e.g. `wsl.exe -e`) |
 | `ssh` prefix hangs at startup | Use key-based auth; the control channel cannot answer password prompts |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds `tmux_exclusive` so Termy can stay in tmux control mode instead of falling back to a classic terminal when control mode exits (the `tmux control mode exited` path from #371, often after Ctrl+D closes the last pane).

- New config key `tmux_exclusive` (default `false`) in `config_core`, settings UI, generated docs, FFI, and macOS Swift config
- When enabled, control-mode exit restarts control mode instead of transitioning to a native PTY
- Detach-to-native is blocked and hidden from the tmux session palette while exclusive
- macOS host restarts the control workspace on exit/startup failure when exclusive instead of shell fallback

## Related Issues

Closes #371

## Checklist

- [x] I confirmed there is no existing open PR for the same or overlapping changes.
- [x] I ran the smallest validation pass for this change (see [CONTRIBUTING.md](CONTRIBUTING.md#testing-and-validation)).
- [x] Config docs regenerated and `--check` clean; dependency policy / keybinding docs clean via `scripts/check-boundaries.sh` (pre-existing file-size failures elsewhere).
- [x] Targeted tests: `termy_config_core`, `termy` `tmux_*`, `termy_ffi` safety/native config + c_header_contract.
- [x] Regenerated `docs/configuration.md` when schema/defaults changed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f529964a-92f0-4c5f-9bac-06edc2837484?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f529964a-92f0-4c5f-9bac-06edc2837484&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

