### PR TITLE
feat(keybindings): add bindable clear_screen action

### DIFF
--- a/crates/command_core/src/catalog.rs
+++ b/crates/command_core/src/catalog.rs
@@ -55,6 +55,7 @@ macro_rules! termy_command_catalog {
             (Copy, "copy"),
             (Paste, "paste"),
             (SelectAll, "select_all"),
+            (ClearScreen, "clear_screen"),
             (CloseSearch, "close_search"),
             (SearchNext, "search_next"),
             (SearchPrevious, "search_previous"),

--- a/crates/command_core/src/keybind.rs
+++ b/crates/command_core/src/keybind.rs
@@ -663,6 +663,23 @@ mod tests {
     }
 
     #[test]
+    fn parses_clear_screen_keybind() {
+        let lines = [KeybindLineRef {
+            line_number: 1,
+            value: "secondary-k=clear_screen",
+        }];
+
+        let (directives, warnings) = parse_keybind_directives(&lines);
+
+        assert!(warnings.is_empty());
+        assert!(matches!(
+            directives.as_slice(),
+            [KeybindDirective::Bind { trigger, action }]
+                if trigger == "secondary-k" && action.config_name() == "clear_screen"
+        ));
+    }
+
+    #[test]
     fn resolve_keybinds_applies_directives_in_order() {
         let defaults = vec![
             resolved("secondary-p", CommandId::ToggleCommandPalette),

--- a/crates/desktop_app/src/commands.rs
+++ b/crates/desktop_app/src/commands.rs
@@ -971,6 +971,16 @@ define_commands!(
             MenuActionRole::SelectAll
         ))
     ),
+    (
+        ClearScreen,
+        TERMINAL_CONTEXT,
+        Some(palette(
+            "Clear Screen",
+            "clear terminal viewport",
+            CommandPaletteVisibility::Always
+        )),
+        None
+    ),
     (CloseSearch, TERMINAL_CONTEXT, None, None),
     (
         SearchNext,
@@ -1145,6 +1155,19 @@ mod tests {
             CommandAction::palette_entries()
                 .iter()
                 .any(|entry| entry.action == CommandAction::SwitchTheme)
+        );
+    }
+
+    #[test]
+    fn clear_screen_is_configurable_and_palette_visible() {
+        assert_eq!(
+            CommandAction::from_config_name("clear_screen"),
+            Some(CommandAction::ClearScreen)
+        );
+        assert!(
+            CommandAction::palette_entries()
+                .iter()
+                .any(|entry| entry.action == CommandAction::ClearScreen)
         );
     }
 

--- a/crates/desktop_app/src/terminal_view/command_palette/mod.rs
+++ b/crates/desktop_app/src/terminal_view/command_palette/mod.rs
@@ -1741,6 +1741,7 @@ impl TerminalView {
             | CommandAction::Copy
             | CommandAction::Paste
             | CommandAction::SelectAll
+            | CommandAction::ClearScreen
             | CommandAction::OpenSearch
             | CommandAction::CloseSearch
             | CommandAction::SearchNext

--- a/crates/desktop_app/src/terminal_view/command_palette/presentation.rs
+++ b/crates/desktop_app/src/terminal_view/command_palette/presentation.rs
@@ -52,6 +52,7 @@ pub(super) fn command_icon_path(id: CommandId) -> &'static str {
         Quit => "icons/command_palette/power.svg",
         ToggleCommandPalette => "icons/command_palette/command.svg",
         Copy | Paste | SelectAll => "icons/command_palette/clipboard.svg",
+        ClearScreen => "icons/settings/reset.svg",
         InstallCli => "icons/command_palette/cli.svg",
         ToggleTabBarVisibility => "icons/settings/tabs.svg",
         ToggleWorkspaceSidebar => "icons/command_palette/sidebar.svg",
@@ -135,7 +136,7 @@ pub(super) fn command_category(id: CommandId) -> &'static str {
         | SearchPrevious
         | ToggleSearchCaseSensitive
         | ToggleSearchRegex => "Search",
-        Copy | Paste | SelectAll => "Edit",
+        Copy | Paste | SelectAll | ClearScreen => "Edit",
         SwitchTheme | ImportColors | ZoomIn | ZoomOut | ZoomReset => "Appearance",
         OpenConfig | PrettifyConfig | OpenSettings | InstallCli => "Settings",
         AppInfo | RestartApp | CheckForUpdates | Quit | ToggleCommandPalette | ToggleInspector => {

--- a/crates/desktop_app/src/terminal_view/interaction/actions.rs
+++ b/crates/desktop_app/src/terminal_view/interaction/actions.rs
@@ -220,6 +220,13 @@ impl TerminalView {
             CommandAction::Copy | CommandAction::Paste | CommandAction::SelectAll => {
                 self.execute_input_command_action(action, cx);
             }
+            CommandAction::ClearScreen => {
+                // Form feed is the control character produced by Ctrl+L.
+                self.write_terminal_input(b"\x0c", cx);
+                if self.clear_selection() {
+                    cx.notify();
+                }
+            }
             CommandAction::ZoomIn | CommandAction::ZoomOut | CommandAction::ZoomReset => {
                 self.execute_layout_command_action(action, cx);
             }
@@ -734,6 +741,15 @@ impl TerminalView {
         cx: &mut Context<Self>,
     ) {
         self.execute_command_action(CommandAction::Paste, true, window, cx);
+    }
+
+    pub(in super::super) fn handle_clear_screen_action(
+        &mut self,
+        _: &commands::ClearScreen,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.execute_command_action(CommandAction::ClearScreen, true, window, cx);
     }
 
     pub(in super::super) fn handle_zoom_in_action(

--- a/crates/desktop_app/src/terminal_view/render.rs
+++ b/crates/desktop_app/src/terminal_view/render.rs
@@ -4021,6 +4021,7 @@ impl Render for TerminalView {
                     .on_action(cx.listener(Self::handle_minimize_window_action))
                     .on_action(cx.listener(Self::handle_copy_action))
                     .on_action(cx.listener(Self::handle_paste_action))
+                    .on_action(cx.listener(Self::handle_clear_screen_action))
                     .on_action(cx.listener(Self::handle_zoom_in_action))
                     .on_action(cx.listener(Self::handle_zoom_out_action))
                     .on_action(cx.listener(Self::handle_zoom_reset_action))

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -254,6 +254,7 @@ Related UI option:
 - `copy`
 - `paste`
 - `select_all`
+- `clear_screen`
 - `close_search`
 - `search_next`
 - `search_previous`

--- a/website/content/docs/reference/actions.mdx
+++ b/website/content/docs/reference/actions.mdx
@@ -30,6 +30,16 @@ description: Every action you can bind to a trigger.
 
 `copy`, `paste`.
 
+## Terminal
+
+`clear_screen` sends the same form-feed control character as `Ctrl+L` to the
+active pane, clearing the viewport while preserving scrollback in shells that
+use the conventional `Ctrl+L` behavior.
+
+```txt
+keybind = secondary-k=clear_screen
+```
+
 ## App
 
 `toggle_command_palette`, `open_settings`, `open_config`, `prettify_config`,


### PR DESCRIPTION
## Summary
- add `clear_screen` to the configurable command catalog
- send the Ctrl+L form-feed character to the active native or tmux pane
- expose the action in the command palette and document `secondary-k=clear_screen`

## Testing
- `cargo test -p termy_command_core`
- `cargo test -p termy`
- `cargo clippy -p termy_command_core -p termy --all-targets -- -D warnings`
- `./scripts/check-boundaries.sh`
- `bun run types:check`
- `bun run lint`

Fixes #377